### PR TITLE
  feat(tui): 支持从 LLM 提供商动态获取模型列表

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -789,12 +789,13 @@ class TestCLI:
         from vulnclaw.config.schema import VulnClawConfig
 
         config = VulnClawConfig()
+        # New flow: provider → base_url → api_key → (fetch models) → model → enter
         answers = iter(
             [
                 "deepseek",
                 "https://api.deepseek.com/v1",
-                "deepseek-chat",
                 "sk-test",
+                "deepseek-chat",
                 "",
             ]
         )
@@ -802,6 +803,8 @@ class TestCLI:
 
         monkeypatch.setattr(tui_mod.Prompt, "ask", lambda *args, **kwargs: next(answers))
         monkeypatch.setattr(tui_mod, "save_config", lambda cfg: saved.append(cfg))
+        # Mock fetch_provider_models to return a model list
+        monkeypatch.setattr(tui_mod, "fetch_provider_models", lambda *a, **kw: ["deepseek-chat", "deepseek-reasoner"])
 
         screen = tui_mod.Console(
             file=io.StringIO(),

--- a/vulnclaw/cli/tui.py
+++ b/vulnclaw/cli/tui.py
@@ -25,7 +25,13 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 from rich.text import Text
 
-from vulnclaw.config.settings import apply_provider_preset, list_providers, load_config, save_config
+from vulnclaw.config.settings import (
+    apply_provider_preset,
+    fetch_provider_models,
+    list_providers,
+    load_config,
+    save_config,
+)
 from vulnclaw.i18n import _, init_i18n
 from vulnclaw.target_state.store import get_target_state_preview, list_target_snapshots
 
@@ -918,17 +924,38 @@ def _cmd_config(session: dict[str, Any], args: str) -> None:
             nonlocal config
             session["config"] = apply_provider_preset(config, value)
             config = session["config"]
-        _set_prompt_input(session, _("tui.prompt_enter_model", model=config.llm.model), _on_model, default=config.llm.model)
-
-    def _on_model(value: str) -> None:
-        if value:
-            config.llm.model = value.strip()
+        # 流程变更：选择提供商后先输入 API Key
         key_status = _("tui.api_key_configured") if config.llm.api_key else _("tui.api_key_not_configured")
         _set_prompt_input(session, _("tui.prompt_enter_apikey", status=key_status), _on_apikey)
 
     def _on_apikey(value: str) -> None:
         if value:
             config.llm.api_key = value.strip()
+        base_url = config.llm.base_url
+        api_key = config.llm.api_key
+        # custom 提供商或缺少 base_url/api_key 时跳过获取，直接手动输入
+        if not base_url or not api_key:
+            _set_prompt_input(session, _("tui.prompt_enter_model_fallback", model=config.llm.model), _on_model_input, default=config.llm.model)
+            return
+        # prompt_toolkit 版本：同步获取模型列表
+        _set_prompt_message(session, _("tui.fetching_models"))
+        # Note: 在 prompt_toolkit 同步循环中，消息不会立即渲染
+        # 直接同步获取模型列表
+        models = fetch_provider_models(base_url, api_key)
+        if models:
+            _set_prompt_choice(session, _("tui.prompt_select_model", model=config.llm.model), models, _on_model_selected)
+        else:
+            _set_prompt_input(session, _("tui.prompt_enter_model_fallback", model=config.llm.model), _on_model_input, default=config.llm.model)
+
+    def _on_model_selected(value: str) -> None:
+        if value:
+            config.llm.model = value.strip()
+        save_config(config)
+        _set_prompt_message(session, f"{_('tui.config_saved')}: {config.llm.provider}/{config.llm.model}")
+
+    def _on_model_input(value: str) -> None:
+        if value:
+            config.llm.model = value.strip()
         save_config(config)
         _set_prompt_message(session, f"{_('tui.config_saved')}: {config.llm.provider}/{config.llm.model}")
 
@@ -1297,16 +1324,45 @@ def _prompt_llm_config(screen: Console, config):
         config = apply_provider_preset(config, provider)
 
     base_url = Prompt.ask("Base URL", default=config.llm.base_url).strip()
-    model = Prompt.ask("Model", default=config.llm.model).strip()
-    current_key = _("tui.api_key_configured") if config.llm.api_key else _("tui.api_key_not_configured")
-    api_key = Prompt.ask(_("tui.enter_api_key"), default="").strip()
-
     if base_url:
         config.llm.base_url = base_url
-    if model:
-        config.llm.model = model
+
+    # 流程变更：先输入 API Key，再获取模型列表
+    current_key = _("tui.api_key_configured") if config.llm.api_key else _("tui.api_key_not_configured")
+    api_key = Prompt.ask(f"API Key ({current_key})", default="").strip()
     if api_key:
         config.llm.api_key = api_key
+
+    # 尝试获取模型列表
+    effective_base_url = config.llm.base_url
+    effective_api_key = config.llm.api_key
+    model = config.llm.model
+
+    if effective_base_url and effective_api_key:
+        Console().print(f"  [{C_MUTED}]{_('tui.fetching_models')}[/]")
+        models = fetch_provider_models(effective_base_url, effective_api_key)
+        if models:
+            model_table = Table(title=_("tui.prompt_select_model", model=model), box=box.ROUNDED, border_style=C_BORDER_SUBTLE)
+            model_table.add_column("#", style=f"bold {C_PRIMARY}", width=4)
+            model_table.add_column("Model", style=C_TEXT)
+            for i, m in enumerate(models, 1):
+                marker = " *" if m == model else ""
+                model_table.add_row(str(i), f"{m}{marker}")
+            screen.print(model_table)
+            model = Prompt.ask(
+                _("tui.prompt_select_model", model=model),
+                default=model,
+            ).strip()
+        else:
+            model = Prompt.ask(
+                _("tui.prompt_enter_model_fallback", model=model),
+                default=model,
+            ).strip()
+    else:
+        model = Prompt.ask("Model", default=model).strip()
+
+    if model:
+        config.llm.model = model
     save_config(config)
 
     screen.print(

--- a/vulnclaw/cli/tui_textual.py
+++ b/vulnclaw/cli/tui_textual.py
@@ -45,7 +45,13 @@ from vulnclaw.cli.tui import (
     build_runtime_diagnostic,
     rebuild_translations,
 )
-from vulnclaw.config.settings import apply_provider_preset, list_providers, load_config, save_config
+from vulnclaw.config.settings import (
+    apply_provider_preset,
+    fetch_provider_models,
+    list_providers,
+    load_config,
+    save_config,
+)
 from vulnclaw.i18n import _, init_i18n
 from vulnclaw.target_state.store import get_target_state_preview, list_target_snapshots
 
@@ -130,7 +136,7 @@ class CommandPalette(ListView):
 class SecondaryPopup(Vertical):
     """Secondary popup for parameter input when a slash command needs arguments.
 
-    Supports input / choice / confirm / message / chain modes.
+    Supports input / choice / confirm / message / chain / loading modes.
     """
     can_focus = True
     def __init__(self, **kwargs: Any):
@@ -143,6 +149,8 @@ class SecondaryPopup(Vertical):
         self._chain_idx: int = 0
         self._session: dict[str, Any] | None = None
         self._on_done: Any = None
+        self._loading_dots: int = 0
+        self._loading_timer: Any = None
 
     def compose(self) -> ComposeResult:
         yield Static(id="popup-desc", markup=True)
@@ -170,6 +178,21 @@ class SecondaryPopup(Vertical):
         elif ptype == "chain":
             _, fields, idx, cb = prompt
             self._show_chain(fields, idx, cb)
+        elif ptype == "loading":
+            _, label, cb = prompt[:3]
+            self._show_loading(label, cb)
+            # If the session has fetch args, start the background model fetch
+            fetch_args = session.get("_fetch_models_args")
+            if fetch_args:
+                base_url, api_key = fetch_args
+                session.pop("_fetch_models_args", None)
+
+                def _bg_fetch() -> None:
+                    models = fetch_provider_models(base_url, api_key)
+                    # Schedule completion on the main thread
+                    self.app.call_later(lambda: self._finish_model_fetch(models))
+
+                threading.Thread(target=_bg_fetch, daemon=True).start()
 
     def _show_input(self, label: str, callback: Any, default: str) -> None:
         self._clear_dynamic()
@@ -241,6 +264,71 @@ class SecondaryPopup(Vertical):
             inp = Input(value=fld_default if fld_default else "", id="popup-input")
             self.mount(inp)
         self._render_chain_step()
+
+    def _show_loading(self, label: str, callback: Any) -> None:
+        """Show a loading indicator with animated dots.
+
+        The popup stays open until ``complete_loading()`` is called
+        from an external source (typically a background thread via
+        ``app.call_later()``).
+        """
+        self._clear_dynamic()
+        self._ptype = "loading"
+        self._cb = callback
+        self._loading_dots = 0
+        self.query_one("#popup-desc", Static).update(
+            f"[bold {C_PRIMARY}]{label}[/]"
+        )
+        hint = Static("  ●", id="popup-hint")
+        self.mount(hint)
+        self.add_class("open")
+        self.focus()
+        # Start dot animation timer
+        self._tick_loading()
+
+    def _tick_loading(self) -> None:
+        """Animate loading dots."""
+        if self._ptype != "loading":
+            return
+        self._loading_dots = (self._loading_dots + 1) % 4
+        dots = "●" + " ○" * self._loading_dots
+        try:
+            self.query_one("#popup-hint", Static).update(
+                f"  [{C_MUTED}]{dots}[/]"
+            )
+        except Exception:
+            return
+        self._loading_timer = self.set_timer(0.5, self._tick_loading)
+
+    def complete_loading(self, result: Any = None) -> None:
+        """Complete a loading prompt and trigger the callback with *result*.
+
+        Typically called via ``app.call_later()`` from a background
+        thread after the async operation finishes.
+        """
+        # Stop the animation timer
+        if self._loading_timer is not None:
+            self._loading_timer.stop()
+            self._loading_timer = None
+        cb = self._cb
+        self._cb = None
+        self._dismiss()
+        if cb:
+            cb(result)
+        if self._on_done:
+            on_done = self._on_done
+            self._on_done = None
+            self.app.call_later(on_done)
+
+    def _finish_model_fetch(self, models: list[str]) -> None:
+        """Called on the main thread after background model fetch completes.
+
+        Completes the loading prompt, triggers the callback, then shows
+        the next prompt (model choice or fallback input).
+        """
+        # Complete the loading — this calls on_models_loaded(models)
+        # and then _on_done (which is _post_popup_refresh)
+        self.complete_loading(models)
 
     def _render_chain_step(self) -> None:
         idx = self._chain_idx
@@ -370,6 +458,9 @@ class SecondaryPopup(Vertical):
             if event.key in ("enter", "escape"):
                 event.stop()
                 self._cancel()
+        elif self._ptype == "loading":
+            # Loading cannot be cancelled by user — ignore all keys
+            event.stop()
         elif event.key == "escape":
             event.stop()
             self._cancel()
@@ -520,7 +611,7 @@ def _h_diag(session: dict[str, Any], args: str) -> str | None:
 @_register_handler("config")
 @_register_handler("cfg")
 def _h_config(session: dict[str, Any], args: str) -> str | None:
-    # [修改] 2026-06-10 Nyaecho - 修复 config 变量引用问题，使用 nonlocal 更新闭包变量
+    # [修改] 重构 config 流程: 选择提供商 → 输入 API Key → 获取模型列表 → 选择/输入模型
     config = session["config"]
     providers = [item["provider"] for item in list_providers()]
     cur = config.llm.provider
@@ -530,17 +621,38 @@ def _h_config(session: dict[str, Any], args: str) -> str | None:
         if v and v != cur:
             config = apply_provider_preset(config, v)
             session["config"] = config
-        _set_prompt(session, "input", _("tui.prompt_enter_model", model=config.llm.model), on_model, config.llm.model)
-
-    def on_model(v):
-        if v:
-            session["config"].llm.model = v.strip()
+        # 流程变更：选择提供商后先输入 API Key
         ks = _("tui.api_key_configured") if session["config"].llm.api_key else _("tui.api_key_not_configured")
         _set_prompt(session, "input", _("tui.prompt_enter_apikey", status=ks), on_apikey)
 
     def on_apikey(v):
         if v:
             session["config"].llm.api_key = v.strip()
+        base_url = session["config"].llm.base_url
+        api_key = session["config"].llm.api_key
+        # custom 提供商或缺少 base_url 时跳过获取，直接手动输入
+        if not base_url or not api_key:
+            _set_prompt(session, "input", _("tui.prompt_enter_model_fallback", model=session["config"].llm.model), on_model_input, session["config"].llm.model)
+            return
+        # 显示 loading，后台获取模型列表
+        session["_fetch_models_args"] = (base_url, api_key)
+        _set_prompt(session, "loading", _("tui.fetching_models"), on_models_loaded)
+
+    def on_models_loaded(models):
+        if models:
+            _set_prompt(session, "choice", _("tui.prompt_select_model", model=session["config"].llm.model), models, on_model_selected)
+        else:
+            _set_prompt(session, "input", _("tui.prompt_enter_model_fallback", model=session["config"].llm.model), on_model_input, session["config"].llm.model)
+
+    def on_model_selected(v):
+        if v:
+            session["config"].llm.model = v.strip()
+        save_config(session["config"])
+        _set_prompt(session, "message", f"{_('tui.config_saved')}: {session['config'].llm.provider}/{session['config'].llm.model}")
+
+    def on_model_input(v):
+        if v:
+            session["config"].llm.model = v.strip()
         save_config(session["config"])
         _set_prompt(session, "message", f"{_('tui.config_saved')}: {session['config'].llm.provider}/{session['config'].llm.model}")
 

--- a/vulnclaw/config/settings.py
+++ b/vulnclaw/config/settings.py
@@ -289,3 +289,51 @@ def list_providers() -> list[dict[str, str]]:
             }
         )
     return result
