### PR TITLE
fix: PR #19 流式输出重复打印回归修复

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1624,7 +1624,8 @@ class TestAgentCoreLoop:
 
         result = await llm_client.call_llm_auto(DummyAgent(), "sys", "round")
         assert result == "followup ok"
-        assert saved_messages == ["followup ok"]
+        # call_llm_auto 不再自己写入上下文，由 caller（loop_controller L55）统一添加
+        assert saved_messages == []
 
     @pytest.mark.asyncio
     async def test_auto_pentest_stops_on_done_signal(self, monkeypatch):

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -342,6 +342,9 @@ class AgentCore:
         auto_report: bool = True,
         on_cycle_step: Optional[Callable[[int, int, AgentResult], None]] = None,
         on_cycle_complete: Optional[Callable[[int, "PersistentCycleResult"], None]] = None,
+        *,
+        # stream_sink 由 main.py 传入，逐级透传到 call_llm_auto_stream 实现流式输出
+        stream_sink: Optional["StreamSink"] = None,
     ) -> list["PersistentCycleResult"]:
         """Persistent penetration test — runs cycles of auto_pentest until stopped."""
         return await run_persistent_pentest(
@@ -353,6 +356,7 @@ class AgentCore:
             auto_report,
             on_cycle_step,
             on_cycle_complete,
+            stream_sink=stream_sink,
         )
 
     def _detect_phase_from_output(self, output: str) -> Optional[PentestPhase]:

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -294,15 +294,13 @@ async def call_llm_auto(
                 "工具总结",
             )
             final_text = extract_response(response2.choices[0].message)
-            # 注释掉: 统一由 auto_pentest L55 或 chat L385 添加上下文，避免重复
-            # agent.context.add_assistant_message(final_text)
+            # 上下文已由 loop_controller L55 / core.py L385 写入，避免重复
             return _prepend_retry_notice(final_text, retry_attempts + second_retry_attempts)
         except Exception as e2:
             error_text = str(e2).lower()
             if _is_non_retriable_llm_error(error_text):
                 fallback = _format_tool_results_fallback(tool_results, skipped_info)
-                # 注释掉: 同上
-                # agent.context.add_assistant_message(fallback)
+                # 同上: 不在此写入上下文
                 return fallback
             return f"[tool results processed] 继续分析错误: {e2}"
 
