### PR TITLE
fix(tui): 修复 /scope 链式输入无法正常完成的问题

### DIFF
--- a/vulnclaw/cli/tui_textual.py
+++ b/vulnclaw/cli/tui_textual.py
@@ -132,7 +132,7 @@ class SecondaryPopup(Vertical):
 
     Supports input / choice / confirm / message / chain modes.
     """
-
+    can_focus = True
     def __init__(self, **kwargs: Any):
         kwargs.setdefault("id", "sec-popup")
         super().__init__(**kwargs)
@@ -205,7 +205,7 @@ class SecondaryPopup(Vertical):
             f"[bold {C_PRIMARY}]{label}[/]"
         )
         hint = Static(
-            f"  [{C_SUCCESS}]y[/] / [{C_ERROR}]n[/]  [/]",
+            f"  [{C_SUCCESS}]y[/] / [{C_ERROR}]n[/]",
             id="popup-hint",
         )
         self.mount(hint)
@@ -233,6 +233,13 @@ class SecondaryPopup(Vertical):
         self._cb = callback
         self._chain_fields = fields
         self._chain_idx = idx
+        # Create the Input widget once for the entire chain lifecycle.
+        # This eliminates the try/except workaround in _render_chain_step()
+        # and prevents focus-loss issues on Windows from widget destruction/recreation.
+        if idx < len(fields):
+            fld_default = fields[idx][2]
+            inp = Input(value=fld_default if fld_default else "", id="popup-input")
+            self.mount(inp)
         self._render_chain_step()
 
     def _render_chain_step(self) -> None:
@@ -253,8 +260,8 @@ class SecondaryPopup(Vertical):
         self.query_one("#popup-desc", Static).update(
             f"[bold {C_PRIMARY}][{idx + 1}/{len(fields)}] {fld_title}[/]"
         )
-        inp = Input(value=fld_default, id="popup-input")
-        self.mount(inp)
+        inp = self.query_one("#popup-input", Input)
+        inp.value = fld_default if fld_default else ""
         self.add_class("open")
         inp.focus()
 
@@ -285,7 +292,6 @@ class SecondaryPopup(Vertical):
                     state.only_port = ""
             else:
                 setattr(state, fld, value if value else "")
-        self._clear_dynamic()
         self._chain_idx += 1
         self._render_chain_step()
 


### PR DESCRIPTION
  ## 根因

  `SecondaryPopup._handle_chain_step()` 在每次 chain 步骤结束时调用 `_clear_dynamic()`，导致 Input widget 在步骤间被销毁。下一步骤的 `_render_chain_step()` 试图查找 `#popup-input` 时失败，chain 流程中断。

  ## 改动

  | 方法 | 改动 |
  |------|------|
  | `_show_chain()` | 入口处显式创建 Input widget 一次，贯穿整个 chain 生命周期复用 |
  | `_render_chain_step()` | Input 保证存在，直接 `query_one` 获取后更新值和焦点 |
  | `_handle_chain_step()` | 移除步骤结束时多余的 `_clear_dynamic()` 调用 |
  | `SecondaryPopup` | 添加 `can_focus = True` 确保弹窗正确接收键盘事件 |
  | `_show_confirm()` | 修复 hint 文本多余的 `[/]` markup 后缀 |

  ## 测试状态

| 步骤 | 结果 |
|------|------|
| Ruff (lint) | All checks passed |
| Frontend typecheck |  无错误 |
| Pytest | 401 passed, 1 skipped |

## 如何验证

  ```bash
 1. 启动 TUI

  vulnclaw tui

  2. 测试链式输入

  设置目标后输入 /scope，依次输入每个字段：

  only_host → only_port → only_path → blocked_host → blocked_path → allow_actions → block_actions

  确认：

  每个步骤的输入框正常显示并可输入
  每步按回车后顺利进入下一步
  第 7 步完成后弹出 resume 确认 (y/n)
  确认后仪表盘 scope 面板正确更新