+
+
+def fetch_provider_models(base_url: str, api_key: str, timeout: float = 10.0) -> list[str]:
+    """Fetch available models from a provider's OpenAI-compatible API.
+
+    Uses the OpenAI SDK's ``client.models.list()`` endpoint.
+    Returns a sorted list of model ID strings.  Returns an empty list
+    on any error (network, auth, timeout, etc.).
+    """
+    if not base_url or not api_key:
+        return []
+    try:
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
+        models_page = client.models.list()
+        model_ids = [m.id for m in models_page if m.id]
+        return sorted(model_ids)
+    except Exception:
+        return []
+
+
+def fetch_provider_models_async(
+    base_url: str,
+    api_key: str,
+    timeout: float = 10.0,
+    on_result: Any = None,
+):
+    """Fetch provider models in a background thread.
+
+    Calls ``fetch_provider_models()`` in a daemon thread.  When the
+    fetch completes, *on_result* (if provided) is called with the
+    model list on the **calling** thread via ``app.call_later()``-style
+    scheduling — the caller is responsible for arranging thread-safe
+    delivery (e.g. by passing a lambda that uses ``call_later``).
+
+    Returns the ``Thread`` object so callers can track or join it.
+    """
+    import threading
+
+    def _worker() -> None:
+        models = fetch_provider_models(base_url, api_key, timeout)
+        if on_result is not None:
+            on_result(models)
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+    return t

