### PR TITLE
fix(tui): 修复了在tui下更改LLM提供商配置时出现的错误问题

### DIFF
--- a/vulnclaw/cli/tui_textual.py
+++ b/vulnclaw/cli/tui_textual.py
@@ -254,7 +254,9 @@ class SecondaryPopup(Vertical):
             if self._on_done:
                 on_done = self._on_done
                 self._on_done = None
-                on_done()
+                # Same rationale as _resolve: defer on_done so pending
+                # async Widget.remove() calls can finish first.
+                self.app.call_later(on_done)
             return
         fld, fld_title, fld_default = fields[idx]
         self.query_one("#popup-desc", Static).update(
@@ -304,7 +306,12 @@ class SecondaryPopup(Vertical):
         if self._on_done:
             on_done = self._on_done
             self._on_done = None
-            on_done()
+            # Defer on_done so that async Widget.remove() triggered by
+            # _dismiss() → _clear_dynamic() can complete the actual DOM
+            # removal before we try to mount a new widget with the same ID.
+            # Without this, Textual raises DuplicateIds because the old
+            # widget is still in _nodes_by_id when mount() runs.
+            self.app.call_later(on_done)
 
     def _cancel(self) -> None:
         self._cb = None
@@ -312,7 +319,9 @@ class SecondaryPopup(Vertical):
         if self._on_done:
             on_done = self._on_done
             self._on_done = None
-            on_done()
+            # Same rationale as _resolve: defer on_done so pending
+            # async Widget.remove() calls can finish first.
+            self.app.call_later(on_done)
 
     def _dismiss(self) -> None:
         self.remove_class("open")


### PR DESCRIPTION
  ## 根因

  在 `SecondaryPopup` 关闭时，`_dismiss()` 会调用 `_clear_dynamic()` 移除动态 Widget。Textual 的 `Widget.remove()` 是异步操作，旧 Widget 在调用返回后仍可能短暂存在于内部 `_nodes_by_id` 中。而关闭弹窗后的 `on_done` 回调会立即挂载新的、使用相同 ID 的 Widget，导致 Textual 抛出 `DuplicateIds` 异常。在 TUI 里切换 LLM 提供商配置并保存/取消时即可复现。

  ## 改动

  - `vulnclaw/cli/tui_textual.py`
    - 在 `_render_chain_step()` 完成链式输入后、`_resolve()` 确认输入后、`_cancel()` 取消输入后，统一将 `on_done()` 改为通过 `self.app.call_later(on_done)` 延迟执行。
    - 这样可以让待处理的异步 `Widget.remove()` 先完成实际的 DOM 清理，再执行后续挂载新 Widget 的逻辑。
    - 添加了注释说明延迟原因，便于后续维护。

  ## 测试状态

  - `pytest -q`：517 passed，1 skipped，0 failed。
  - `ruff check vulnclaw/cli/tui_textual.py`：通过。

  ## 如何验证
        
手动复现：
     - 启动 TUI：`vulnclaw tui`
     - 进入设置 → LLM 提供商配置
     - 切换或修改 LLM 提供商配置并保存/取消
     - 确认不再出现 `DuplicateIds` 异常，界面正常回到主界面
