### PR TITLE
fix: auto-include www/non-www subdomain variant in allowed_hosts

### DIFF
--- a/vulnclaw/agent/input_analysis.py
+++ b/vulnclaw/agent/input_analysis.py
@@ -84,6 +84,21 @@ def detect_target(user_input: str) -> Optional[str]:
     return None
 
 
+def _add_domain_variant(constraints: TaskConstraints, host: str) -> None:
+    """Add www/non-www variant of the host to allowed_hosts.
+
+    E.g. tutoubaby.com → also allow www.tutoubaby.com, and vice versa.
+    """
+    if host.startswith("www."):
+        bare = host[4:]
+        if bare not in constraints.allowed_hosts:
+            constraints.allowed_hosts.append(bare)
+    else:
+        www = f"www.{host}"
+        if www not in constraints.allowed_hosts:
+            constraints.allowed_hosts.append(www)
+
+
 def extract_task_constraints(user_input: str) -> TaskConstraints:
     """Extract structured hard constraints from natural-language user input."""
     text = user_input or ""
@@ -166,9 +181,11 @@ def extract_task_constraints(user_input: str) -> TaskConstraints:
                 host = host_match.group(1)
                 if host and host not in constraints.allowed_hosts:
                     constraints.allowed_hosts.append(host)
+                    _add_domain_variant(constraints, host)
         elif "." in target_lower:
             if target_lower not in constraints.allowed_hosts:
                 constraints.allowed_hosts.append(target_lower)
+                _add_domain_variant(constraints, target_lower)
 
     if (
         constraints.allowed_ports


### PR DESCRIPTION
When a user specifies a target like `tutoubaby.com`, the constraint extractor only adds the exact host to `allowed_hosts`. If the target redirects requests to `www.tutoubaby.com` (or vice versa), subsequent fetch calls are blocked by the constraint policy as "outside allowed scope".

This PR adds `_add_domain_variant()` to automatically include:
- the `www.` variant when a bare domain is detected (e.g. `tutoubaby.com` → also allow `www.tutoubaby.com`)
- the bare domain when a `www.` variant is detected (e.g. `www.example.com` → also allow `example.com`)

This prevents self-blocking when the target uses www/non-www redirects, a very common pattern for web servers behind reverse proxies.