--- a/vulnclaw/i18n/en.json
+++ b/vulnclaw/i18n/en.json
@@ -270,5 +270,10 @@
   "tui.language_auto": "Auto (follow system)",
   "tui.language_zh": "Chinese",
   "tui.language_en": "English",
-  "tui.language_switched": "UI language switched to: {lang}"
+  "tui.language_switched": "UI language switched to: {lang}",
+  "tui.prompt_select_model": "Select Model (current: {model}):",
+  "tui.prompt_enter_model_fallback": "Failed to fetch models, enter model name manually (current: {model}):",
+  "tui.fetching_models": "Fetching model list...",
+  "tui.fetch_models_failed": "Failed to fetch model list",
+  "tui.no_models_available": "No models available from this provider"
 }

--- a/vulnclaw/i18n/zh.json
+++ b/vulnclaw/i18n/zh.json
@@ -270,5 +270,10 @@
   "tui.language_auto": "自动 (跟随系统)",
   "tui.language_zh": "中文",
   "tui.language_en": "English",
-  "tui.language_switched": "界面语言已切换为: {lang}"
+  "tui.language_switched": "界面语言已切换为: {lang}",
+  "tui.prompt_select_model": "选择模型 (当前: {model}):",
+  "tui.prompt_enter_model_fallback": "获取模型列表失败，请手动输入模型名 (当前: {model}):",
+  "tui.fetching_models": "正在获取模型列表...",
+  "tui.fetch_models_failed": "获取模型列表失败",
+  "tui.no_models_available": "该提供商未返回可用模型"
 }


