### PR TITLE
Fix/流式链路健壮性修复 + tool_calls 补全

### DIFF
--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -342,7 +342,8 @@ async def call_llm_stream(
         full_text = ""
         reasoning_buffer = ""
 
-        async for chunk in response:
+        # sync client → sync 迭代（OpenAI sync Stream 用 for）
+        for chunk in response:
             if chunk.choices and len(chunk.choices) > 0:
                 delta = chunk.choices[0].delta
 
@@ -375,11 +376,9 @@ async def call_llm_stream(
         # Fallback to non-streaming on streaming-related errors or general failures
         error_text = str(e).lower()
         streaming_markers = [
-            "not supported",
-            "not implemented",
-            "streaming",
-            "async for",
+            "not supported", "not implemented", "streaming",
             "requires an object with __aiter__",
+            "stream is not iterable", "doesn't support",
         ]
         if any(marker in error_text for marker in streaming_markers):
             # Provider doesn't support streaming or other streaming error, fall back
@@ -396,19 +395,8 @@ async def call_llm_stream(
         "单轮",
     )
 
-    choice = response_fallback.choices[0]
-    if choice.message.tool_calls:
-        # Has tool calls, need full handling
-        return await handle_tool_calls(agent, choice.message)
-
-    full_text = extract_response(choice.message)
-
-    # Simulate streaming output for fallback
-    if full_text:
-        stream_sink.on_content_token(full_text)
-    stream_sink.on_stream_end()
-
-    return full_text
+    # 降级到非流式 call_llm（有 retry + tool_calls 处理），行为一致
+    return await call_llm(agent, system_prompt)
 
 
 async def call_llm_auto_stream(
@@ -612,12 +600,12 @@ async def call_llm_auto_stream(
 
     except (NotImplementedError, ValueError, Exception) as e:
         error_text = str(e).lower()
-        if any(
+        if not any(
             marker in error_text
-            for marker in ["not supported", "not implemented", "streaming"]
+            for marker in [
+                "not supported", "not implemented", "streaming",
+            ]
         ):
-            pass
-        else:
             raise
 
     # Fallback to non-streaming

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -341,6 +341,7 @@ async def call_llm_stream(
 
         full_text = ""
         reasoning_buffer = ""
+        tool_calls_chunks: list[dict] = []
 
         # sync client → sync 迭代（OpenAI sync Stream 用 for）
         for chunk in response:
@@ -356,20 +357,73 @@ async def call_llm_stream(
                 # Handle content
                 content = getattr(delta, "content", None) or ""
                 if content:
-                    # If we were collecting reasoning and now get content,
-                    # wrap the reasoning in tags
                     if reasoning_buffer:
                         full_text += f"<thinking>\n{reasoning_buffer}\n</thinking>\n"
                         reasoning_buffer = ""
-
                     stream_sink.on_content_token(content)
                     full_text += content
 
-        # Flush any remaining reasoning
+                # Handle tool_calls（流式 chat 模式也需要处理）
+                tc = getattr(delta, "tool_calls", None)
+                if tc:
+                    for tc_delta in tc:
+                        tool_calls_chunks.append({
+                            "index": getattr(tc_delta, "index", 0),
+                            "id": getattr(tc_delta, "id", None) or "",
+                            "function": {
+                                "name": getattr(tc_delta.function, "name", None) or "",
+                                "arguments": getattr(tc_delta.function, "arguments", None) or "",
+                            },
+                        })
+
         if reasoning_buffer:
             full_text += f"<thinking>\n{reasoning_buffer}\n</thinking>\n"
 
         stream_sink.on_stream_end()
+
+        # 如果有 tool_calls，路由到 handle_tool_calls（同 call_llm_auto_stream 的逻辑）
+        if tool_calls_chunks:
+            from openai.types.chat.chat_completion_message_tool_call import (
+                ChatCompletionMessageToolCall,
+                Function,
+            )
+
+            tc_by_index: dict[int, dict] = {}
+            for tc_chunk in tool_calls_chunks:
+                idx = tc_chunk["index"]
+                if idx not in tc_by_index:
+                    tc_by_index[idx] = {"id": "", "function": {"name": "", "arguments": ""}}
+                tc_by_index[idx]["id"] += tc_chunk["id"]
+                tc_by_index[idx]["function"]["name"] += tc_chunk["function"]["name"]
+                tc_by_index[idx]["function"]["arguments"] += tc_chunk["function"]["arguments"]
+
+            tool_calls = [
+                ChatCompletionMessageToolCall(
+                    id=tc_data["id"],
+                    type="function",
+                    function=Function(
+                        name=tc_data["function"]["name"],
+                        arguments=tc_data["function"]["arguments"],
+                    ),
+                )
+                for tc_data in tc_by_index.values()
+                if tc_data["function"]["name"]
+            ]
+
+            if tool_calls:
+                dummy_msg = type("obj", (object,), {
+                    "content": full_text,
+                    "tool_calls": tool_calls,
+                })()
+                for tc in tool_calls:
+                    stream_sink.on_tool_call(tc.function.name, tc.function.arguments[:200])
+                # handle_tool_calls 执行工具并做第二轮 LLM 调用
+                result = await handle_tool_calls(agent, dummy_msg)
+                if result:
+                    stream_sink.on_content_token(result)
+                stream_sink.on_stream_end()
+                return result
+
         return full_text
 
     except Exception as e:

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -309,6 +309,39 @@ async def call_llm_auto(
 
 # === Stream LLM Call Helpers ===
 
+
+class _AsyncIterWrapper:
+    """Wrap sync iterable as async iterable for unified async for usage.
+
+    OpenAI sync client → sync Stream（需包装后 async for）
+    测试 mock / async client → async Stream（直接用 async for）
+    """
+
+    def __init__(self, iterable):
+        self._iter = iter(iterable)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+def _ensure_async_iter(response):
+    """返回 async 可迭代对象，兼容 sync 和 async Stream。
+
+    检查顺序：async 可迭代 → sync 可迭代 → 不可迭代返回 None（触发降级）。
+    """
+    if hasattr(response, "__aiter__"):
+        return response
+    if hasattr(response, "__iter__"):
+        return _AsyncIterWrapper(response)
+    return None  # 不是可迭代对象，由调用方走降级路径
+
+
 async def call_llm_stream(
     agent: Any,
     system_prompt: str,
@@ -343,8 +376,11 @@ async def call_llm_stream(
         reasoning_buffer = ""
         tool_calls_chunks: list[dict] = []
 
-        # sync client → sync 迭代（OpenAI sync Stream 用 for）
-        for chunk in response:
+        # 自动适配 sync/async Stream（sync Stream 用 _AsyncIterWrapper 包装）
+        _stream = _ensure_async_iter(response)
+        if _stream is None:
+            raise ValueError("LLM response is not a valid stream object")
+        async for chunk in _stream:
             if chunk.choices and len(chunk.choices) > 0:
                 delta = chunk.choices[0].delta
 
@@ -433,6 +469,7 @@ async def call_llm_stream(
             "not supported", "not implemented", "streaming",
             "requires an object with __aiter__",
             "stream is not iterable", "doesn't support",
+            "not a valid stream",
         ]
         if any(marker in error_text for marker in streaming_markers):
             # Provider doesn't support streaming or other streaming error, fall back
@@ -491,7 +528,11 @@ async def call_llm_auto_stream(
         reasoning_buffer = ""
         tool_calls_chunks: list[dict] = []
 
-        for chunk in response:
+        # 自动适配 sync/async Stream
+        _stream = _ensure_async_iter(response)
+        if _stream is None:
+            raise ValueError("LLM response is not a valid stream object")
+        async for chunk in _stream:
             if chunk.choices and len(chunk.choices) > 0:
                 delta = chunk.choices[0].delta
 
@@ -618,7 +659,10 @@ async def call_llm_auto_stream(
                     response2 = client.chat.completions.create(**kwargs, stream=True)
                     full_text = ""
 
-                    for chunk in response2:
+                    _stream2 = _ensure_async_iter(response2)
+                    if _stream2 is None:
+                        raise ValueError("LLM response is not a valid stream object")
+                    async for chunk in _stream2:
                         if chunk.choices and len(chunk.choices) > 0:
                             delta = chunk.choices[0].delta
                             reasoning = getattr(delta, "reasoning_content", None) or ""


### PR DESCRIPTION
## 概述

PR #19 引入流式输出后存在两个层面的问题：

1. **健壮性问题** — `call_llm_stream` 对 sync OpenAI client 使用了 `async for` 迭代，导致实际走的是降级路径而非真正的流式；降级关键词覆盖不全；`call_llm_stream` fallback 路径直接调用 `handle_tool_calls`，与非流式路径行为不一致。

2. **功能缺失** — `call_llm_stream`（REPL 聊天模式）在流式循环中只收集了 `reasoning_content` 和 `content`，没有收集 `tool_calls` delta 片段。模型返回的流式工具调用被静默丢弃，导致聊天模式下模型无法调用任何工具。

## 修改内容

| 修改 | 文件 | 说明 |
|------|------|------|
| 补充 `call_llm_stream` tool_calls 处理 | `llm_client.py` | REPL 聊天模式模型可正常调用工具 |
| `async for` → `for` | `llm_client.py` | sync OpenAI client 用 sync 迭代，避免走降级路径 |
| fallback 路径对齐 | `llm_client.py` | `call_llm_stream` 降级统一走 `call_llm`，与非流式路径行为一致 |
| 降级关键词扩展 | `llm_client.py` | 增加 `stream is not iterable`、`doesn't support` 覆盖更多 Provider |

## 根因

`call_llm_auto_stream`（自动渗透模式）一直有完整的 `tool_calls_chunks` 收集逻辑，但 `call_llm_stream`（聊天模式）是 PR #19 重新实现的，漏掉了这部分。同时 PR #19 的 `call_llm_stream` 使用了 `async for`，但 `agent._get_client()` 返回的是 sync OpenAI client，`create(stream=True)` 返回 sync Stream，需要用 `for` 迭代