### PR TITLE
fix(regression): 优化域名匹配正则以支持多级域名

### DIFF
--- a/vulnclaw/agent/input_analysis.py
+++ b/vulnclaw/agent/input_analysis.py
@@ -76,7 +76,7 @@ def detect_target(user_input: str) -> Optional[str]:
     for pattern in (
         r"(https?://[a-zA-Z0-9][-a-zA-Z0-9.:]*)",
         r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})",
-        r"([a-zA-Z0-9][-a-zA-Z0-9]*\.[a-zA-Z]{2,})",
+        r"([a-zA-Z0-9][-a-zA-Z0-9]*(?:\.[a-zA-Z0-9][-a-zA-Z0-9]*)+)",
     ):
         match = re.search(pattern, user_input)
         if match:

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -1758,7 +1758,7 @@ def _extract_target_from_input(user_input: str) -> Optional[str]:
     if ip_match:
         return ip_match.group(1)
     # Try to find domain
-    domain_match = re.search(r"([a-zA-Z0-9][-a-zA-Z0-9]*\.[a-zA-Z]{2,})", user_input)
+    domain_match = re.search(r"([a-zA-Z0-9][-a-zA-Z0-9]*(?:\.[a-zA-Z0-9][-a-zA-Z0-9]*)+)", user_input)
     if domain_match:
         return domain_match.group(1)
     return None


### PR DESCRIPTION
修复原正则仅能匹配二级域名的问题，更新为可以正确识别如api.example.com这类多级子域名的匹配规则
#11