### PR DESCRIPTION
  ## 改进内容

  - 在 `vulnclaw/config/settings.py` 中新增 `fetch_provider_models()` 与 `fetch_provider_models_async()`，通过 OpenAI 兼容 API 动态拉取可用模型列表。
  - 重构 prompt_toolkit 与 Textual 两版 TUI 的 LLM 配置流程：选择提供商 → 输入 API Key → 自动获取模型列表 → 选择或输入模型。
  - 为 Textual TUI 添加异步获取与加载动画，避免阻塞 UI 线程。
  - 获取失败（如网络异常、API Key 无效）时自动降级为手动输入模式，保证配置流程仍可继续。
  - 更新 `vulnclaw/i18n/en.json` 与 `vulnclaw/i18n/zh.json`，补充新流程所需的中英文提示与错误文案。
  - 更新 `tests/test_cli.py` 测试用例，适配新的配置交互流程。

  ## 修改文件

  | 文件 | 说明 |
  |------|------|
  | `vulnclaw/config/settings.py` | 新增模型获取函数与异步版本 |
  | `vulnclaw/cli/tui.py` | 重构 prompt_toolkit 版本的 LLM 配置流程 |
  | `vulnclaw/cli/tui_textual.py` | 重构 Textual 版本的 LLM 配置流程，添加加载状态 |
  | `vulnclaw/i18n/en.json` | 新增英文国际化字符串 |
  | `vulnclaw/i18n/zh.json` | 新增中文国际化字符串 |
  | `tests/test_cli.py` | 更新测试用例适配新流程 |

  ## 测试状态

  - `pytest tests/test_cli.py -v`：**42 passed**，1 warning（来自 `chromadb` 依赖的 DeprecationWarning，与本次改动无关）
  - `pytest -q`（完整套件）：**517 passed, 1 skipped**，1 warning

  ## 如何验证

  1. 运行自动化测试：
     ```bash
     pytest tests/test_cli.py -v
     pytest -q
  2. 手动启动 TUI，进入 LLM 配置界面：
    - 选择 OpenAI 或兼容提供商；
    - 输入有效 API Key；
    - 确认模型列表可自动加载并展示。
  3. 测试降级逻辑：
    - 输入错误 API Key 或断开网络；
    - 确认界面自动切换为手动输入模型模式。
  4. 检查国际化文案：
    - 切换中英文语言，确认新提示文案显示正常。