### PR TITLE
Fix/issue 10 trailing dot in allowed hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Desktop.ini
 # VulnClaw runtime
 .vulnclaw/
 .workbuddy/
+.trae/
 sessions/
 reports/
 pocs/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -842,9 +842,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -859,9 +856,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -876,9 +870,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -893,9 +884,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -910,9 +898,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -927,9 +912,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,9 +926,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -961,9 +940,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -978,9 +954,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -995,9 +968,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1012,9 +982,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1029,9 +996,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1046,9 +1010,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -977,6 +977,23 @@ class TestAgentCore:
         assert "/admin" in constraints.allowed_paths
         assert constraints.strict_mode is True
 
+    def test_extract_task_constraints_url_with_trailing_dot_in_sentence(self):
+        """URL at end of sentence should not capture trailing period as part of host.
+
+        Regression test for issue #10: when a URL appears before a period ending
+        a sentence, detect_target() was capturing the period as part of the URL,
+        causing allowed_hosts to contain 'example.com.' with a trailing dot.
+        This then caused fetch scope checks to fail because urlparse().hostname
+        never returns a trailing dot per RFC 3986.
+        """
+        from vulnclaw.agent.input_analysis import extract_task_constraints
+
+        # The period after .com is sentence punctuation, not part of the URL
+        constraints = extract_task_constraints("对 http://example.com. 进行渗透测试")
+        assert "example.com" in constraints.allowed_hosts
+        # Must NOT contain trailing dot - urlparse().hostname never returns trailing dots
+        assert all(not h.endswith(".") for h in constraints.allowed_hosts)
+
     def test_round_context_includes_hard_constraints(self):
         from vulnclaw.agent.context import PentestPhase
 

--- a/vulnclaw/agent/input_analysis.py
+++ b/vulnclaw/agent/input_analysis.py
@@ -80,7 +80,7 @@ def detect_target(user_input: str) -> Optional[str]:
     ):
         match = re.search(pattern, user_input)
         if match:
-            return match.group(1).rstrip("/") if match.groups() else match.group(0)
+            return match.group(1).rstrip("/.") if match.groups() else match.group(0)
     return None
 
 


### PR DESCRIPTION
# 修复：去除检测到的URL末尾的点号

## 问题描述
当URL出现在句子末尾时，`detect_target()` 函数会将句子末尾的句号也捕获到URL中（例如，捕获 "http://example.com." 而不是 "http://example.com" ）。这导致 `allowed_hosts` 中包含带末尾点号的主机，但 `urlparse().hostname` 按照 RFC 3986 标准永远不会返回带末尾点号的主机名，因此所有 fetch 请求都被错误地拒绝为"超出允许范围"。

## 修复方案
在 `detect_target()` 函数中，将 `rstrip("/")` 改为 `rstrip("/.")`，同时去除 URL 末尾的斜杠和点号。

## 修改内容
- 修改了 [`vulnclaw/agent/input_analysis.py`](https://github.com/sjkxq/VulnClaw/blob/77e4578/vulnclaw/agent/input_analysis.py#L83) 第 83 行
- 新增了回归测试 [`test_extract_task_constraints_url_with_trailing_dot_in_sentence`](https://github.com/sjkxq/VulnClaw/blob/77e4578/tests/test_agent.py#L980-L995)

## 相关Issue
Fixes: https://github.com/Unclecheng-li/VulnClaw/issues/10

## 验证
- [x] 新增测试通过
- [x] 符合项目贡献指引