@@ -597,8 +595,7 @@ async def call_llm_auto_stream(
                     if reasoning_buffer:
                         full_text += f"<thinking>\n{reasoning_buffer}\n</thinking>\n"
 
-                    # 注释掉: 由 auto_pentest L55 统一添加上下文，避免重复（PR #19 引入）
-                    # agent.context.add_assistant_message(full_text)
+                    # 上下文由 loop_controller L55 写入，不在此重复添加
                     stream_sink.on_stream_end()
                     return full_text
 
@@ -606,12 +603,11 @@ async def call_llm_auto_stream(
                     error_text = str(e2).lower()
                     if _is_non_retriable_llm_error(error_text):
                         fallback = _format_tool_results_fallback(tool_results, skipped_info)
-                        # 也注释掉: 同上，避免重复
-                        # agent.context.add_assistant_message(fallback)
+                        # 同上: 不在此写入上下文
                         return fallback
                     return f"[tool results processed] 继续分析错误: {e2}"
 
-        # agent.context.add_assistant_message(full_text)  # 已注释: 同上原因
+        # 上下文已由调用方写入，不在此重复添加
         return full_text
 
     except (NotImplementedError, ValueError, Exception) as e:

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -294,13 +294,15 @@ async def call_llm_auto(
                 "工具总结",
             )
             final_text = extract_response(response2.choices[0].message)
-            agent.context.add_assistant_message(final_text)
+            # 注释掉: 统一由 auto_pentest L55 或 chat L385 添加上下文，避免重复
+            # agent.context.add_assistant_message(final_text)
             return _prepend_retry_notice(final_text, retry_attempts + second_retry_attempts)
         except Exception as e2:
             error_text = str(e2).lower()
             if _is_non_retriable_llm_error(error_text):
                 fallback = _format_tool_results_fallback(tool_results, skipped_info)
-                agent.context.add_assistant_message(fallback)
+                # 注释掉: 同上
+                # agent.context.add_assistant_message(fallback)
                 return fallback
             return f"[tool results processed] 继续分析错误: {e2}"
 
@@ -595,7 +597,8 @@ async def call_llm_auto_stream(
                     if reasoning_buffer:
                         full_text += f"<thinking>\n{reasoning_buffer}\n</thinking>\n"
 
-                    agent.context.add_assistant_message(full_text)
+                    # 注释掉: 由 auto_pentest L55 统一添加上下文，避免重复（PR #19 引入）
+                    # agent.context.add_assistant_message(full_text)
                     stream_sink.on_stream_end()
                     return full_text
 
@@ -603,11 +606,12 @@ async def call_llm_auto_stream(
                     error_text = str(e2).lower()
                     if _is_non_retriable_llm_error(error_text):
                         fallback = _format_tool_results_fallback(tool_results, skipped_info)
-                        agent.context.add_assistant_message(fallback)
+                        # 也注释掉: 同上，避免重复
+                        # agent.context.add_assistant_message(fallback)
                         return fallback
                     return f"[tool results processed] 继续分析错误: {e2}"
 
-        agent.context.add_assistant_message(full_text)
+        # agent.context.add_assistant_message(full_text)  # 已注释: 同上原因
         return full_text
 
     except (NotImplementedError, ValueError, Exception) as e:

--- a/vulnclaw/agent/loop_controller.py
+++ b/vulnclaw/agent/loop_controller.py
@@ -193,6 +193,9 @@ async def persistent_pentest(
     auto_report: bool = True,
     on_cycle_step: Callable[[int, int, AgentResult], None] | None = None,
     on_cycle_complete: Callable[[int, PersistentCycleResult], None] | None = None,
+    *,
+    # stream_sink 由 core.py 透传入，传给 agent.auto_pentest() 实现流式输出
+    stream_sink: Any = None,
 ) -> list[PersistentCycleResult]:
     cycle_results: list[PersistentCycleResult] = []
 
@@ -240,6 +243,8 @@ async def persistent_pentest(
                 target=agent.context.state.target,
                 max_rounds=rounds_per_cycle,
                 on_step=_make_step_callback(cycle_num),
+                # 透传 stream_sink，使 persistent 模式也支持流式输出
+                stream_sink=stream_sink,
             )
             cycle_results_list = results if results else cycle_results_list
         except KeyboardInterrupt:

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -368,8 +368,7 @@ def _run_repl() -> None:
 
                 def _on_persistent_step(round_num: int, cycle_num: int, result) -> None:
                     console.print(f"[dim]-- Cycle {cycle_num} | Round {round_num} --[/]")
-                    if result.output:
-                        _print_agent_output(result.output, config)
+                    # TerminalStreamSink 已实时流式显示，回调不重复打印
                     console.print()
                     nonlocal current_target, current_phase
                     if result.target:
@@ -951,8 +950,7 @@ def persistent(
     def _on_cycle_step(round_num: int, cycle_num: int, result) -> None:
         """Real-time output for each step within a cycle."""
         console.print(f"[dim]-- Cycle {cycle_num} | Round {round_num} --[/]")
-        if result.output:
-            _print_agent_output(result.output, config)
+        # TerminalStreamSink 已实时流式显示，回调不重复打印
         console.print()
 
     def _on_cycle_complete(cycle_num: int, cycle_result: PersistentCycleResult) -> None:
@@ -1078,10 +1076,8 @@ def recon(
     async def _run():
         async def runner(agent, _config):
             sink = TerminalStreamSink(console, _config.session.show_thinking)
-            result = await agent.chat(task_prompt, target=target, stream_sink=sink)
-            if result and result.output:
-                console.print(result.output)
-            return result
+            # TerminalStreamSink 已实时流式显示，不重复 console.print
+            return await agent.chat(task_prompt, target=target, stream_sink=sink)
 
         await _run_cli_orchestrated_task(
             command="recon",
@@ -1143,10 +1139,8 @@ def scan(
     async def _run():
         async def runner(agent, _config):
             sink = TerminalStreamSink(console, _config.session.show_thinking)
-            result = await agent.chat(task_prompt, target=target, stream_sink=sink)
-            if result and result.output:
-                console.print(result.output)
-            return result
+            # TerminalStreamSink 已实时流式显示，不重复 console.print
+            return await agent.chat(task_prompt, target=target, stream_sink=sink)
 
         await _run_cli_orchestrated_task(
             command="scan",
@@ -1211,10 +1205,8 @@ def exploit(
     async def _run():
         async def runner(agent, _config):
             sink = TerminalStreamSink(console, _config.session.show_thinking)
-            result = await agent.chat(task_prompt, target=target, stream_sink=sink)
-            if result and result.output:
-                console.print(result.output)
-            return result
+            # TerminalStreamSink 已实时流式显示，不重复 console.print
+            return await agent.chat(task_prompt, target=target, stream_sink=sink)
 
         await _run_cli_orchestrated_task(
             command="exploit",

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -497,8 +497,6 @@ def _run_repl() -> None:
                             def on_step(round_num, result):
                                 nonlocal current_target, current_phase
                                 console.print(f"[dim]-- Round {round_num} --[/]")
-                                if result.output:
-                                    _print_agent_output(result.output, config)
                                 console.print()
                                 if result.target:
                                     current_target = result.target
@@ -563,8 +561,9 @@ def _run_repl() -> None:
                                     current_target = result.target
                                 if result.phase:
                                     current_phase = result.phase
-                                if result.output:
-                                    _print_agent_output(result.output, config)
+                                # 注释掉: 流式输出已通过 TerminalStreamSink 实时显示，无需重复打印
+                                # if result.output:
+                                #     _print_agent_output(result.output, config)
 
                         await _run_repl_agent_call(agent, call=call, after_result=after_result)
 


### PR DESCRIPTION
## 概述

  PR #19 (sjkxq/fix/issue-9-streaming-output) 引入流式输出后，TerminalStreamSink 已实时流式显示，但回调层未同步清理，导致同一份内容通过流式和回调两条路径先后输出。同时 llm_client.py 内部的 add_assistant_message 与调用方
  loop_controller 重复写入上下文。

  ## 修改内容

  | 文件 | 改动 | 原因 |
  |------|------|------|
  | `vulnclaw/agent/llm_client.py` | 移除 call_llm_auto / call_llm_auto_stream 中 5 处冗余的 add_assistant_message 调用 | 上下文已由 loop_controller / core.py 统一管理 |
  | `vulnclaw/cli/main.py` `_on_persistent_step` | 移除 `_print_agent_output` | TerminalStreamSink 已流式显示 |
  | `vulnclaw/cli/main.py` `_on_cycle_step` | 移除 `_print_agent_output` | 同上 |
  | `vulnclaw/cli/main.py` recon/scan/exploit runner | 移除 `console.print(result.output)` | 同上 |
  | `vulnclaw/agent/core.py` | `persistent_pentest` 新增 `stream_sink` 参数透传 | 修复 persistent 模式下流式输出断链 |
  | `vulnclaw/agent/loop_controller.py` | `persistent_pentest` 新增 `stream_sink` 参数并透传给 `auto_pentest` | 同上 |