### PR TITLE
feat: 重构渗透引擎 + 反幻觉 + 推理/反思/插件体系 (v0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,15 @@ VulnClaw 自动执行：
 
 ## 特性
 
+- **目标驱动求解引擎（默认）** — 抛弃固定轮数工作流，以「目标达成 / 探索前沿耗尽 / 安全预算」为终止条件，自动收敛
+- **黑板图状态空间搜索** — 把渗透建模为从 origin 向 goal 的搜索：Fact（已确认事实）+ Intent（探索方向），结构上杜绝"原地打转"
+- **证据级反幻觉闸门** — 声称的 flag/结论必须在真实工具输出里逐字符出现才被采信，杜绝凭空编造 flag 的假胜利
 - **自然语言驱动** — 用人话描述渗透意图，自动识别阶段和工具
 - **13 个 LLM Provider** — OpenAI / MiniMax / DeepSeek / 智谱 / Moonshot / 千问 / SiliconFlow / 豆包 / 百川 / 阶跃星辰 / 商汤 / 零一万物，一键切换
 - **MCP 工具链** — 4 个 MCP 服务：`fetch` / `memory` 本地实现开箱即用，`chrome-devtools` / `burp` 对接外部 MCP 服务实现浏览器自动化和 HTTP 抓包重放
 - **AI Agent 核心** — OpenAI 兼容协议 + Tool Calling + 自主渗透循环
+- **结构化推理 + 自适应反思** — 已知事实/约束/攻击链结构化沉淀；失败自动归类并按 L0-L4 渐进升级 payload 绕过策略
+- **漏洞检测插件体系** — 低耦合插件运行时 + 内置只读 Web 插件，结果自动汇入报告链路（`vulnclaw plugins`）
 - **21 个渗透 Skill** — 7 核心 + 14 专项 Skill（含 CTF Web/Crypto/Misc、osint-recon、secknowledge-skill），含 180 个参考文档
 - **编解码/加解密工具** — 29 种操作（Base64/Hex/URL/AES/JWT/Morse 等），LLM 可精确调用，不再靠猜测
 - **Python 代码执行** — 内置 `python_execute` 工具，适合 payload 构造和响应解析；当前仍属高风险实验能力，不应视为强隔离沙箱
@@ -64,6 +69,54 @@ VulnClaw 自动执行：
 - **自动报告 & PoC** — 生成结构化 Markdown 报告和可运行的 Python PoC 脚本
 - **Web UI 模式** — `vulnclaw web` 启动本地 Web 界面，浏览器操作渗透测试全流程，默认 `127.0.0.1:7788`
 - **安全知识库** — 已内置知识库模块与基础种子数据，CLI 可维护；检索增强正在逐步接入主流程
+
+---
+
+## 架构升级：从「固定轮数工作流」到「目标驱动求解」
+
+旧版自主渗透是**固定轮数循环**（跑满 N 轮才停），在弱模型上容易陷入"反复请求同一页面、嘴上说要测注入却不发包"的死循环。新版把渗透重构为**状态空间搜索**，这是本次重构的核心。
+
+### 黑板图 + OODA 求解循环（默认引擎 `solve`）
+
+把渗透看作从 **origin**（目标）向 **goal**（拿到 flag / shell / 确认高危漏洞）的有向搜索，用两个原语驱动：
+
+| 原语 | 含义 |
+|------|------|
+| **Fact** | 已被真实工具输出证实的客观事实（探索的落脚点） |
+| **Intent** | 声明的探索方向（尚未执行的一步），从 Fact 出发，结论后产出新 Fact |
+
+循环结构（`vulnclaw/agent/solver.py`）：
+
+```
+REASON（读全图）→ 目标达成? / 提出新探索方向 / 不提出
+        │
+EXPLORE（领一个 Intent）→ 用工具实际执行 → 把确认的结论写回为一个 Fact
+        │
+终止：目标达成 / 探索前沿耗尽（Reason 不再提方向）/ 触达安全预算
+```
+
+**为什么结构上杜绝打转**：一旦"首页是登录框"成为一个 Fact，Reason 就不会再提"去看首页"，而是提"测 SQL 注入"；每个 Intent 领取一次、结论一次即标记 `concluded`/`abandoned`，**不可能重复**。终止由目标驱动，不再是数死轮数。
+
+### 证据级反幻觉闸门
+
+弱模型常凭空编造 flag。新引擎在 `solve()` 里录制**所有真实工具输出**（HTTP 响应体、`python_execute` 输出）作为唯一可信证据：
+
+- **结论闸门**：Explore 结论里声称的 flag，若未在真实工具输出里逐字符出现 → 判定幻觉、丢弃、标记 `[未验证]`。
+- **完成闸门**：Reason 宣布"目标达成"时，若目标要 flag 但真实输出里从无 flag → 拒绝完成、继续探索。
+- **即时收敛**：一旦拿到经证据验证的 flag，立即完成，不再空跑验证轮。
+
+> 这套机制对弱模型尤其友好：旧的固定轮数循环容易在重复请求里空转，而「目标驱动 + 证据反幻觉」会逼着 Agent 用真实工具输出一步步逼近目标，并拒绝任何无证据支撑的「完成」。
+
+### 结构化推理 + 自适应反思
+
+- **推理状态层**（`reasoning_state.py`）：已知事实（带置信度）、推理障碍（WAF/过滤等）、候选攻击链，结构化沉淀并注入提示词。
+- **反思引擎**（`reflexion.py`）：失败自动归类（环境限制/路径错误/参数错误/信息不足），按 **L0-L4 渐进升级** payload 绕过策略（原始 → URL 编码 → 双写注释 → Unicode/hex → 多层混淆/换攻击面），persistent 模式跨周期保留失败记忆。
+
+### 漏洞检测插件体系
+
+低耦合插件运行时（`vulnclaw/plugins/`）+ 内置只读 Web 插件（安全响应头 / JWT / JS 端点分析），插件结果可去重合并进 `SessionState.findings` 进入报告链路。
+
+> 切回旧的固定轮数引擎：`vulnclaw config set session.engine rounds`
 
 ---
 
@@ -170,7 +223,8 @@ $ vulnclaw --help
 | `vulnclaw` | 默认打开原 CLI / REPL 交互界面 | `vulnclaw` |
 | `vulnclaw tui` | 显式打开终端图形化工作台 | `vulnclaw tui` / `vulnclaw tui --target target.com` |
 | `vulnclaw repl` | 启动经典 REPL 交互界面 | `vulnclaw repl` |
-| `vulnclaw run <target>` | 一键全流程渗透测试 | `vulnclaw run 192.168.1.1` |
+| `vulnclaw solve <target>` | 目标驱动求解（无固定轮数，拿到目标即停） | `vulnclaw solve target.com --goal "拿到flag"` |
+| `vulnclaw run <target>` | 一键全流程渗透（默认走 solve 引擎） | `vulnclaw run 192.168.1.1` |
 | `vulnclaw persistent <target>` | 持续性渗透（100轮/周期） | `vulnclaw persistent 192.168.1.1` |
 | `vulnclaw recon <target>` | 仅信息收集（不利用漏洞） | `vulnclaw recon target.com` |
 | `vulnclaw scan <target>` | 漏洞扫描阶段 | `vulnclaw scan target.com --ports 80,443` |
@@ -182,6 +236,9 @@ $ vulnclaw --help
 | `vulnclaw config provider <name>` | 切换 LLM 提供商 | `vulnclaw config provider minimax` |
 | `vulnclaw init` | 初始化配置文件 | `vulnclaw init` |
 | `vulnclaw doctor` | 检查运行环境 | `vulnclaw doctor` |
+| `vulnclaw plugins list` | 列出漏洞检测插件 | `vulnclaw plugins list --stage discovery` |
+| `vulnclaw plugins info <id>` | 查看插件元信息 | `vulnclaw plugins info builtin.web.headers` |
+| `vulnclaw plugins run <id>` | 运行插件（仅分析传入数据） | `vulnclaw plugins run builtin.web.headers --input headers.json --session s.json` |
 | `vulnclaw web` | 启动本地 Web UI | `vulnclaw web` / `vulnclaw web --port 8080` |
 
 ### TUI 工作台
@@ -465,6 +522,9 @@ vulnclaw config provider minimax   # 一键切换
 | -------------- | ------------------------------------------------ | --------------------------------------------- |
 | **CLI/TUI 入口** | `cli/main.py` + `cli/tui.py`                   | Typer 命令 + 默认原 CLI/REPL + 显式 TUI       |
 | **Agent 核心** | `agent/core.py`                                  | AgentCore 协调入口（核心重构后主要保留少量协调职责） |
+| **求解引擎（默认）** | `agent/solver.py` + `agent/blackboard.py`  | 目标驱动 OODA 循环 + Fact/Intent 黑板图 + 证据级反幻觉闸门 |
+| **推理 / 反思**   | `agent/reasoning_state.py` + `reflexion.py`   | 结构化事实/约束/攻击链 + 失败归类与 L0-L4 升级 |
+| **插件体系**   | `plugins/`（registry/runtime/web）                | 低耦合漏洞检测插件运行时 + 内置只读 Web 插件   |
 | **动态提示词** | `agent/prompts.py`                               | 基础身份 + 核心契约 + Skill + MCP 工具列表    |
 | **Prompt 组装** | `agent/system_prompt.py` + `prompt_context.py`  | system prompt / round context / attack summary 组装 |
 | **输入分析**   | `agent/input_analysis.py`                        | 目标识别、阶段识别、用户漏洞提示提取          |
@@ -635,7 +695,11 @@ vulnclaw config set session.show_thinking false # 隐藏推理过程（也可在
 | `llm.model`              | 按 provider | 模型名称，可自定义                   |
 | `llm.temperature`        | 0.1    | 采样温度                                 |
 | `llm.max_tokens`         | 4096   | 单次最大输出 token                       |
-| `session.max_rounds`     | 15     | 自主渗透循环最大轮数（建议 10-50）       |
+| `session.engine`         | solve  | 自主引擎：`solve`（目标驱动，默认）/ `rounds`（旧固定轮数） |
+| `session.solve_max_steps` | 40    | solve 探索步数安全上限（兜底，非固定工作流长度） |
+| `session.solve_max_intents` | 3   | 每次 Reason 最多提出的新探索方向数        |
+| `session.solve_max_tool_rounds` | 6 | 每个 Intent 探索的最大工具调用轮数        |
+| `session.max_rounds`     | 15     | 旧 `rounds` 引擎的最大轮数（建议 10-50）  |
 | `session.output_dir`     | ./vulnclaw-output | 报告输出目录                    |
 | `session.report_format`  | markdown | 报告格式（markdown / html）            |
 | `session.poc_language`   | python | PoC 生成语言（python / bash）            |
@@ -653,12 +717,33 @@ vulnclaw config set session.show_thinking false # 隐藏推理过程（也可在
 | `VULNCLAW_LLM_API_KEY`        | API Key                |
 | `VULNCLAW_LLM_BASE_URL`       | API 基础 URL           |
 | `VULNCLAW_LLM_MODEL`          | 模型名称               |
-| `VULNCLAW_SESSION__MAX_ROUNDS`| 自主渗透最大轮数       |
-| `VULNCLAW_SESSION__STALE_ROUNDS_THRESHOLD` | 死循环检测阈值 |
+| `VULNCLAW_SESSION_MAX_ROUNDS`| 自主渗透最大轮数       |
+| `VULNCLAW_SESSION_STALE_ROUNDS_THRESHOLD` | 死循环检测阈值 |
+| `VULNCLAW_SESSION_REASONING_STATE_ENABLED` | 结构化推理状态开关 |
+| `VULNCLAW_SESSION_REFLEXION_ENABLED` | 自适应反思引擎开关 |
+| `VULNCLAW_SESSION_REFLEXION_MAX_SAME_VULN_FAILS` | 同类漏洞连败触发反思阈值 |
+| `VULNCLAW_SESSION_ESCALATION_MAX_LEVEL` | Payload 升级上限（0-4） |
+| `VULNCLAW_SESSION_PLUGIN_RUNTIME_ENABLED` | 插件运行时开关 |
+| `VULNCLAW_SESSION_PLUGIN_MAX_REQUESTS_PER_TARGET` | 单目标插件请求预算 |
 
 优先级：**环境变量 > 配置文件 > 内置默认值**
 
 配置文件位于 `~/.vulnclaw/config.yaml`。
+
+---
+
+## 更新日志
+
+### v0.4.0
+
+**核心：自主引擎从「固定轮数工作流」重构为「目标驱动求解」**
+
+- **新增目标驱动求解引擎（默认）** — 基于 Fact/Intent 黑板图的 OODA 循环，以「目标达成 / 探索前沿耗尽 / 安全预算」为终止条件，结构上杜绝"原地打转"；新增 `vulnclaw solve` 命令，`run`/REPL 自主模式默认改走该引擎（`session.engine=rounds` 可回退旧逻辑）。
+- **新增证据级反幻觉闸门** — 录制所有真实工具输出作为唯一可信证据；声称的 flag/完成必须在真实输出里逐字符出现才被采信，否则判定幻觉并继续探索；拿到验证过的 flag 即时收敛。
+- **新增结构化推理 + 自适应反思** — 已知事实（带置信度）/约束/攻击链结构化沉淀并注入提示词；失败自动归类并按 L0–L4 渐进升级 payload 绕过策略，persistent 模式跨周期保留失败记忆。
+- **新增漏洞检测插件体系** — 低耦合插件运行时 + 内置只读 Web 插件（安全响应头 / JWT / JS 端点），结果可去重合并进 findings 与报告链路；新增 `vulnclaw plugins list/info/run` 命令。
+- **修复 #45 工具被误约束** — 动作约束不再把 HTTP 方法（OPTIONS/POST）或使用 `requests` 误判为「利用」；只有实际攻击载荷（SQLi/RCE/路径穿越等）才算 exploit；`load_skill_reference`/`crypto_decode` 等纯本地工具豁免范围约束。
+- 新增 `session.engine` / `solve_*` / `reflexion_*` / `plugin_*` 等配置项，均支持环境变量注入。
 
 ---
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import os
 import tempfile
-from uuid import uuid4
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
-
 
 TEST_ROOT = Path(__file__).resolve().parent / ".test-tmp"
 TEST_ROOT.mkdir(parents=True, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vulnclaw"
-version = "0.3.1"
+version = "0.4.0"
 description = "🦞 AI-powered penetration testing CLI tool for cybersecurity professionals"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import argparse
+import shutil
 import subprocess
 import sys
-import shutil
-import argparse
 from pathlib import Path
-
 
 ROOT = Path(__file__).resolve().parent.parent
 FRONTEND = ROOT / "frontend"

--- a/scripts/verify_dist_artifacts.py
+++ b/scripts/verify_dist_artifacts.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parent.parent
 DIST_DIR = ROOT / "dist"
 PYPROJECT = ROOT / "pyproject.toml"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -104,12 +104,25 @@ class TestSessionState:
         state.add_note("Interesting endpoint found")
         assert len(state.notes) == 1
 
+    def test_add_confirmed_fact_updates_reasoning(self):
+        from vulnclaw.agent.context import SessionState
+
+        state = SessionState()
+        state.add_confirmed_fact("CVE-2024-1234 confirmed on https://example.com")
+        state.add_confirmed_fact("CVE-2024-1234 confirmed on https://example.com")
+
+        assert state.confirmed_facts == ["CVE-2024-1234 confirmed on https://example.com"]
+        assert len(state.reasoning.facts) == 1
+        assert state.reasoning.facts[0].key == "cve"
+        assert state.reasoning.facts[0].confidence == 0.99
+
     def test_save_and_load(self, tmp_path):
         from vulnclaw.agent.context import PentestPhase, SessionState, VulnerabilityFinding
 
         state = SessionState(target="192.168.1.100")
         state.advance_phase(PentestPhase.RECON)
         state.add_finding(VulnerabilityFinding(title="SQLi", severity="Critical"))
+        state.add_confirmed_fact("port 80 open")
 
         save_path = tmp_path / "session.json"
         returned_path = state.save(save_path)
@@ -121,6 +134,7 @@ class TestSessionState:
         assert len(loaded.findings) == 1
         # Critical severity without evidence gets [未验证] prefix
         assert "SQLi" in loaded.findings[0].title
+        assert loaded.reasoning.facts[0].value == "port 80 open"
 
     def test_multiple_findings(self):
         from vulnclaw.agent.context import SessionState, VulnerabilityFinding

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from vulnclaw.agent.blackboard import Blackboard, IntentStatus
+
+
+def test_fact_and_intent_ids_are_sequential():
+    board = Blackboard(origin="t", goal="flag")
+    f1 = board.add_fact("login form", "origin")
+    f2 = board.add_fact("php 7.3", "fetch")
+    assert (f1.id, f2.id) == ("f001", "f002")
+    i1 = board.add_intent("test sqli", [f1.id])
+    assert i1.id == "i001"
+    assert i1.from_facts == ["f001"]
+
+
+def test_add_intent_drops_unknown_from_facts():
+    board = Blackboard()
+    board.add_fact("x")
+    intent = board.add_intent("explore", ["f001", "f999"])
+    assert intent.from_facts == ["f001"]
+
+
+def test_conclude_intent_creates_linked_fact():
+    board = Blackboard()
+    f = board.add_fact("seed")
+    intent = board.add_intent("probe", [f.id])
+    board.claim_intent(intent.id)
+    assert board.get_intent(intent.id).status == IntentStatus.EXPLORING
+
+    new_fact = board.conclude_intent(intent.id, "sqli confirmed")
+    assert new_fact.id == "f002"
+    assert board.get_intent(intent.id).status == IntentStatus.CONCLUDED
+    assert board.get_intent(intent.id).result_fact == "f002"
+    assert not board.open_intents()
+
+
+def test_abandon_and_active_intents():
+    board = Blackboard()
+    board.add_fact("seed")
+    a = board.add_intent("dead end")
+    b = board.add_intent("live path")
+    board.abandon_intent(a.id, note="走不通")
+    assert board.get_intent(a.id).status == IntentStatus.ABANDONED
+    assert board.get_intent(a.id).note == "走不通"
+    # active = open + exploring (abandoned/concluded excluded)
+    active_ids = {i.id for i in board.active_intents()}
+    assert active_ids == {b.id}
+
+
+def test_mark_complete_and_summary():
+    board = Blackboard(goal="flag")
+    board.add_fact("seed")
+    board.mark_complete("flag{found} 已验证")
+    summary = board.get_summary()
+    assert summary["completed"] is True
+    assert summary["complete_reason"].startswith("flag{found}")
+    assert summary["facts"] == 1
+
+
+def test_to_prompt_graph_renders_goal_facts_intents():
+    board = Blackboard(origin="http://t", goal="capture flag")
+    f = board.add_fact("login form", "origin")
+    board.add_intent("sqli bypass", [f.id])
+    text = board.to_prompt_graph()
+    assert "goal: capture flag" in text
+    assert "f001: login form" in text
+    assert "i001 [open]" in text
+
+
+def test_board_roundtrips_through_pydantic():
+    board = Blackboard(goal="g")
+    f = board.add_fact("a")
+    board.add_intent("b", [f.id])
+    dumped = board.model_dump()
+    restored = Blackboard.model_validate(dumped)
+    assert restored.goal == "g"
+    assert restored.fact_ids() == ["f001"]
+    assert restored.open_intents()[0].description == "b"

--- a/tests/test_builtin_plugins.py
+++ b/tests/test_builtin_plugins.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import base64
+import json
+
+from vulnclaw.plugins import PluginContext, PluginStage, RiskLevel
+from vulnclaw.plugins.web import (
+    BUILTIN_WEB_PLUGINS,
+    JavaScriptEndpointsPlugin,
+    JWTClaimsPlugin,
+    SecurityHeadersPlugin,
+)
+
+
+def test_builtin_web_plugins_are_exported() -> None:
+    plugin_ids = {plugin_cls.plugin_id for plugin_cls in BUILTIN_WEB_PLUGINS}
+
+    assert plugin_ids == {
+        "builtin.web.headers",
+        "builtin.web.jwt",
+        "builtin.web.js_endpoints",
+    }
+
+
+def test_security_headers_plugin_reports_missing_headers_from_options_only() -> None:
+    context = PluginContext(
+        target="https://example.com",
+        stage=PluginStage.DISCOVERY,
+        options={"headers": {"Content-Security-Policy": "default-src 'self'"}},
+    )
+
+    result = SecurityHeadersPlugin().run(context)
+
+    assert result.plugin_id == "builtin.web.headers"
+    assert result.ok is True
+    assert result.findings
+    assert result.findings[0].risk == RiskLevel.LOW
+    assert "x-frame-options" in result.findings[0].evidence["missing_headers"]
+
+
+def test_security_headers_plugin_handles_missing_input_without_findings() -> None:
+    result = SecurityHeadersPlugin().run(PluginContext(options={}))
+
+    assert result.ok is True
+    assert result.findings == []
+    assert result.messages == ["No headers were supplied."]
+
+
+def test_jwt_plugin_reports_unsigned_and_missing_claims() -> None:
+    token = _jwt({"alg": "none", "typ": "JWT"}, {"sub": "user-1"})
+    context = PluginContext(
+        target="https://example.com",
+        stage=PluginStage.VERIFICATION,
+        options={"token": token},
+    )
+
+    result = JWTClaimsPlugin().run(context)
+
+    titles = {finding.title for finding in result.findings}
+    assert "JWT uses an unsigned or missing algorithm" in titles
+    assert "JWT is missing common validation claims" in titles
+    assert result.metadata["payload_keys"] == ["sub"]
+
+
+def test_jwt_plugin_rejects_invalid_format() -> None:
+    result = JWTClaimsPlugin().run(PluginContext(options={"token": "not-a-jwt"}))
+
+    assert result.ok is False
+    assert result.error == "Invalid JWT format."
+
+
+def test_js_endpoints_plugin_extracts_endpoints_from_content() -> None:
+    context = PluginContext(
+        target="https://example.com",
+        stage=PluginStage.RECON,
+        options={
+            "content": """
+                fetch("/api/users");
+                const admin = '/admin/debug';
+                const cdn = "https://cdn.example.com/assets/app.js";
+            """,
+        },
+    )
+
+    result = JavaScriptEndpointsPlugin().run(context)
+
+    assert result.findings[0].risk == RiskLevel.INFO
+    evidence = result.findings[0].evidence
+    assert evidence["endpoints"] == [
+        "/admin/debug",
+        "/api/users",
+        "https://cdn.example.com/assets/app.js",
+    ]
+    assert evidence["interesting_endpoints"] == ["/admin/debug"]
+
+
+def _jwt(header: dict[str, object], payload: dict[str, object]) -> str:
+    return f"{_segment(header)}.{_segment(payload)}."
+
+
+def _segment(value: dict[str, object]) -> str:
+    raw = json.dumps(value, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -282,6 +282,7 @@ class TestCLI:
 
         config = VulnClawConfig()
         config.llm.api_key = "test-key"
+        config.session.engine = "rounds"
         monkeypatch.setattr(cli_main, "load_config", lambda: config)
 
         prompts = []
@@ -323,6 +324,7 @@ class TestCLI:
 
         config = VulnClawConfig()
         config.llm.api_key = "test-key"
+        config.session.engine = "rounds"
         monkeypatch.setattr(cli_main, "load_config", lambda: config)
 
         prompts = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,6 +74,24 @@ class TestMCPServerConfig:
         assert config.transport.type == "sse"
 
 
+class TestSessionConfig:
+    """Test SessionConfig schema."""
+
+    def test_runtime_integration_default_values(self):
+        from vulnclaw.config.schema import SessionConfig
+
+        config = SessionConfig()
+        assert config.reasoning_state_enabled is True
+        assert config.reflexion_enabled is True
+        assert config.reflexion_max_same_vuln_fails == 2
+        assert config.reflexion_max_total_no_progress == 5
+        assert config.escalation_max_level == 4
+        assert config.plugin_runtime_enabled is True
+        assert config.plugin_default_timeout == 10
+        assert config.plugin_max_requests_per_target == 30
+        assert config.evidence_min_report_level == "L4"
+
+
 class TestVulnClawConfig:
     """Test VulnClawConfig schema."""
 
@@ -83,6 +101,8 @@ class TestVulnClawConfig:
         config = VulnClawConfig()
         assert config.llm.model == "gpt-4o"
         assert isinstance(config.mcp.servers, dict)
+        assert config.session.reasoning_state_enabled is True
+        assert config.session.reflexion_enabled is True
 
     def test_mcp_builtin_servers(self):
         from vulnclaw.config.schema import BUILTIN_MCP_SERVERS, VulnClawConfig
@@ -200,3 +220,25 @@ class TestSettingsLoad:
         # The env var may or may not be applied depending on load_config implementation
         # Just verify it doesn't crash
         assert config is not None
+
+    def test_env_var_override_new_session_fields(self, monkeypatch):
+        """二开新增的 session 配置（反思/插件）可通过环境变量注入。"""
+        from vulnclaw.config.settings import load_config
+
+        monkeypatch.setenv("VULNCLAW_SESSION_REFLEXION_ENABLED", "false")
+        monkeypatch.setenv("VULNCLAW_SESSION_REASONING_STATE_ENABLED", "false")
+        monkeypatch.setenv("VULNCLAW_SESSION_REFLEXION_MAX_SAME_VULN_FAILS", "5")
+        monkeypatch.setenv("VULNCLAW_SESSION_ESCALATION_MAX_LEVEL", "2")
+        monkeypatch.setenv("VULNCLAW_SESSION_PLUGIN_RUNTIME_ENABLED", "false")
+        monkeypatch.setenv("VULNCLAW_SESSION_PLUGIN_MAX_REQUESTS_PER_TARGET", "7")
+        monkeypatch.setenv("VULNCLAW_SESSION_EVIDENCE_MIN_REPORT_LEVEL", "L2")
+
+        config = load_config()
+
+        assert config.session.reflexion_enabled is False
+        assert config.session.reasoning_state_enabled is False
+        assert config.session.reflexion_max_same_vuln_fails == 5
+        assert config.session.escalation_max_level == 2
+        assert config.session.plugin_runtime_enabled is False
+        assert config.session.plugin_max_requests_per_target == 7
+        assert config.session.evidence_min_report_level == "L2"

--- a/tests/test_constraint_tool_action.py
+++ b/tests/test_constraint_tool_action.py
@@ -1,0 +1,54 @@
+"""Issue #45 回归：recon/scan 模式不应误拦正常的侦察/扫描工具调用。"""
+
+from __future__ import annotations
+
+from vulnclaw.agent.constraint_policy import infer_tool_action, validate_tool_action
+from vulnclaw.agent.context import TaskConstraints
+
+
+def _scope_recon_scan() -> TaskConstraints:
+    return TaskConstraints(allowed_actions=["recon", "scan"], blocked_actions=["post_exploitation"])
+
+
+def test_options_and_post_are_not_exploit():
+    # 方法本身不代表利用：OPTIONS 属侦察、POST 属扫描
+    assert infer_tool_action("fetch", {"url": "http://t/", "method": "OPTIONS"}) == "recon"
+    assert infer_tool_action("fetch", {"url": "http://t/login", "method": "POST", "body": "a=1"}) == "scan"
+
+
+def test_requests_in_python_is_scan_not_exploit():
+    code = "import requests\nrequests.get('http://t/')"
+    assert infer_tool_action("python_execute", {"code": code}) == "scan"
+
+
+def test_local_meta_tools_are_exempt_from_scope():
+    scope = _scope_recon_scan()
+    # 加载技能文档 / 编解码不触碰目标，任何范围下都不应被拦
+    assert validate_tool_action("load_skill_reference", {"skill_name": "x", "reference_name": "y"}, scope) is None
+    assert validate_tool_action("crypto_decode", {"operation": "base64_decode", "input": "eA=="}, scope) is None
+
+
+def test_recon_scan_scope_allows_normal_probing():
+    scope = _scope_recon_scan()
+    allowed_cases = [
+        ("nmap_scan", {"target": "10.0.0.5", "scan_type": "top_ports"}),
+        ("fetch", {"url": "http://t/robots.txt", "method": "GET"}),
+        ("fetch", {"url": "http://t/", "method": "OPTIONS"}),
+        ("fetch", {"url": "http://t/login", "method": "POST", "body": "u=a&p=b"}),
+        ("python_execute", {"code": "import requests\nrequests.get('http://t/')"}),
+    ]
+    for name, args in allowed_cases:
+        assert validate_tool_action(name, args, scope) is None, f"{name} should be allowed"
+
+
+def test_actual_exploit_payloads_still_blocked():
+    scope = _scope_recon_scan()
+    blocked_cases = [
+        ("fetch", {"url": "http://t/?id=1 union select 1,2,3", "method": "GET"}),
+        ("fetch", {"url": "http://t/?file=../../etc/passwd", "method": "GET"}),
+        ("python_execute", {"code": "import os; os.system('id')"}),
+        ("python_execute", {"code": "requests.get('http://t/?cmd=whoami')"}),
+    ]
+    for name, args in blocked_cases:
+        violation = validate_tool_action(name, args, scope)
+        assert violation is not None and "exploit" in violation, f"{name} should be blocked as exploit"

--- a/tests/test_loop_reflexion_integration.py
+++ b/tests/test_loop_reflexion_integration.py
@@ -1,0 +1,89 @@
+import pytest
+
+from vulnclaw.agent.context import PentestPhase
+from vulnclaw.agent.core import AgentCore
+from vulnclaw.agent.reflexion import FailureCategory
+from vulnclaw.config.schema import VulnClawConfig
+
+
+def _make_agent(tmp_path, reflexion_enabled=True):
+    config = VulnClawConfig()
+    config.session.output_dir = tmp_path
+    config.session.reflexion_enabled = reflexion_enabled
+    config.session.reflexion_max_same_vuln_fails = 2
+    config.session.reflexion_max_total_no_progress = 5
+    return AgentCore(config)
+
+
+@pytest.mark.asyncio
+async def test_consecutive_same_failures_generate_reflexion_prompt(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, reflexion_enabled=True)
+    captured_contexts = []
+
+    from vulnclaw.agent import loop_controller
+
+    async def _fake_call_llm_auto(agent_obj, system_prompt, round_context, **kwargs):
+        captured_contexts.append(round_context)
+        return "尝试 sqli payload，ConnectionError 请求失败。"
+
+    monkeypatch.setattr(loop_controller, "call_llm_auto", _fake_call_llm_auto)
+
+    await agent.auto_pentest("扫描 example.com 的 SQL注入漏洞", max_rounds=4)
+
+    assert "🔴 反思接管" in captured_contexts[3]
+    assert "停止在当前攻击路径上重复换 payload。" in captured_contexts[3]
+    assert "路径切换强制指令" not in captured_contexts[3]
+    assert agent.runtime.same_path_fail_count >= 2
+
+
+def test_reflexion_disabled_keeps_legacy_same_path_warning(tmp_path):
+    agent = _make_agent(tmp_path, reflexion_enabled=False)
+    agent.context.state.advance_phase(PentestPhase.VULN_DISCOVERY)
+    agent.runtime.same_path_fail_count = 3
+
+    context = agent._build_round_context(5, 5)
+
+    assert "路径切换强制指令" in context
+    assert "🔴 反思接管" not in context
+    assert agent.runtime.same_path_fail_count == 0
+    assert agent.runtime.path_switch_forced is True
+
+
+def test_reflexion_memory_persists_across_cycles(tmp_path):
+    """P2-7: persistent 跨周期保留失败记忆，但重置本周期 stuck 计数。"""
+    agent = _make_agent(tmp_path, reflexion_enabled=True)
+
+    # 周期 1：累积同类失败
+    rx = agent.runtime.reflexion
+    for _ in range(2):
+        rx.record_attempt(
+            path="sqli",
+            success=False,
+            category=FailureCategory.ENV_CONSTRAINT,
+            details="WAF 拦截",
+            vuln_type="sqli",
+        )
+    assert rx.state.consecutive_failures == 2
+    assert rx.state.vuln_type_fail_count == 2
+
+    # 周期 1 结束：写回快照
+    agent._save_reflexion_snapshot()
+    assert agent.context.state.reflexion_snapshot
+
+    # 周期 2 边界：重建 runtime 并恢复记忆
+    agent._reset_runtime_state(user_input="[Persistent Cycle 2] 继续渗透")
+    rx2 = agent.runtime.reflexion
+
+    # 记忆保留：失败路径可见
+    assert "sqli" in rx2.get_failed_paths()
+    # 本周期 stuck 计数重置，卡住检测重新开始
+    assert rx2.state.consecutive_failures == 0
+    assert rx2.state.vuln_type_fail_count == 0
+
+
+def test_reflexion_snapshot_skipped_when_disabled(tmp_path):
+    """reflexion_enabled=False 时不写/不恢复快照。"""
+    agent = _make_agent(tmp_path, reflexion_enabled=False)
+    agent.runtime.reflexion.record_attempt(path="sqli", success=False, vuln_type="sqli")
+    agent._save_reflexion_snapshot()
+    assert agent.context.state.reflexion_snapshot == {}

--- a/tests/test_plugin_cli.py
+++ b/tests/test_plugin_cli.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from vulnclaw.cli.main import app
+
+runner = CliRunner()
+
+
+def test_plugins_list_shows_builtin_plugins():
+    result = runner.invoke(app, ["plugins", "list"])
+    assert result.exit_code == 0
+    assert "builtin.web.headers" in result.stdout
+
+
+def test_plugins_list_unknown_stage_errors():
+    result = runner.invoke(app, ["plugins", "list", "--stage", "nope"])
+    assert result.exit_code == 1
+
+
+def test_plugins_info_known_and_unknown():
+    ok = runner.invoke(app, ["plugins", "info", "builtin.web.headers"])
+    assert ok.exit_code == 0
+    assert "builtin.web.headers" in ok.stdout
+
+    missing = runner.invoke(app, ["plugins", "info", "does.not.exist"])
+    assert missing.exit_code == 1
+
+
+def test_plugins_run_with_inline_option_and_session_merge(tmp_path):
+    session_file = tmp_path / "session.json"
+    result = runner.invoke(
+        app,
+        [
+            "plugins",
+            "run",
+            "builtin.web.headers",
+            "--target",
+            "http://t.com",
+            "--option",
+            'headers={"server": "nginx"}',
+            "--session",
+            str(session_file),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Missing common security headers" in result.stdout
+
+    data = json.loads(session_file.read_text(encoding="utf-8"))
+    titles = [f["title"] for f in data["findings"]]
+    assert "Missing common security headers" in titles
+
+
+def test_plugins_run_unknown_stage_errors():
+    result = runner.invoke(
+        app, ["plugins", "run", "builtin.web.headers", "--stage", "bogus"]
+    )
+    assert result.exit_code == 1

--- a/tests/test_plugin_integration.py
+++ b/tests/test_plugin_integration.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from vulnclaw.config.schema import SessionConfig, VulnClawConfig
+from vulnclaw.plugins import (
+    PluginContext,
+    PluginResult,
+    PluginRuntime,
+    PluginStage,
+    VulnPlugin,
+    create_builtin_runtime,
+    registry,
+)
+
+
+def test_global_registry_registers_and_finds_builtin_plugin():
+    plugin_id = "test.integration.registry"
+
+    class IntegrationPlugin(VulnPlugin):
+        plugin_id = "test.integration.registry"
+
+        def run(self, context: PluginContext) -> PluginResult:
+            return PluginResult(plugin_id=self.plugin_id, stage=context.stage)
+
+    registry.unregister(plugin_id)
+    registry.register(IntegrationPlugin)
+
+    assert registry.get("builtin.web.headers") is not None
+    assert registry.get(plugin_id) is IntegrationPlugin
+
+    registry.unregister(plugin_id)
+
+
+async def test_runtime_executes_builtin_plugin():
+    runtime = create_builtin_runtime(VulnClawConfig())
+
+    result = await runtime.execute(
+        "builtin.web.headers",
+        {
+            "target": "https://example.com",
+            "options": {"headers": {"server": "nginx"}},
+        },
+    )
+
+    assert result.ok is True
+    assert result.plugin_id == "builtin.web.headers"
+    assert result.stage == PluginStage.DISCOVERY
+    assert result.findings
+
+
+def test_config_defaults_expose_plugin_runtime_and_budget_fields():
+    config = SessionConfig()
+
+    assert config.plugin_runtime_enabled is True
+    assert config.plugin_default_timeout == 10
+    assert config.plugin_max_requests_per_target == 30
+
+
+def test_plugin_finding_converts_to_vuln_finding():
+    from vulnclaw.plugins.integration import plugin_finding_to_vuln_finding
+    from vulnclaw.plugins.result import PluginFinding, RiskLevel
+
+    pf = PluginFinding(
+        title="Missing security headers",
+        risk=RiskLevel.HIGH,
+        vuln_type="security_headers",
+        description="缺少安全响应头",
+        evidence={"missing": ["x-frame-options"]},
+        remediation="补齐响应头",
+        confidence=0.9,
+    )
+    vuln = plugin_finding_to_vuln_finding(pf, plugin_id="builtin.web.headers")
+
+    assert vuln.severity == "High"
+    assert vuln.vuln_type == "security_headers"
+    assert "builtin.web.headers" in vuln.description
+    assert "x-frame-options" in vuln.evidence
+    assert vuln.evidence_level == "L2"
+
+
+def test_merge_plugin_results_dedups_into_session():
+    from vulnclaw.agent.context import SessionState
+    from vulnclaw.plugins.integration import merge_plugin_results_into_session
+    from vulnclaw.plugins.result import PluginFinding, PluginResult, RiskLevel
+
+    finding = PluginFinding(title="Weak CSP", risk=RiskLevel.LOW, vuln_type="security_headers")
+    result = PluginResult(plugin_id="builtin.web.headers", findings=[finding])
+
+    session = SessionState(target="t.com")
+    added_first = merge_plugin_results_into_session(session, result)
+    added_again = merge_plugin_results_into_session(session, result)
+
+    assert added_first == 1
+    assert added_again == 0  # 去重：相同 finding 不重复计入
+    assert len(session.findings) == 1
+
+
+async def test_disabled_runtime_does_not_execute_plugin():
+    calls = 0
+
+    class DisabledPlugin(VulnPlugin):
+        plugin_id = "test.integration.disabled"
+
+        def run(self, context: PluginContext) -> PluginResult:
+            nonlocal calls
+            calls += 1
+            return PluginResult(plugin_id=self.plugin_id, stage=context.stage)
+
+    config = VulnClawConfig()
+    config.session.plugin_runtime_enabled = False
+    plugin_registry = type(registry)()
+    plugin_registry.register(DisabledPlugin)
+    runtime = PluginRuntime(plugin_registry, config=config)
+
+    result = await runtime.execute("test.integration.disabled", {"target": "https://example.com"})
+
+    assert result.ok is False
+    assert result.skipped is True
+    assert result.error_type == "disabled"
+    assert calls == 0

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,130 @@
+import pytest
+from pydantic import ValidationError
+
+from vulnclaw.plugins import (
+    PluginContext,
+    PluginFinding,
+    PluginRegistry,
+    PluginResult,
+    PluginStage,
+    RiskLevel,
+    VulnPlugin,
+    registry,
+)
+
+
+class DemoPlugin(VulnPlugin):
+    plugin_id = "demo"
+    name = "Demo"
+    version = "1.0.0"
+    description = "Demo plugin"
+    stages = (PluginStage.RECON, PluginStage.DISCOVERY)
+    default_risk = RiskLevel.LOW
+
+    def run(self, context: PluginContext) -> PluginResult:
+        return PluginResult(
+            plugin_id=self.plugin_id,
+            stage=context.stage,
+            findings=[
+                PluginFinding(
+                    title="Demo finding",
+                    risk=self.default_risk,
+                    target=context.target,
+                    evidence={"url": context.target},
+                    confidence=0.8,
+                )
+            ],
+        )
+
+
+class OtherPlugin(VulnPlugin):
+    plugin_id = "other"
+    stages = (PluginStage.REPORTING,)
+
+    def run(self, context: PluginContext) -> PluginResult:
+        return PluginResult(plugin_id=self.plugin_id, stage=context.stage)
+
+
+def test_plugin_models_are_json_serializable():
+    context = PluginContext(target="https://example.com", stage=PluginStage.RECON)
+    result = DemoPlugin().run(context)
+
+    dumped = result.model_dump(mode="json")
+
+    assert dumped["plugin_id"] == "demo"
+    assert dumped["stage"] == "recon"
+    assert dumped["findings"][0]["risk"] == "low"
+    assert dumped["findings"][0]["evidence"] == {"url": "https://example.com"}
+
+
+def test_finding_validates_confidence_range():
+    with pytest.raises(ValidationError):
+        PluginFinding(title="bad confidence", confidence=1.1)
+
+
+def test_base_plugin_requires_run_implementation():
+    class MissingRun(VulnPlugin):
+        plugin_id = "missing"
+
+    with pytest.raises(TypeError):
+        MissingRun()
+
+
+def test_registry_register_get_and_metadata():
+    plugin_registry = PluginRegistry()
+
+    returned = plugin_registry.register(DemoPlugin)
+
+    assert returned is DemoPlugin
+    assert plugin_registry.count == 1
+    assert plugin_registry.get("demo") is DemoPlugin
+    assert plugin_registry.metadata() == [DemoPlugin.metadata()]
+
+
+def test_registry_rejects_duplicate_plugin_ids():
+    plugin_registry = PluginRegistry()
+    plugin_registry.register(DemoPlugin)
+
+    with pytest.raises(ValueError, match="Plugin already registered: demo"):
+        plugin_registry.register(DemoPlugin)
+
+
+def test_registry_rejects_missing_plugin_id():
+    class MissingIdPlugin(VulnPlugin):
+        plugin_id = ""
+
+        def run(self, context: PluginContext) -> PluginResult:
+            return PluginResult(plugin_id="missing", stage=context.stage)
+
+    plugin_registry = PluginRegistry()
+
+    with pytest.raises(ValueError, match="Plugin class must define plugin_id"):
+        plugin_registry.register(MissingIdPlugin)
+
+
+def test_registry_filters_plugins_by_stage():
+    plugin_registry = PluginRegistry()
+    plugin_registry.register(DemoPlugin)
+    plugin_registry.register(OtherPlugin)
+
+    assert plugin_registry.by_stage(PluginStage.RECON) == [DemoPlugin]
+    assert plugin_registry.by_stage("reporting") == [OtherPlugin]
+
+
+def test_registry_unregister_and_clear_are_idempotent():
+    plugin_registry = PluginRegistry()
+    plugin_registry.register(DemoPlugin)
+
+    plugin_registry.unregister("demo")
+    plugin_registry.unregister("demo")
+
+    assert plugin_registry.count == 0
+
+    plugin_registry.register(DemoPlugin)
+    plugin_registry.clear()
+
+    assert plugin_registry.list() == []
+
+
+def test_global_registry_is_plugin_registry():
+    assert isinstance(registry, PluginRegistry)

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from vulnclaw.agent.context import TaskConstraints
+from vulnclaw.plugins import (
+    PluginContext,
+    PluginRegistry,
+    PluginResult,
+    PluginRuntime,
+    VulnPlugin,
+)
+
+
+def runtime_config(
+    *,
+    enabled: bool = True,
+    timeout: float = 1,
+    max_requests: int = 30,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        session=SimpleNamespace(
+            plugin_runtime_enabled=enabled,
+            plugin_default_timeout=timeout,
+            plugin_max_requests_per_target=max_requests,
+        )
+    )
+
+
+class EchoPlugin(VulnPlugin):
+    plugin_id = "echo"
+    requires_target = True
+
+    def run(self, context: PluginContext) -> PluginResult:
+        return PluginResult(
+            plugin_id=self.plugin_id,
+            stage=context.stage,
+            metadata={"target": context.target, "options": context.options},
+        )
+
+
+class DisabledPlugin(EchoPlugin):
+    plugin_id = "disabled"
+    enabled = False
+
+
+class DangerousPlugin(EchoPlugin):
+    plugin_id = "danger"
+    destructive = True
+
+
+class SlowPlugin(VulnPlugin):
+    plugin_id = "slow"
+
+    async def run(self, context: PluginContext) -> PluginResult:
+        await asyncio.sleep(0.05)
+        return PluginResult(plugin_id=self.plugin_id, stage=context.stage)
+
+
+class BrokenPlugin(VulnPlugin):
+    plugin_id = "broken"
+
+    def run(self, context: PluginContext) -> PluginResult:
+        raise RuntimeError("boom")
+
+
+def _runtime(*plugin_classes: type[VulnPlugin], config=None, allowed_targets=None) -> PluginRuntime:
+    plugin_registry = PluginRegistry()
+    for plugin_cls in plugin_classes:
+        plugin_registry.register(plugin_cls)
+    return PluginRuntime(
+        plugin_registry,
+        config=config or runtime_config(),
+        allowed_targets=allowed_targets,
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_executes_plugin_by_id() -> None:
+    runtime = _runtime(EchoPlugin)
+
+    result = await runtime.execute(
+        "echo",
+        PluginContext(
+            target="example.com",
+            options={"path": "/health"},
+            scope_targets={"example.com"},
+        ),
+    )
+
+    assert result.ok is True
+    assert result.plugin_id == "echo"
+    assert result.metadata == {"target": "example.com", "options": {"path": "/health"}}
+    assert result.remaining_requests == 29
+
+
+@pytest.mark.asyncio
+async def test_runtime_blocks_when_runtime_disabled() -> None:
+    runtime = _runtime(EchoPlugin, config=runtime_config(enabled=False))
+
+    result = await runtime.execute("echo", {"target": "example.com"})
+
+    assert result.ok is False
+    assert result.skipped is True
+    assert result.error_type == "disabled"
+    assert result.error == "Plugin runtime is disabled"
+
+
+@pytest.mark.asyncio
+async def test_runtime_blocks_disabled_plugin() -> None:
+    runtime = _runtime(DisabledPlugin)
+
+    result = await runtime.execute("disabled")
+
+    assert result.ok is False
+    assert result.error_type == "disabled"
+    assert result.error == "Plugin is disabled"
+
+
+@pytest.mark.asyncio
+async def test_runtime_blocks_destructive_plugin_without_permission() -> None:
+    runtime = _runtime(DangerousPlugin)
+
+    blocked = await runtime.execute("danger", {"target": "example.com"})
+    allowed = await runtime.execute(
+        "danger",
+        PluginContext(target="example.com", allow_destructive=True),
+    )
+
+    assert blocked.ok is False
+    assert blocked.error_type == "blocked"
+    assert allowed.ok is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_enforces_target_constraints() -> None:
+    runtime = _runtime(EchoPlugin, allowed_targets={"example.com"})
+
+    missing = await runtime.execute("echo")
+    outside_runtime = await runtime.execute("echo", {"target": "other.com"})
+    outside_request = await runtime.execute(
+        "echo",
+        PluginContext(target="example.com", scope_targets={"api.example.com"}),
+    )
+
+    assert missing.error_type == "target_blocked"
+    assert missing.error == "Plugin requires a target"
+    assert outside_runtime.error_type == "target_blocked"
+    assert outside_runtime.error == "Target is outside runtime scope"
+    assert outside_request.error_type == "target_blocked"
+    assert outside_request.error == "Target is outside request scope"
+
+
+@pytest.mark.asyncio
+async def test_runtime_enforces_task_constraints() -> None:
+    runtime = _runtime(EchoPlugin)
+
+    result = await runtime.execute(
+        "echo",
+        PluginContext(
+            target="https://example.com:8443/admin",
+            task_constraints=TaskConstraints(
+                allowed_hosts=["example.com"],
+                allowed_ports=[443],
+                allowed_actions=["scan"],
+                strict_mode=True,
+            ),
+        ),
+    )
+
+    assert result.ok is False
+    assert result.error_type == "constraint_violation"
+    assert "port '8443'" in result.error
+
+
+@pytest.mark.asyncio
+async def test_runtime_enforces_request_budget_per_target() -> None:
+    runtime = _runtime(EchoPlugin, config=runtime_config(max_requests=1))
+    context = PluginContext(target="example.com")
+
+    first = await runtime.execute("echo", context)
+    second = await runtime.execute("echo", context)
+
+    assert first.ok is True
+    assert first.remaining_requests == 0
+    assert second.ok is False
+    assert second.error_type == "budget_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_runtime_converts_timeout_to_result() -> None:
+    runtime = _runtime(SlowPlugin, config=runtime_config(timeout=0.01))
+
+    result = await runtime.execute("slow")
+
+    assert result.ok is False
+    assert result.error_type == "timeout"
+    assert result.error == "Plugin execution timed out"
+
+
+@pytest.mark.asyncio
+async def test_runtime_converts_exception_to_result() -> None:
+    runtime = _runtime(BrokenPlugin)
+
+    result = await runtime.execute("broken")
+
+    assert result.ok is False
+    assert result.error_type == "error"
+    assert result.error == "RuntimeError: boom"

--- a/tests/test_reasoning_prompt_context.py
+++ b/tests/test_reasoning_prompt_context.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from vulnclaw.agent.context import SessionState
+from vulnclaw.agent.prompt_context import build_round_context
+from vulnclaw.agent.reasoning_state import PathStep
+from vulnclaw.agent.reflexion import FailureCategory, ReflexionEngine
+
+
+def _fake_agent(tmp_path: Path, state: SessionState, reflexion=None):
+    runtime = SimpleNamespace(
+        user_vuln_hint="",
+        user_vuln_hint_rounds=0,
+        same_path_fail_count=0,
+        python_timeout_rounds=0,
+        rounds_without_progress=0,
+        blocked_targets=set(),
+        claimed_flag=None,
+        flag_verified=False,
+        is_ctf_mode=False,
+        is_recon_phase=False,
+        reflexion=reflexion,
+    )
+    session = SimpleNamespace(
+        output_dir=tmp_path,
+        stale_rounds_threshold=5,
+        reasoning_state_enabled=True,
+        reflexion_enabled=True,
+    )
+    return SimpleNamespace(
+        context=SimpleNamespace(state=state),
+        runtime=runtime,
+        config=SimpleNamespace(session=session),
+    )
+
+
+def test_session_state_persists_reasoning(tmp_path):
+    state = SessionState(target="example.com")
+    state.reasoning.add_fact("framework", "thinkphp", source="fingerprint", confidence=0.8)
+    state.reasoning.add_constraint("union keyword blocked", category="waf", severity="blocking")
+    state.reasoning.add_path(
+        "login sql injection",
+        [PathStep(action="test username with quote", target="/login", vuln_type="sqli")],
+        priority=5,
+    )
+
+    save_path = tmp_path / "session.json"
+    state.save(save_path)
+
+    loaded = SessionState.load(save_path)
+
+    assert loaded.reasoning.facts[0].key == "framework"
+    assert loaded.reasoning.facts[0].value == "thinkphp"
+    assert loaded.reasoning.constraints[0].description == "union keyword blocked"
+    assert loaded.reasoning.paths[0].name == "login sql injection"
+    assert loaded.reasoning.paths[0].steps[0].action == "test username with quote"
+
+
+def test_build_round_context_injects_reasoning_and_reflexion(tmp_path):
+    state = SessionState(target="example.com")
+    state.reasoning.add_fact("candidate", "admin search looks injectable", confidence=0.7)
+    state.reasoning.add_path(
+        "admin search sqli",
+        [PathStep(action="verify with a boolean probe", target="/admin/search", vuln_type="sqli")],
+        priority=5,
+    )
+    state.reasoning.set_active_path("admin search sqli")
+
+    reflexion = ReflexionEngine()
+    reflexion.record_attempt(
+        path="/admin/search?q='",
+        success=False,
+        category=FailureCategory.PARAM_ERROR,
+        details="syntax did not change the response",
+        vuln_type="sqli",
+    )
+
+    context = build_round_context(_fake_agent(tmp_path, state, reflexion), 2, 5)
+
+    assert "🧭 当前推理状态" in context
+    assert "admin search looks injectable" in context
+    assert "admin search sqli" in context
+    assert "🔁 反思状态：" in context
+    assert "/admin/search?q='" in context
+    assert "当前升级级别" in context

--- a/tests/test_reasoning_state.py
+++ b/tests/test_reasoning_state.py
@@ -1,0 +1,128 @@
+from vulnclaw.agent.reasoning_state import (
+    ConstraintCategory,
+    ConstraintSeverity,
+    PathStatus,
+    PathStep,
+    ReasoningState,
+    StepStatus,
+)
+
+
+def test_add_fact_same_value_increases_confidence_and_merges_sources():
+    state = ReasoningState()
+
+    fact = state.add_fact("framework", "thinkphp", source="fingerprint", confidence=0.5)
+    updated = state.add_fact("framework", "thinkphp", source="error_page", confidence=0.5)
+
+    assert fact is updated
+    assert len(state.facts) == 1
+    assert updated.confidence > 0.5
+    assert updated.source == "fingerprint, error_page"
+
+
+def test_add_fact_conflict_lowers_old_value_and_adds_new_fact():
+    state = ReasoningState()
+
+    old = state.add_fact("db", "mysql", source="banner", confidence=0.8)
+    new = state.add_fact("db", "postgresql", source="error", confidence=0.6)
+
+    assert len(state.facts) == 2
+    assert old.confidence < 0.8
+    assert new.value == "postgresql"
+    assert new.confidence == 0.6
+
+
+def test_constraints_and_blocking_filter():
+    state = ReasoningState()
+
+    state.add_constraint(
+        "union keyword blocked",
+        category=ConstraintCategory.WAF,
+        severity=ConstraintSeverity.BLOCKING,
+    )
+    state.add_constraint(
+        "login required",
+        category="auth",
+        severity="high",
+    )
+
+    blocking = state.get_blocking_constraints()
+
+    assert len(blocking) == 1
+    assert blocking[0].description == "union keyword blocked"
+    assert blocking[0].category == ConstraintCategory.WAF
+
+
+def test_add_set_update_and_abandon_path():
+    state = ReasoningState()
+    state.add_path(
+        "sql injection",
+        [
+            PathStep(action="find parameter", target="/search"),
+            PathStep(action="test boolean payload", vuln_type="sqli"),
+        ],
+        priority=5,
+    )
+    state.add_path("ssti", [PathStep(action="test template marker")], priority=3)
+
+    active = state.set_active_path("sql injection")
+    step = state.update_step("sql injection", 0, StepStatus.SUCCESS, "q parameter found")
+    failed_path = state.update_path("ssti", status=PathStatus.FAILED, result="no reflection")
+    abandoned = state.abandon_path("sql injection", reason="waf blocks all payloads")
+
+    assert active.status == PathStatus.ABANDONED
+    assert step.status == StepStatus.SUCCESS
+    assert step.result == "q parameter found"
+    assert failed_path.status == PathStatus.FAILED
+    assert abandoned.result == "waf blocks all payloads"
+    assert state.active_path_index == -1
+
+
+def test_auto_prioritize_sorts_paths_and_preserves_active_path():
+    state = ReasoningState()
+    state.add_path("low success", [PathStep(action="a")], priority=10)
+    state.add_path("high success", [PathStep(action="b")], priority=10)
+    state.set_active_path("low success")
+
+    state.auto_prioritize({"high success": 0.9, "low success": 0.1})
+
+    assert [path.name for path in state.paths] == ["high success", "low success"]
+    assert state.paths[state.active_path_index].name == "low success"
+    assert state.paths[0].priority > state.paths[1].priority
+
+
+def test_to_prompt_block_empty_state_returns_empty_string():
+    assert ReasoningState().to_prompt_block() == ""
+
+
+def test_prompt_block_and_summary_include_state():
+    state = ReasoningState()
+    state.add_fact("server", "nginx", confidence=0.9)
+    state.add_constraint("403 on admin", category="auth", severity="blocking")
+    state.add_path("auth bypass", [PathStep(action="compare users")], priority=4)
+    state.set_active_path("auth bypass")
+
+    prompt = state.to_prompt_block()
+    summary = state.get_summary()
+
+    assert "🧭 当前推理状态" in prompt
+    assert "server=nginx" in prompt
+    assert "[auth/blocking] 403 on admin" in prompt
+    assert "[active] auth bypass" in prompt
+    assert summary["facts"] == 1
+    assert summary["blocking_constraints"] == 1
+    assert summary["active_path"] == "auth bypass"
+
+
+def test_model_dump_and_validate_roundtrip():
+    state = ReasoningState()
+    state.add_fact("port", "443", source="nmap", confidence=0.7)
+    state.add_constraint("rate limited", category="rate_limit", severity="medium")
+    state.add_path("tls checks", [PathStep(action="inspect certificate")], priority=2)
+
+    loaded = ReasoningState.model_validate(state.model_dump(mode="json"))
+
+    assert loaded == state
+    assert loaded.facts[0].key == "port"
+    assert loaded.constraints[0].category == ConstraintCategory.RATE_LIMIT
+    assert loaded.paths[0].steps[0].action == "inspect certificate"

--- a/tests/test_reflexion.py
+++ b/tests/test_reflexion.py
@@ -1,0 +1,155 @@
+from vulnclaw.agent.reflexion import (
+    FailureCategory,
+    ReflexionEngine,
+    classify_failure,
+)
+
+
+def test_classify_failure_categories():
+    assert classify_failure("403 forbidden by WAF") == FailureCategory.ENV_CONSTRAINT
+    assert classify_failure("target is not vulnerable, no injection found") == FailureCategory.PATH_ERROR
+    assert classify_failure("syntax error from invalid payload") == FailureCategory.PARAM_ERROR
+    assert classify_failure("need more recon, unknown parameter") == FailureCategory.INFO_NEEDED
+    assert classify_failure("unexpected result") == FailureCategory.UNKNOWN
+    assert classify_failure("") is None
+
+
+def test_record_attempt_tracks_failures_and_success_resets_counters():
+    engine = ReflexionEngine()
+
+    engine.record_attempt(
+        path="sqli_union",
+        success=False,
+        category=FailureCategory.ENV_CONSTRAINT,
+        details="WAF blocked UNION",
+        vuln_type="sqli",
+    )
+    engine.record_attempt(
+        path="sqli_boolean",
+        success=False,
+        category=FailureCategory.PARAM_ERROR,
+        details="bad delimiter",
+        vuln_type="sqli",
+    )
+
+    assert engine.state.consecutive_failures == 2
+    assert engine.state.vuln_type_fail_count == 2
+    assert engine.should_reflect() is True
+    assert engine.get_failed_paths() == ["sqli_union", "sqli_boolean"]
+    assert "WAF blocked UNION" in engine.state.constraints
+
+    engine.record_attempt(path="sqli_time", success=True, vuln_type="sqli")
+
+    assert engine.state.consecutive_failures == 0
+    assert engine.state.vuln_type_fail_count == 0
+
+
+def test_should_reflect_on_total_no_progress():
+    engine = ReflexionEngine(max_same_vuln_fails=10, max_total_no_progress=3)
+
+    for index in range(3):
+        engine.record_attempt(path=f"path_{index}", success=False, vuln_type=f"type_{index}")
+
+    assert engine.should_reflect() is True
+
+
+def test_reflections_drive_escalation_and_reset_failure_counters():
+    engine = ReflexionEngine(max_reflections_before_escalate=2)
+    engine.record_attempt(path="xss", success=False, vuln_type="xss")
+    engine.record_attempt(path="xss", success=False, vuln_type="xss")
+
+    assert engine.get_escalation_level() == 1
+
+    engine.record_reflection("xss", "ssti", "filters blocked script payloads")
+
+    assert engine.state.consecutive_failures == 0
+    assert engine.state.vuln_type_fail_count == 0
+    assert engine.get_escalation_level() == 1
+    assert engine.should_escalate() is False
+
+    engine.record_reflection("ssti", "file_inclusion", "template path looked unlikely")
+
+    assert engine.should_escalate() is True
+
+
+def test_escalation_hints_are_level_specific_and_capped():
+    engine = ReflexionEngine()
+
+    assert engine.get_escalation_hints() == ["先尝试原始 payload（不编码）。"]
+
+    for index in range(10):
+        engine.record_attempt(path=f"path_{index}", success=False, vuln_type="sqli")
+
+    assert engine.get_escalation_level() == 4
+    hints = engine.get_escalation_hints()
+    assert "组合多层编码混淆。" in hints
+    assert "切换到完全不同的漏洞类型/攻击面。" in hints
+
+
+def test_analyze_failure_patterns_groups_by_category():
+    engine = ReflexionEngine()
+    engine.record_attempt(
+        path="union",
+        success=False,
+        category=FailureCategory.ENV_CONSTRAINT,
+        details="WAF blocked UNION",
+    )
+    engine.record_attempt(
+        path="boolean",
+        success=False,
+        category=FailureCategory.ENV_CONSTRAINT,
+        details="WAF blocked boolean probe",
+    )
+    engine.record_attempt(
+        path="ssti",
+        success=False,
+        category=FailureCategory.PATH_ERROR,
+        details="not vulnerable",
+    )
+
+    patterns = engine.analyze_failure_patterns()
+
+    assert patterns[0]["category"] == FailureCategory.ENV_CONSTRAINT.value
+    assert patterns[0]["occurrences"] == 2
+    assert patterns[0]["affected_paths"] == ["boolean", "union"]
+    assert patterns[1]["category"] == FailureCategory.PATH_ERROR.value
+
+
+def test_prompt_block_is_empty_until_state_exists():
+    engine = ReflexionEngine()
+
+    assert engine.to_prompt_block() == ""
+
+    engine.record_attempt(
+        path="sqli_union",
+        success=False,
+        category=FailureCategory.ENV_CONSTRAINT,
+        details="WAF blocked UNION",
+        vuln_type="sqli",
+    )
+
+    block = engine.to_prompt_block()
+
+    # 轻量状态块：仅计数 + 失败路径；详细的失败模式/升级提示已移至 to_reflection_prompt
+    assert "🔁 反思状态：" in block
+    assert "当前升级级别: L0" in block
+    assert "sqli_union" in block
+    assert "失败模式" not in block
+    assert "绕过提示" not in block
+
+
+def test_extract_experience_returns_none_or_dict():
+    engine = ReflexionEngine()
+
+    assert engine.extract_experience() is None
+
+    engine.record_attempt(path="union", success=False, category=FailureCategory.PARAM_ERROR)
+    engine.record_attempt(path="time_based", success=True, vuln_type="sqli")
+
+    experience = engine.extract_experience()
+
+    assert experience is not None
+    assert experience["total_attempts"] == 2
+    assert experience["successful_paths"] == ["time_based"]
+    assert experience["failed_paths"] == ["union"]
+    assert experience["last_vuln_type"] == "sqli"

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -1,0 +1,7 @@
+from vulnclaw.agent.runtime_state import RuntimeState
+
+
+def test_runtime_state_has_reflexion_field():
+    runtime = RuntimeState()
+
+    assert hasattr(runtime, "reflexion")

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from vulnclaw.agent import solver
+from vulnclaw.agent.blackboard import Blackboard, IntentStatus
+
+
+def _fake_agent(tool_outputs: list[str] | None = None):
+    state = SimpleNamespace(board=Blackboard(), save=lambda: None)
+    context = SimpleNamespace(state=state, add_user_message=lambda *a: None)
+    queue = list(tool_outputs or [])
+
+    async def _execute(tool_name, tool_args):
+        return queue.pop(0) if queue else "Status: 200"
+
+    return SimpleNamespace(context=context, _execute_mcp_tool=_execute)
+
+
+def test_flag_evidence_helpers():
+    assert solver._extract_flags("got flag{abc} and ctfshow{xyz}") == ["flag{abc}", "ctfshow{xyz}"]
+    # 声称的 flag 不在证据中 → 判定未验证
+    assert solver._unverified_flags("flag{fake}", "server said: error") == ["flag{fake}"]
+    # 在证据中 → 视为已验证
+    assert solver._unverified_flags("flag{real}", "body: flag{real}") == []
+    # flag 目标但证据无 flag → 完成不成立
+    ok, _ = solver._completion_is_grounded("找到 flag", "only status 200")
+    assert ok is False
+    ok2, _ = solver._completion_is_grounded("找到 flag", "leaked flag{x}")
+    assert ok2 is True
+    # 非 flag 目标 → 不强制
+    ok3, _ = solver._completion_is_grounded("枚举子域名", "")
+    assert ok3 is True
+
+
+def test_extract_json_handles_fences_and_noise():
+    assert solver._extract_json('```json\n{"complete": "ok"}\n```') == {"complete": "ok"}
+    assert solver._extract_json('prefix {"intents": []} suffix') == {"intents": []}
+    assert solver._extract_json("not json at all") is None
+
+
+async def test_solve_completes_when_reason_signals_goal(monkeypatch):
+    calls = {"reason": 0}
+
+    async def fake_reason(agent, board, max_intents):
+        calls["reason"] += 1
+        if calls["reason"] == 1:
+            return {"intents": [{"from": [], "description": "test sqli bypass"}]}
+        return {"complete": "flag{captured} 已验证"}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        # 模拟真实工具输出里出现了 flag（证据闸门据此放行）
+        evidence_buffer.append("HTTP 200\n<html>... flag{captured} ...</html>")
+        return True, "sqli 确认，提取到 flag{captured}"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(),
+        origin="http://t",
+        goal="flag",
+        max_steps=10,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert result.completed is True
+    assert "flag{captured}" in result.reason
+    # origin fact + 1 concluded fact
+    assert result.facts == 2
+    assert "conclude" in events
+
+
+async def test_solve_completes_immediately_on_verified_flag(monkeypatch):
+    """探索一拿到有真实证据的 flag 就立即完成，不再多跑验证轮。"""
+    reason_calls = {"n": 0}
+
+    async def fake_reason(agent, board, max_intents):
+        reason_calls["n"] += 1
+        return {"intents": [{"from": [], "description": "union inject"}]}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        evidence_buffer.append("欢迎你，flag{real_one}")  # 真实工具输出含 flag
+        return True, "union 注入回显 flag{real_one}"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    result = await solver.solve(_fake_agent(), origin="t", goal="找到 flag", max_steps=10)
+
+    assert result.completed is True
+    assert "flag{real_one}" in result.board.complete_reason
+    # 拿到 flag 立即收敛：reason 只被调用一次，不再进入下一轮验证
+    assert reason_calls["n"] == 1
+
+
+async def test_solve_rejects_hallucinated_flag(monkeypatch):
+    """结论声称的 flag 不在真实工具输出里 → 判定幻觉、拒绝、不完成。"""
+    reason_calls = {"n": 0}
+
+    async def fake_reason(agent, board, max_intents):
+        reason_calls["n"] += 1
+        if reason_calls["n"] == 1:
+            return {"intents": [{"from": [], "description": "test sqli"}]}
+        return {}  # 之后不再提出 → 前沿耗尽
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        # 不往 evidence_buffer 写 flag —— 模拟模型凭空编造
+        return True, "成功拿到 flag{HALLUCINATED}"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(),
+        origin="t",
+        goal="找到 flag",
+        max_steps=10,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert result.completed is False
+    assert "hallucination" in events
+    # 被拒绝的旗标产生一条 [未验证] 事实
+    assert any("[未验证]" in f.description for f in result.board.facts)
+
+
+async def test_solve_rejects_ungrounded_completion(monkeypatch):
+    """目标要 flag，但真实工具输出里从未出现 flag → 拒绝 Reason 的完成声明。"""
+    reason_calls = {"n": 0}
+
+    async def fake_reason(agent, board, max_intents):
+        reason_calls["n"] += 1
+        if reason_calls["n"] == 1:
+            return {"complete": "我觉得已经拿到 flag 了"}  # 无任何证据支撑
+        return {}  # 之后不再提出 → 前沿耗尽
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        return True, "x"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(),
+        origin="t",
+        goal="找到 flag",
+        max_steps=10,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert result.completed is False
+    assert "complete_rejected" in events
+
+
+async def test_solve_stops_when_frontier_exhausted(monkeypatch):
+    async def fake_reason_noop(agent, board, max_intents):
+        return {}  # never proposes intents
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        return True, "unused"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason_noop)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    result = await solver.solve(_fake_agent(), origin="t", goal="g", max_steps=10)
+
+    assert result.completed is False
+    assert result.reason == "探索前沿耗尽"
+    # only the seeded origin fact
+    assert result.facts == 1
+
+
+async def test_solve_abandons_unproductive_intent(monkeypatch):
+    state = {"reason": 0}
+
+    async def fake_reason(agent, board, max_intents):
+        state["reason"] += 1
+        if state["reason"] == 1:
+            return {"intents": [{"from": [], "description": "dead path"}]}
+        return {}  # afterward propose nothing -> frontier exhausts
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        return False, "该方向走不通"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    result = await solver.solve(_fake_agent(), origin="t", goal="g", max_steps=10)
+
+    assert result.completed is False
+    board = result.board
+    assert board.intents[0].status == IntentStatus.ABANDONED
+    assert board.intents[0].note == "该方向走不通"
+
+
+async def test_solve_respects_safety_step_budget(monkeypatch):
+    async def fake_reason(agent, board, max_intents):
+        # always propose a fresh intent -> would loop forever without the cap
+        return {"intents": [{"from": [], "description": "endless"}]}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        return True, "step fact"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    result = await solver.solve(_fake_agent(), origin="t", goal="g", max_steps=3)
+
+    assert result.completed is False
+    assert result.reason == "触达安全预算上限"
+    assert result.steps == 3

--- a/version-manifest.txt
+++ b/version-manifest.txt
@@ -1,4 +1,4 @@
-VERSION=0.3.1
+VERSION=0.4.0
 
 # VulnClaw versioned file manifest
 # Keep these files in sync when bumping a release version.

--- a/vulnclaw/__init__.py
+++ b/vulnclaw/__init__.py
@@ -15,6 +15,6 @@ except Exception:
     try:
         __version__ = version("vulnclaw")
     except PackageNotFoundError:
-        __version__ = "0.3.1"
+        __version__ = "0.4.0"
 
 __author__ = "VulnClaw Team"

--- a/vulnclaw/agent/blackboard.py
+++ b/vulnclaw/agent/blackboard.py
@@ -1,0 +1,152 @@
+"""黑板图模型 — Fact / Intent 双原语驱动的状态空间搜索。
+
+渗透测试视为从 origin 向 goal 的有向状态空间搜索：
+- Fact:   已确认的客观事实（探索的落脚点）
+- Intent: 声明的探索方向（尚未执行的一步）；从一个或多个 Fact 出发，结论后产出一个新 Fact
+- 终止条件由「目标达成 / 探索前沿耗尽 / 安全预算」决定，而非固定轮数
+
+该模型是纯数据结构，挂载到 SessionState 持久化，由 solver.py 的 OODA 循环驱动。
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class IntentStatus(str, Enum):
+    OPEN = "open"  # 已声明，待探索
+    EXPLORING = "exploring"  # 正在探索
+    CONCLUDED = "concluded"  # 已结论，产出了 Fact
+    ABANDONED = "abandoned"  # 探索后未推进目标，放弃
+
+
+class BoardFact(BaseModel):
+    id: str
+    description: str
+    source: str = ""  # 来源（bootstrap / explore:i003 / hint ...）
+
+
+class BoardIntent(BaseModel):
+    id: str
+    from_facts: list[str] = Field(default_factory=list)  # 出发的 Fact id
+    description: str
+    status: IntentStatus = IntentStatus.OPEN
+    result_fact: str | None = None  # 结论后产出的 Fact id
+    note: str = ""  # 放弃原因 / 备注
+
+
+class Blackboard(BaseModel):
+    """Fact/Intent 图。从 origin 增长到 goal。"""
+
+    origin: str = ""
+    goal: str = ""
+    facts: list[BoardFact] = Field(default_factory=list)
+    intents: list[BoardIntent] = Field(default_factory=list)
+    completed: bool = False
+    complete_reason: str = ""
+    _fact_seq: int = 0
+    _intent_seq: int = 0
+
+    # ── Fact ────────────────────────────────────────────────────────
+    def add_fact(self, description: str, source: str = "") -> BoardFact:
+        self._fact_seq += 1
+        fact = BoardFact(id=f"f{self._fact_seq:03d}", description=description.strip(), source=source)
+        self.facts.append(fact)
+        return fact
+
+    def get_fact(self, fact_id: str) -> BoardFact | None:
+        return next((f for f in self.facts if f.id == fact_id), None)
+
+    def fact_ids(self) -> list[str]:
+        return [f.id for f in self.facts]
+
+    # ── Intent ──────────────────────────────────────────────────────
+    def add_intent(self, description: str, from_facts: list[str] | None = None) -> BoardIntent:
+        self._intent_seq += 1
+        valid_from = [fid for fid in (from_facts or []) if self.get_fact(fid)]
+        intent = BoardIntent(
+            id=f"i{self._intent_seq:03d}",
+            from_facts=valid_from,
+            description=description.strip(),
+        )
+        self.intents.append(intent)
+        return intent
+
+    def get_intent(self, intent_id: str) -> BoardIntent | None:
+        return next((i for i in self.intents if i.id == intent_id), None)
+
+    def open_intents(self) -> list[BoardIntent]:
+        return [i for i in self.intents if i.status == IntentStatus.OPEN]
+
+    def active_intents(self) -> list[BoardIntent]:
+        """未结论的 Intent（open + exploring），用于判断探索前沿是否耗尽。"""
+        return [i for i in self.intents if i.status in (IntentStatus.OPEN, IntentStatus.EXPLORING)]
+
+    def claim_intent(self, intent_id: str) -> BoardIntent | None:
+        intent = self.get_intent(intent_id)
+        if intent and intent.status == IntentStatus.OPEN:
+            intent.status = IntentStatus.EXPLORING
+        return intent
+
+    def conclude_intent(self, intent_id: str, fact_description: str, source: str = "") -> BoardFact | None:
+        """探索得到了有价值的结论 → 产出一个 Fact 并链接。"""
+        intent = self.get_intent(intent_id)
+        if intent is None:
+            return None
+        fact = self.add_fact(fact_description, source=source or f"explore:{intent_id}")
+        intent.status = IntentStatus.CONCLUDED
+        intent.result_fact = fact.id
+        return fact
+
+    def abandon_intent(self, intent_id: str, note: str = "") -> BoardIntent | None:
+        intent = self.get_intent(intent_id)
+        if intent is not None:
+            intent.status = IntentStatus.ABANDONED
+            if note:
+                intent.note = note
+        return intent
+
+    def mark_complete(self, reason: str) -> None:
+        self.completed = True
+        self.complete_reason = reason.strip()
+
+    # ── 渲染 ────────────────────────────────────────────────────────
+    def to_prompt_graph(self, *, include_concluded: bool = True) -> str:
+        """把图渲染成给 LLM 阅读的紧凑文本（YAML 风格）。"""
+        lines: list[str] = [f"goal: {self.goal or '(未设定)'}", f"origin: {self.origin or '(未设定)'}"]
+
+        lines.append("facts:")
+        if self.facts:
+            for fact in self.facts:
+                src = f"  ({fact.source})" if fact.source else ""
+                lines.append(f"  - {fact.id}: {fact.description}{src}")
+        else:
+            lines.append("  (暂无)")
+
+        lines.append("intents:")
+        shown = self.intents if include_concluded else self.active_intents()
+        if shown:
+            for intent in shown:
+                frm = f" from={','.join(intent.from_facts)}" if intent.from_facts else ""
+                res = f" -> {intent.result_fact}" if intent.result_fact else ""
+                note = f"  // {intent.note}" if intent.note else ""
+                lines.append(f"  - {intent.id} [{intent.status.value}]{frm}{res}: {intent.description}{note}")
+        else:
+            lines.append("  (暂无)")
+
+        return "\n".join(lines)
+
+    def get_summary(self) -> dict[str, object]:
+        status_counts: dict[str, int] = {}
+        for intent in self.intents:
+            status_counts[intent.status.value] = status_counts.get(intent.status.value, 0) + 1
+        return {
+            "completed": self.completed,
+            "facts": len(self.facts),
+            "intents": len(self.intents),
+            "open_intents": len(self.open_intents()),
+            "intent_status_counts": status_counts,
+            "complete_reason": self.complete_reason,
+        }

--- a/vulnclaw/agent/constraint_policy.py
+++ b/vulnclaw/agent/constraint_policy.py
@@ -69,9 +69,56 @@ def validate_phase_transition(
     return f"{violation} (phase transition to {next_phase.value})"
 
 
+# 纯本地/知识类工具：不与目标交互，不纳入「动作范围」约束
+LOCAL_META_TOOLS = {"load_skill_reference", "crypto_decode"}
+
+# 真正代表「利用」意图的攻击载荷特征——与传输方式（HTTP 方法/网络库）无关
+EXPLOIT_PAYLOAD_MARKERS = [
+    "union select",
+    " or 1=1",
+    "'or'",
+    "../",
+    "..\\",
+    "<script",
+    "cmd=",
+    "php://",
+    "data://",
+    "extractvalue(",
+    "updatexml(",
+    "load_file(",
+    "into outfile",
+    "{{",  # SSTI
+    "${",  # SSTI/EL
+    "%00",
+    "/etc/passwd",
+    "/bin/sh",
+    "bash -i",
+    "nc -e",
+    "powershell -e",
+]
+
+# python_execute 中代表本地命令执行/反弹 shell 的特征
+PYTHON_EXPLOIT_MARKERS = [
+    "os.system",
+    "subprocess",
+    "pty.spawn",
+    "/bin/sh",
+    "bash -i",
+    "nc -e",
+    "reverse_shell",
+]
+
+
 def infer_tool_action(tool_name: str, args: dict[str, object]) -> str:
-    """Infer the effective action class of a tool invocation."""
+    """Infer the effective action class of a tool invocation.
+
+    关键原则：只有「实际攻击载荷」才推断为 exploit；HTTP 方法、是否用 requests/urllib
+    等传输细节不构成利用意图（recon/scan 阶段本就需要发 POST/OPTIONS、用 requests 探测）。
+    """
     normalized_tool = (tool_name or "").strip().lower()
+
+    if normalized_tool in LOCAL_META_TOOLS:
+        return "recon"  # 仅本地操作，配合 validate_tool_action 豁免
 
     if normalized_tool == "nmap_scan":
         return "recon"
@@ -80,39 +127,23 @@ def infer_tool_action(tool_name: str, args: dict[str, object]) -> str:
         url = str(args.get("url", "") or "").lower()
         method = str(args.get("method", "GET") or "GET").upper()
         body = str(args.get("body", "") or "").lower()
-        suspicious_markers = [
-            "union select",
-            " or 1=1",
-            "../",
-            "<script",
-            "cmd=",
-            "php://",
-            "extractvalue(",
-            "whoami",
-        ]
-        if method != "GET" or any(marker in url or marker in body for marker in suspicious_markers):
+        if any(marker in url or marker in body for marker in EXPLOIT_PAYLOAD_MARKERS):
             return "exploit"
-        return "recon"
+        # 方法本身不代表利用：GET/HEAD/OPTIONS 属侦察，其它（POST 测表单等）属扫描
+        if method in ("GET", "HEAD", "OPTIONS"):
+            return "recon"
+        return "scan"
 
     if normalized_tool == "python_execute":
         code = str(args.get("code", "") or "").lower()
-        if any(
-            marker in code
-            for marker in [
-                "requests.",
-                "httpx.",
-                "urllib",
-                "socket.",
-                "whoami",
-                "extractvalue(",
-                "../",
-                "<script",
-            ]
-        ):
+        if any(marker in code for marker in EXPLOIT_PAYLOAD_MARKERS + PYTHON_EXPLOIT_MARKERS):
             return "exploit"
-        return "scan"
+        # 用 requests/httpx/urllib/socket 做 HTTP 探测属扫描，而非利用
+        if any(m in code for m in ("requests.", "httpx.", "urllib", "http.client", "socket")):
+            return "scan"
+        return "recon"
 
-    if normalized_tool in {"crypto_decode", "load_skill_reference", "brute_force_login"}:
+    if normalized_tool == "brute_force_login":
         return "scan"
 
     return "scan"
@@ -122,6 +153,9 @@ def validate_tool_action(
     tool_name: str, args: dict[str, object], constraints: TaskConstraints
 ) -> str | None:
     """Return a constraint violation when a tool invocation implies a blocked action."""
+    # 纯本地/知识类工具不受动作范围约束（加载文档、编解码不触碰目标）
+    if (tool_name or "").strip().lower() in LOCAL_META_TOOLS:
+        return None
     inferred = infer_tool_action(tool_name, args)
     violation = validate_action_constraints(inferred, constraints)
     if violation is None:

--- a/vulnclaw/agent/context.py
+++ b/vulnclaw/agent/context.py
@@ -11,6 +11,9 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field, PrivateAttr
 
+from vulnclaw.agent.blackboard import Blackboard
+from vulnclaw.agent.reasoning_state import ReasoningState
+
 
 class PentestPhase(str, Enum):
     """Penetration test phases."""
@@ -284,6 +287,11 @@ class SessionState(BaseModel):
     task_constraints: TaskConstraints = Field(default_factory=TaskConstraints)
     constraint_violations: list[str] = Field(default_factory=list)
     constraint_violation_events: list[ConstraintViolationEvent] = Field(default_factory=list)
+    reasoning: ReasoningState = Field(default_factory=ReasoningState)
+    # 目标驱动求解引擎的黑板图（Fact/Intent），随会话持久化
+    board: Blackboard = Field(default_factory=Blackboard)
+    # 反思引擎跨周期记忆快照（persistent 模式），存为 dict 以避免与 reflexion 模块循环导入
+    reflexion_snapshot: dict[str, Any] = Field(default_factory=dict)
     findings: list[VulnerabilityFinding] = Field(default_factory=list)
     recon_data: dict[str, Any] = Field(default_factory=dict)
     # ★ 原始步骤日志（向后兼容）
@@ -777,6 +785,27 @@ class SessionState(BaseModel):
         """Add a confirmed fact (verified by tool output)."""
         if fact and fact not in self.confirmed_facts:
             self.confirmed_facts.append(fact)
+        if fact:
+            self.reasoning.add_fact(
+                key=self._fact_key_from_text(fact),
+                value=fact,
+                source="confirmed_fact",
+                confidence=0.9,
+            )
+
+    def _fact_key_from_text(self, fact: str) -> str:
+        text = fact.lower()
+        if "cve-" in text:
+            return "cve"
+        if "http://" in text or "https://" in text:
+            return "url"
+        if "port" in text or "端口" in fact:
+            return "port"
+        if "server" in text or "x-powered-by" in text:
+            return "service"
+        if "waf" in text:
+            return "waf"
+        return "confirmed_fact"
 
     def add_assumption(self, assumption: str) -> None:
         """Add an unverified assumption."""

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -185,6 +185,48 @@ class AgentCore:
         # Re-bind finding parser to the new runtime object
         self._finding_parser = FindingParser(self.context, self.runtime)
 
+        # 跨周期恢复反思记忆（persistent 模式）：保留失败路径/历史/归因，重置本周期 stuck 计数
+        self._restore_reflexion_history()
+
+    # ── Reflexion 跨周期持久化 ───────────────────────────────────────
+    _REFLEXION_ATTEMPT_MEMORY = 50  # 跨周期最多携带的 attempt 条数，限制内存与归因开销
+
+    def _restore_reflexion_history(self) -> None:
+        """从 SessionState 快照恢复反思的记忆部分，但重置每周期 stuck 计数。"""
+        if not getattr(self.config.session, "reflexion_enabled", True):
+            return
+        snapshot = getattr(self.context.state, "reflexion_snapshot", None)
+        reflexion = getattr(self.runtime, "reflexion", None)
+        if not snapshot or reflexion is None:
+            return
+        try:
+            from vulnclaw.agent.reflexion import ReflexionState
+
+            restored = ReflexionState.model_validate(snapshot)
+        except Exception:
+            return
+        # 记忆：失败路径 / 归因素材 / 最近 attempts / 已知障碍
+        reflexion.state.failed_paths = restored.failed_paths
+        reflexion.state.constraints = restored.constraints
+        reflexion.state.attempts = restored.attempts[-self._REFLEXION_ATTEMPT_MEMORY :]
+        reflexion.state.last_vuln_type = restored.last_vuln_type
+        # 每周期重置：连败计数 / 同类失败计数 / 升级驱动（reflections）
+        reflexion.state.consecutive_failures = 0
+        reflexion.state.vuln_type_fail_count = 0
+        reflexion.state.reflections = []
+
+    def _save_reflexion_snapshot(self) -> None:
+        """把当前反思状态写回 SessionState 快照，供下个周期/同目标恢复时复用。"""
+        if not getattr(self.config.session, "reflexion_enabled", True):
+            return
+        reflexion = getattr(self.runtime, "reflexion", None)
+        if reflexion is None:
+            return
+        try:
+            self.context.state.reflexion_snapshot = reflexion.state.model_dump(mode="json")
+        except Exception:
+            pass
+
     def _get_client(self):
         """Lazy-initialize OpenAI client."""
         if self._client is None:
@@ -362,6 +404,42 @@ class AgentCore:
     def _build_round_context(self, round_num: int, max_rounds: int) -> str:
         """Build context string for the current round in auto loop."""
         return build_round_context(self, round_num, max_rounds)
+
+    # ── 目标驱动求解循环（黑板图 OODA，无固定轮数）──────────────────
+
+    async def solve(
+        self,
+        user_input: str,
+        target: Optional[str] = None,
+        *,
+        goal: Optional[str] = None,
+        max_steps: int = 40,
+        max_intents: int = 3,
+        max_tool_rounds: int = 4,
+        stream_sink: Optional["StreamSink"] = None,
+        on_event: Optional[Callable[[str, dict], None]] = None,
+    ) -> Any:
+        """以「目标达成 / 探索前沿耗尽 / 安全预算」为终止条件求解，而非固定轮数。"""
+        from vulnclaw.agent.solver import solve as run_solve
+
+        detected_target = target or self._detect_target(user_input)
+        if detected_target:
+            self.context.state.target = detected_target
+        self._reset_runtime_state(user_input=user_input)
+        self.context.add_user_message(user_input)
+
+        resolved_goal = goal or user_input
+        origin = detected_target or self.context.state.target or user_input
+        return await run_solve(
+            self,
+            origin=origin,
+            goal=resolved_goal,
+            max_steps=max_steps,
+            max_intents=max_intents,
+            max_tool_rounds=max_tool_rounds,
+            stream_sink=stream_sink,
+            on_event=on_event,
+        )
 
     # ── Persistent pentest loop ──────────────────────────────────────
 

--- a/vulnclaw/agent/loop_controller.py
+++ b/vulnclaw/agent/loop_controller.py
@@ -10,9 +10,74 @@ from vulnclaw.agent.constraint_policy import validate_phase_transition
 from vulnclaw.agent.context import PentestPhase
 from vulnclaw.agent.ctf_mode import update_ctf_state
 from vulnclaw.agent.llm_client import call_llm_auto
+from vulnclaw.agent.reasoning_state import (
+    ConstraintCategory,
+    ConstraintSeverity,
+    PathStatus,
+)
+from vulnclaw.agent.reflexion import FailureCategory, classify_failure
 from vulnclaw.agent.runtime_state import AgentResult, PersistentCycleResult
 
 RECON_MIN_ROUNDS = 8
+
+
+def _reasoning_enabled(agent: Any) -> bool:
+    return getattr(getattr(agent.config, "session", None), "reasoning_state_enabled", True)
+
+
+def _sync_reasoning_path(agent: Any, path_name: str, *, success: bool) -> None:
+    """把识别到的攻击路径落进结构化推理状态，并刷新优先级。"""
+    if not path_name or not _reasoning_enabled(agent):
+        return
+    reasoning = getattr(agent.context.state, "reasoning", None)
+    if reasoning is None or not hasattr(reasoning, "add_path"):
+        return
+    existing = next((p for p in reasoning.paths if p.name == path_name), None)
+    if existing is None:
+        existing = reasoning.add_path(path_name, steps=[], priority=1)
+    if success:
+        existing.status = PathStatus.SUCCESS
+        existing.result = "取得进展"
+    elif existing.status != PathStatus.SUCCESS:
+        existing.status = PathStatus.FAILED
+    reasoning.auto_prioritize()
+
+
+def _sync_reasoning_constraint(agent: Any, path_name: str, category: FailureCategory) -> None:
+    """把识别到的障碍（WAF/过滤等）落进结构化推理状态，描述保持稳定以便去重。"""
+    if not _reasoning_enabled(agent):
+        return
+    reasoning = getattr(agent.context.state, "reasoning", None)
+    if reasoning is None or not hasattr(reasoning, "add_constraint"):
+        return
+    mapping = {
+        FailureCategory.ENV_CONSTRAINT: ConstraintCategory.WAF,
+        FailureCategory.PARAM_ERROR: ConstraintCategory.FILTER,
+    }
+    category_value = mapping.get(category)
+    if category_value is None:
+        return
+    reasoning.add_constraint(
+        description=f"{path_name or '当前路径'} 被 {category_value.value} 阻断",
+        category=category_value,
+        severity=ConstraintSeverity.HIGH,
+        source="auto_pentest",
+    )
+
+
+def _configure_reflexion(agent: Any) -> None:
+    reflexion = getattr(agent.runtime, "reflexion", None)
+    session = getattr(agent.config, "session", None)
+    if not reflexion or not session:
+        return
+
+    for attr, config_attr in (
+        ("max_same_vuln_fails", "reflexion_max_same_vuln_fails"),
+        ("max_total_no_progress", "reflexion_max_total_no_progress"),
+        ("escalation_max_level", "escalation_max_level"),
+    ):
+        if hasattr(reflexion, attr) and hasattr(session, config_attr):
+            setattr(reflexion, attr, getattr(session, config_attr))
 
 
 async def auto_pentest(
@@ -36,6 +101,7 @@ async def auto_pentest(
 
     agent.context.add_user_message(user_input)
     agent._reset_runtime_state(user_input=user_input, detected_phase=detected_phase)
+    _configure_reflexion(agent)
 
     for round_num in range(1, max_rounds + 1):
         result = AgentResult()
@@ -149,12 +215,42 @@ async def auto_pentest(
             agent.runtime.last_notes_count = current_notes
             agent.runtime.last_steps_count = current_steps
 
+            detected_path = agent._detect_attack_path(response_text)
+            reflexion = getattr(agent.runtime, "reflexion", None)
+            reflexion_on = getattr(agent.config.session, "reflexion_enabled", True) and hasattr(
+                reflexion, "record_attempt"
+            )
+            failure_category = None if has_new_progress else classify_failure(response_text)
+            if reflexion_on:
+                reflexion.record_attempt(
+                    path=detected_path or agent.runtime.current_attack_path or "unknown",
+                    success=has_new_progress,
+                    category=failure_category,
+                    details=response_text[:200],
+                    vuln_type=detected_path or "",
+                )
+
+            # 把攻击路径与障碍同步进结构化推理状态
+            _sync_reasoning_path(agent, detected_path, success=has_new_progress)
+            if failure_category is not None:
+                _sync_reasoning_constraint(agent, detected_path, failure_category)
+
             if not has_new_progress and not agent.runtime.path_switch_forced:
-                detected_path = agent._detect_attack_path(response_text)
                 if detected_path:
                     if detected_path == agent.runtime.current_attack_path:
                         agent.runtime.same_path_fail_count += 1
                     else:
+                        # 卡住后切换了攻击路径 = 一次反思事件，记录以闭合升级环
+                        if (
+                            reflexion_on
+                            and agent.runtime.current_attack_path
+                            and reflexion.should_reflect()
+                        ):
+                            reflexion.record_reflection(
+                                old_path=agent.runtime.current_attack_path,
+                                new_path=detected_path,
+                                reasoning=response_text[:200],
+                            )
                         agent.runtime.current_attack_path = detected_path
                         agent.runtime.same_path_fail_count = 0
                         agent.runtime.path_switch_forced = False
@@ -180,6 +276,11 @@ async def auto_pentest(
             on_step(round_num, result)
         if not result.should_continue:
             break
+
+    # 把本周期反思记忆写回 SessionState 快照，供下个周期/同目标恢复时复用
+    if hasattr(agent, "_save_reflexion_snapshot"):
+        agent._save_reflexion_snapshot()
+        agent.context.state.save()
 
     return results
 

--- a/vulnclaw/agent/prompt_context.py
+++ b/vulnclaw/agent/prompt_context.py
@@ -17,6 +17,31 @@ def build_round_context(agent: Any, round_num: int, max_rounds: int) -> str:
     if constraints_block:
         constraints_summary = f"\n\n{constraints_block}"
 
+    reasoning_summary = ""
+    session_config = getattr(agent.config, "session", None)
+    reasoning_enabled = getattr(session_config, "reasoning_state_enabled", True)
+    if reasoning_enabled:
+        reasoning = getattr(state, "reasoning", None)
+        reasoning_block = (
+            reasoning.to_prompt_block()
+            if hasattr(reasoning, "to_prompt_block")
+            else ""
+        )
+        if reasoning_block:
+            reasoning_summary = f"\n\n{reasoning_block}"
+
+    reflexion_summary = ""
+    reflexion_enabled = getattr(session_config, "reflexion_enabled", True)
+    reflexion = getattr(agent.runtime, "reflexion", None)
+    if reflexion_enabled and hasattr(reflexion, "to_prompt_block"):
+        reflexion_block = reflexion.to_prompt_block()
+        if reflexion_block:
+            reflexion_summary = f"\n\n{reflexion_block}"
+        if hasattr(reflexion, "to_reflection_prompt"):
+            reflection_block = reflexion.to_reflection_prompt()
+            if reflection_block:
+                reflexion_summary += f"\n\n{reflection_block}"
+
     findings_summary = ""
     if state.findings:
         findings_summary = f"\n已发现漏洞: {len(state.findings)} 个"
@@ -119,7 +144,7 @@ def build_round_context(agent: Any, round_num: int, max_rounds: int) -> str:
                 )
 
     path_switch_warning = ""
-    if same_path_fails >= 3:
+    if not reflexion_enabled and same_path_fails >= 3:
         path_switch_warning = (
             f"\n\n🔴 路径切换强制指令：你已经在同一条攻击路径上失败了 {same_path_fails} 次！"
             f"\n你必须立即执行以下步骤："
@@ -268,6 +293,8 @@ def build_round_context(agent: Any, round_num: int, max_rounds: int) -> str:
         f"\n当前阶段: {state.phase.value}"
         f"\n输出目录: {agent.config.session.output_dir.resolve()}"
         f"{constraints_summary}"
+        f"{reasoning_summary}"
+        f"{reflexion_summary}"
         f"{user_hint_directive}"
         f"{findings_summary}"
         f"{facts_summary}"

--- a/vulnclaw/agent/reasoning_state.py
+++ b/vulnclaw/agent/reasoning_state.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ConstraintCategory(str, Enum):
+    WAF = "waf"
+    AUTH = "auth"
+    FILTER = "filter"
+    SANDBOX = "sandbox"
+    NETWORK = "network"
+    RATE_LIMIT = "rate_limit"
+    OTHER = "other"
+
+
+class ConstraintSeverity(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    BLOCKING = "blocking"
+
+
+class PathStatus(str, Enum):
+    PLANNED = "planned"
+    ACTIVE = "active"
+    SUCCESS = "success"
+    FAILED = "failed"
+    ABANDONED = "abandoned"
+
+
+class StepStatus(str, Enum):
+    PLANNED = "planned"
+    ACTIVE = "active"
+    SUCCESS = "success"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    BLOCKED = "blocked"
+
+
+class KnownFact(BaseModel):
+    key: str
+    value: str
+    source: str = ""
+    confidence: float = 1.0
+
+    @field_validator("confidence")
+    @classmethod
+    def clamp_confidence(cls, value: float) -> float:
+        return max(0.0, min(1.0, value))
+
+
+class ReasoningConstraint(BaseModel):
+    description: str
+    category: ConstraintCategory = ConstraintCategory.OTHER
+    severity: ConstraintSeverity = ConstraintSeverity.MEDIUM
+    source: str = ""
+
+    @property
+    def is_blocking(self) -> bool:
+        return self.severity == ConstraintSeverity.BLOCKING
+
+
+class PathStep(BaseModel):
+    action: str
+    target: str = ""
+    vuln_type: str = ""
+    status: StepStatus = StepStatus.PLANNED
+    result: str = ""
+
+
+class AttackPath(BaseModel):
+    name: str
+    steps: list[PathStep] = Field(default_factory=list)
+    priority: int = 0
+    status: PathStatus = PathStatus.PLANNED
+    result: str = ""
+    base_priority: int | None = None
+
+    def effective_base_priority(self) -> int:
+        return self.priority if self.base_priority is None else self.base_priority
+
+
+class ReasoningState(BaseModel):
+    facts: list[KnownFact] = Field(default_factory=list)
+    constraints: list[ReasoningConstraint] = Field(default_factory=list)
+    paths: list[AttackPath] = Field(default_factory=list)
+    active_path_index: int = -1
+
+    def add_fact(
+        self,
+        key: str,
+        value: str,
+        source: str = "",
+        confidence: float = 1.0,
+    ) -> KnownFact:
+        confidence = max(0.0, min(1.0, confidence))
+        for fact in self.facts:
+            if fact.key == key and fact.value == value:
+                fact.confidence = self._combine_confidence(fact.confidence, confidence)
+                if source and source not in self._split_sources(fact.source):
+                    fact.source = self._join_sources(fact.source, source)
+                return fact
+
+        for fact in self.facts:
+            if fact.key == key and fact.value != value:
+                fact.confidence = round(max(0.0, fact.confidence * (1.0 - confidence * 0.5)), 4)
+
+        new_fact = KnownFact(key=key, value=value, source=source, confidence=confidence)
+        self.facts.append(new_fact)
+        return new_fact
+
+    def add_constraint(
+        self,
+        description: str,
+        category: ConstraintCategory | str = ConstraintCategory.OTHER,
+        severity: ConstraintSeverity | str = ConstraintSeverity.MEDIUM,
+        source: str = "",
+    ) -> ReasoningConstraint:
+        for constraint in self.constraints:
+            if (
+                constraint.description == description
+                and constraint.category == category
+                and constraint.severity == severity
+            ):
+                if source and source not in self._split_sources(constraint.source):
+                    constraint.source = self._join_sources(constraint.source, source)
+                return constraint
+        constraint = ReasoningConstraint(
+            description=description,
+            category=category,
+            severity=severity,
+            source=source,
+        )
+        self.constraints.append(constraint)
+        return constraint
+
+    def get_blocking_constraints(self) -> list[ReasoningConstraint]:
+        return [constraint for constraint in self.constraints if constraint.is_blocking]
+
+    def add_path(
+        self,
+        name: str | AttackPath,
+        steps: list[PathStep | dict[str, Any]] | None = None,
+        priority: int = 0,
+        status: PathStatus | str = PathStatus.PLANNED,
+    ) -> AttackPath:
+        if isinstance(name, AttackPath):
+            path = name
+        else:
+            path_steps = [step if isinstance(step, PathStep) else PathStep(**step) for step in steps or []]
+            path = AttackPath(
+                name=name,
+                steps=path_steps,
+                priority=priority,
+                base_priority=priority,
+                status=status,
+            )
+        self.paths.append(path)
+        if self.active_path_index < 0 and path.status == PathStatus.ACTIVE:
+            self.active_path_index = len(self.paths) - 1
+        return path
+
+    def set_active_path(self, path: int | str) -> AttackPath:
+        idx = self._path_index(path)
+        for current in self.paths:
+            if current.status == PathStatus.ACTIVE:
+                current.status = PathStatus.PLANNED
+        self.paths[idx].status = PathStatus.ACTIVE
+        self.active_path_index = idx
+        return self.paths[idx]
+
+    def set_path(self, path: int | str) -> AttackPath:
+        return self.set_active_path(path)
+
+    def update_path(
+        self,
+        path: int | str,
+        status: PathStatus | str | None = None,
+        result: str | None = None,
+        priority: int | None = None,
+    ) -> AttackPath:
+        idx = self._path_index(path)
+        item = self.paths[idx]
+        if status is not None:
+            item.status = PathStatus(status)
+        if result is not None:
+            item.result = result
+        if priority is not None:
+            item.priority = priority
+            item.base_priority = priority
+        if item.status == PathStatus.ACTIVE:
+            self.active_path_index = idx
+        elif self.active_path_index == idx and item.status != PathStatus.ACTIVE:
+            self.active_path_index = -1
+        return item
+
+    def update_step(
+        self,
+        path: int | str,
+        step: int,
+        status: StepStatus | str,
+        result: str = "",
+    ) -> PathStep:
+        path_item = self.paths[self._path_index(path)]
+        step_item = path_item.steps[step]
+        step_item.status = StepStatus(status)
+        if result:
+            step_item.result = result
+        if step_item.status == StepStatus.SUCCESS and path_item.steps and all(
+            item.status in {StepStatus.SUCCESS, StepStatus.SKIPPED} for item in path_item.steps
+        ):
+            path_item.status = PathStatus.SUCCESS
+        elif step_item.status in {StepStatus.FAILED, StepStatus.BLOCKED}:
+            path_item.status = PathStatus.FAILED
+        return step_item
+
+    def abandon_path(self, path: int | str, reason: str = "") -> AttackPath:
+        idx = self._path_index(path)
+        item = self.paths[idx]
+        item.status = PathStatus.ABANDONED
+        if reason:
+            item.result = reason
+        if self.active_path_index == idx:
+            self.active_path_index = -1
+        return item
+
+    def auto_prioritize(self, success_history: dict[str, float] | None = None) -> None:
+        history = success_history or {}
+        blocking_penalty = len(self.get_blocking_constraints()) * 2
+        for path in self.paths:
+            base = path.effective_base_priority()
+            success_rate = max(0.0, min(1.0, history.get(path.name, 0.0)))
+            score = round(base * (1.0 + success_rate))
+            if path.status == PathStatus.SUCCESS:
+                score += 5
+            elif path.status == PathStatus.ACTIVE:
+                score += 2
+            elif path.status == PathStatus.FAILED:
+                score -= 3
+            elif path.status == PathStatus.ABANDONED:
+                score -= 10
+            path.priority = int(score - blocking_penalty)
+        active_name = self.paths[self.active_path_index].name if self._has_active_index() else None
+        self.paths.sort(key=lambda item: item.priority, reverse=True)
+        if active_name is None:
+            self.active_path_index = -1
+        else:
+            self.active_path_index = next(
+                (idx for idx, path in enumerate(self.paths) if path.name == active_name),
+                -1,
+            )
+
+    def to_prompt_block(self, max_facts: int = 8, max_paths: int = 5) -> str:
+        if not self.facts and not self.constraints and not self.paths:
+            return ""
+        lines = ["🧭 当前推理状态"]
+        if self.facts:
+            lines.append("已知事实（置信度）：")
+            for fact in sorted(self.facts, key=lambda item: item.confidence, reverse=True)[:max_facts]:
+                source = f", source={fact.source}" if fact.source else ""
+                lines.append(f"- {fact.key}={fact.value} (confidence={fact.confidence:.2f}{source})")
+        if self.constraints:
+            lines.append("障碍（推理层）：")
+            severity_order = {
+                ConstraintSeverity.BLOCKING: 0,
+                ConstraintSeverity.HIGH: 1,
+                ConstraintSeverity.MEDIUM: 2,
+                ConstraintSeverity.LOW: 3,
+            }
+            ordered_constraints = sorted(
+                self.constraints,
+                key=lambda item: severity_order[item.severity],
+            )
+            for constraint in ordered_constraints:
+                lines.append(
+                    f"- [{constraint.category.value}/{constraint.severity.value}] {constraint.description}"
+                )
+        if self.paths:
+            lines.append("候选攻击链（按优先级）：")
+            for idx, path in enumerate(sorted(self.paths, key=lambda item: item.priority, reverse=True)[:max_paths]):
+                original_idx = next(
+                    (path_idx for path_idx, item in enumerate(self.paths) if item is path),
+                    -1,
+                )
+                marker = "*" if original_idx == self.active_path_index else "-"
+                done = sum(1 for step in path.steps if step.status == StepStatus.SUCCESS)
+                total = len(path.steps)
+                progress = f", steps={done}/{total}" if total else ""
+                result = f", result={path.result}" if path.result else ""
+                lines.append(
+                    f"{marker} {idx + 1}. [{path.status.value}] {path.name} "
+                    f"(priority={path.priority}{progress}{result})"
+                )
+        return "\n".join(lines)
+
+    def get_summary(self) -> dict[str, Any]:
+        status_counts: dict[str, int] = {}
+        for path in self.paths:
+            status_counts[path.status.value] = status_counts.get(path.status.value, 0) + 1
+        return {
+            "facts": len(self.facts),
+            "constraints": len(self.constraints),
+            "blocking_constraints": len(self.get_blocking_constraints()),
+            "paths": len(self.paths),
+            "active_path": self.paths[self.active_path_index].name if self._has_active_index() else None,
+            "path_status_counts": status_counts,
+            "top_facts": [
+                {"key": fact.key, "value": fact.value, "confidence": fact.confidence}
+                for fact in sorted(self.facts, key=lambda item: item.confidence, reverse=True)[:5]
+            ],
+            "top_paths": [
+                {"name": path.name, "priority": path.priority, "status": path.status.value}
+                for path in sorted(self.paths, key=lambda item: item.priority, reverse=True)[:5]
+            ],
+        }
+
+    @staticmethod
+    def _combine_confidence(current: float, incoming: float) -> float:
+        return round(max(current, current + (1.0 - current) * incoming), 4)
+
+    @staticmethod
+    def _split_sources(source: str) -> set[str]:
+        return {part.strip() for part in source.split(",") if part.strip()}
+
+    @staticmethod
+    def _join_sources(current: str, incoming: str) -> str:
+        parts = [part for part in [current, incoming] if part]
+        return ", ".join(parts)
+
+    def _path_index(self, path: int | str) -> int:
+        if isinstance(path, int):
+            if path < 0 or path >= len(self.paths):
+                raise IndexError("path index out of range")
+            return path
+        for idx, item in enumerate(self.paths):
+            if item.name == path:
+                return idx
+        raise KeyError(f"unknown path: {path}")
+
+    def _has_active_index(self) -> bool:
+        return 0 <= self.active_path_index < len(self.paths)

--- a/vulnclaw/agent/reflexion.py
+++ b/vulnclaw/agent/reflexion.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from vulnclaw.agent.anti_loop import FAILED_ACCESS_PATTERNS
+
+
+class FailureCategory(str, Enum):
+    ENV_CONSTRAINT = "env_constraint"
+    PATH_ERROR = "path_error"
+    PARAM_ERROR = "param_error"
+    INFO_NEEDED = "info_needed"
+    UNKNOWN = "unknown"
+
+
+class Attempt(BaseModel):
+    path: str
+    success: bool
+    category: FailureCategory | None = None
+    details: str = ""
+    vuln_type: str = ""
+    timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class ReflexionState(BaseModel):
+    attempts: list[Attempt] = Field(default_factory=list)
+    constraints: list[str] = Field(default_factory=list)
+    failed_paths: list[str] = Field(default_factory=list)
+    reflections: list[dict[str, Any]] = Field(default_factory=list)
+    consecutive_failures: int = 0
+    last_vuln_type: str = ""
+    vuln_type_fail_count: int = 0
+
+
+class ReflexionEngine(BaseModel):
+    max_same_vuln_fails: int = 2
+    max_total_no_progress: int = 5
+    max_reflections_before_escalate: int = 3
+    escalation_max_level: int = 4
+    state: ReflexionState = Field(default_factory=ReflexionState)
+
+    def record_attempt(
+        self,
+        path: str,
+        success: bool,
+        category: FailureCategory | None = None,
+        details: str = "",
+        vuln_type: str = "",
+    ) -> None:
+        attempt = Attempt(
+            path=path,
+            success=success,
+            category=category,
+            details=details,
+            vuln_type=vuln_type,
+        )
+        self.state.attempts.append(attempt)
+
+        if success:
+            self.state.consecutive_failures = 0
+            self.state.vuln_type_fail_count = 0
+            if vuln_type:
+                self.state.last_vuln_type = vuln_type
+            return
+
+        self.state.consecutive_failures += 1
+        # 不把占位符 "unknown"/空路径塞进失败路径列表，避免污染失败历史与归因
+        if path and path != "unknown":
+            self.state.failed_paths.append(path)
+
+        if vuln_type:
+            if vuln_type == self.state.last_vuln_type:
+                self.state.vuln_type_fail_count += 1
+            else:
+                self.state.last_vuln_type = vuln_type
+                self.state.vuln_type_fail_count = 1
+
+        if category and category != FailureCategory.UNKNOWN and details:
+            self.state.constraints.append(details)
+
+    def should_reflect(self) -> bool:
+        same_vuln_stale = self.state.vuln_type_fail_count >= self.max_same_vuln_fails
+        no_progress_stale = self.state.consecutive_failures >= self.max_total_no_progress
+        return same_vuln_stale or no_progress_stale
+
+    def should_escalate(self) -> bool:
+        return len(self.state.reflections) >= self.max_reflections_before_escalate
+
+    def get_escalation_level(self) -> int:
+        level = (self.state.consecutive_failures // 2) + len(self.state.reflections)
+        return min(self.escalation_max_level, max(0, level))
+
+    def get_escalation_hints(self) -> list[str]:
+        hints_by_level = {
+            0: ["先尝试原始 payload（不编码）。"],
+            1: [
+                "URL 编码特殊字符。",
+                "切换关键字大小写（SeLeCt）。",
+                "尝试空白符变体（/**/、换行、Tab）。",
+            ],
+            2: [
+                "尝试双重 URL 编码。",
+                "插入内联注释，如 /**/。",
+                "面向浏览器的注入点使用 HTML 实体编码。",
+            ],
+            3: [
+                "尝试 Unicode 转义（\\u0027）。",
+                "尝试 hex 编码（0x...）。",
+                "用字符串拼接拆分关键字（con||cat）。",
+                "用等价的替代函数绕过被封函数。",
+            ],
+            4: [
+                "组合多层编码混淆。",
+                "改用替代语法达成同样目的（如 HANDLER 代替 SELECT）。",
+                "改用时间盲注或带外（OOB）通道确认。",
+                "切换到完全不同的漏洞类型/攻击面。",
+            ],
+        }
+        return hints_by_level[self.get_escalation_level()]
+
+    def record_reflection(self, old_path: str, new_path: str, reasoning: str) -> None:
+        self.state.reflections.append(
+            {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "old_path": old_path,
+                "new_path": new_path,
+                "reasoning": reasoning,
+            }
+        )
+        self.state.consecutive_failures = 0
+        self.state.vuln_type_fail_count = 0
+
+    def analyze_failure_patterns(self) -> list[dict[str, Any]]:
+        patterns: dict[str, dict[str, Any]] = {}
+        for attempt in self.state.attempts:
+            if attempt.success:
+                continue
+            category = attempt.category.value if attempt.category else FailureCategory.UNKNOWN.value
+            if category not in patterns:
+                patterns[category] = {"count": 0, "paths": set(), "examples": []}
+            patterns[category]["count"] += 1
+            patterns[category]["paths"].add(attempt.path)
+            if attempt.details and len(patterns[category]["examples"]) < 3:
+                patterns[category]["examples"].append(attempt.details[:200])
+
+        result = []
+        for category, info in sorted(patterns.items(), key=lambda item: item[1]["count"], reverse=True):
+            result.append(
+                {
+                    "category": category,
+                    "occurrences": info["count"],
+                    "affected_paths": sorted(info["paths"]),
+                    "example_details": info["examples"],
+                    "suggested_action": self._suggest_for_category(category),
+                }
+            )
+        return result
+
+    def get_failed_paths(self) -> list[str]:
+        return list(dict.fromkeys(self.state.failed_paths))
+
+    def to_prompt_block(self) -> str:
+        """轻量状态块（每轮注入）。详细的失败模式/升级提示只在 to_reflection_prompt
+        触发反思时输出，避免与本块重复注入、浪费 token。"""
+        if not self.state.attempts and not self.state.reflections:
+            return ""
+
+        lines = [
+            "🔁 反思状态：",
+            f"- 连续无进展轮数: {self.state.consecutive_failures}",
+            f"- 同类漏洞失败次数: {self.state.vuln_type_fail_count}",
+            f"- 当前升级级别: L{self.get_escalation_level()}",
+        ]
+
+        failed_paths = self.get_failed_paths()
+        if failed_paths:
+            lines.append(f"- 已失败路径（勿重复）: {', '.join(failed_paths[:8])}")
+
+        return "\n".join(lines)
+
+    def to_reflection_prompt(self) -> str:
+        """反思接管指令，仅在 should_reflect() 触发时输出；承载详细失败归因 + 升级提示。"""
+        if not self.should_reflect():
+            return ""
+
+        lines = [
+            "🔴 反思接管（同类攻击已连续失败，必须改变策略）：",
+            "- 停止在当前攻击路径上重复换 payload。",
+            "- 复盘失败记录，明确指出此前哪个假设很可能是错的。",
+            "- 在换下一个 payload 之前，先选择一条实质不同的攻击路径/漏洞类型。",
+            f"- 当前升级级别: L{self.get_escalation_level()}",
+        ]
+
+        if self.should_escalate():
+            lines.append("- ⚠️ 强制升级：切换到完全不同的漏洞类型或攻击面，不要再恋战当前方向。")
+
+        patterns = self.analyze_failure_patterns()
+        if patterns:
+            lines.append("- 失败模式分析：")
+            for pattern in patterns[:3]:
+                lines.append(
+                    f"  - {pattern['category']} ×{pattern['occurrences']}: "
+                    f"{pattern['suggested_action']}"
+                )
+
+        hints = self.get_escalation_hints()
+        if hints:
+            lines.append(f"- 本级（L{self.get_escalation_level()}）绕过提示：")
+            for hint in hints:
+                lines.append(f"  - {hint}")
+
+        return "\n".join(lines)
+
+    def extract_experience(self) -> dict[str, Any] | None:
+        if not self.state.attempts:
+            return None
+
+        successful_paths = [attempt.path for attempt in self.state.attempts if attempt.success]
+        return {
+            "total_attempts": len(self.state.attempts),
+            "successful_paths": successful_paths,
+            "failed_paths": self.get_failed_paths(),
+            "constraints": list(dict.fromkeys(self.state.constraints)),
+            "reflections": self.state.reflections,
+            "failure_patterns": self.analyze_failure_patterns(),
+            "last_vuln_type": self.state.last_vuln_type,
+            "escalation_level": self.get_escalation_level(),
+        }
+
+    @staticmethod
+    def _suggest_for_category(category: str) -> str:
+        suggestions = {
+            FailureCategory.ENV_CONSTRAINT.value: (
+                "用编码/混淆绕过过滤，切换协议或端点，并确认访问限制（WAF/权限/限流）。"
+            ),
+            FailureCategory.PATH_ERROR.value: (
+                "降低该路径优先级，切换到不同的攻击面/漏洞类型。"
+            ),
+            FailureCategory.PARAM_ERROR.value: (
+                "调整参数名、分隔符、payload 语法或注入位置。"
+            ),
+            FailureCategory.INFO_NEEDED.value: (
+                "先补充侦察信息再重试该路径。"
+            ),
+        }
+        return suggestions.get(category, "复盘失败记录，换一种思路。")
+
+
+def classify_failure(response_text: str) -> FailureCategory | None:
+    text = response_text.lower()
+    if not text.strip():
+        return None
+
+    if any(pattern.lower() in text for pattern in FAILED_ACCESS_PATTERNS):
+        return FailureCategory.ENV_CONSTRAINT
+
+    category_patterns = {
+        FailureCategory.ENV_CONSTRAINT: [
+            # English
+            "waf",
+            "403",
+            "forbidden",
+            "blocked",
+            "filtered",
+            "permission denied",
+            "unauthorized",
+            "rate limit",
+            "timeout",
+            "connection refused",
+            "bad gateway",
+            "service unavailable",
+            # 中文
+            "被拦截",
+            "被过滤",
+            "被waf",
+            "拦截",
+            "过滤掉",
+            "转义",
+            "禁止访问",
+            "无权限",
+            "权限不足",
+            "频率限制",
+            "限流",
+        ],
+        FailureCategory.PATH_ERROR: [
+            # English
+            "vulnerability does not exist",
+            "not vulnerable",
+            "no injection",
+            "not injectable",
+            "false positive",
+            "dead end",
+            "wrong attack surface",
+            # 中文
+            "不存在该漏洞",
+            "没有漏洞",
+            "无漏洞",
+            "不是注入点",
+            "无注入",
+            "此处无",
+            "误报",
+            "死胡同",
+            "走不通",
+            "换攻击面",
+            "换个方向",
+        ],
+        FailureCategory.PARAM_ERROR: [
+            # English
+            "invalid payload",
+            "syntax error",
+            "bad parameter",
+            "wrong parameter",
+            "encoding error",
+            "malformed",
+            "parse error",
+            "delimiter",
+            # 中文
+            "参数错误",
+            "参数不对",
+            "payload无效",
+            "payload 无效",
+            "语法错误",
+            "编码错误",
+            "格式错误",
+            "分隔符",
+        ],
+        FailureCategory.INFO_NEEDED: [
+            # English
+            "need more information",
+            "need more recon",
+            "unknown parameter",
+            "insufficient information",
+            "collect more",
+            "fingerprint first",
+            "enumerate first",
+            # 中文
+            "需要更多信息",
+            "信息不足",
+            "未知参数",
+            "先收集",
+            "先侦察",
+            "先枚举",
+            "先指纹",
+            "再收集",
+        ],
+    }
+
+    for category, patterns in category_patterns.items():
+        if any(pattern in text for pattern in patterns):
+            return category
+
+    return FailureCategory.UNKNOWN

--- a/vulnclaw/agent/runtime_state.py
+++ b/vulnclaw/agent/runtime_state.py
@@ -3,9 +3,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 from vulnclaw.agent.context import TaskConstraints
+
+try:
+    from vulnclaw.agent.reflexion import ReflexionEngine
+except ImportError:
+    ReflexionEngine = None
+
+
+def _create_reflexion_engine() -> Any:
+    if ReflexionEngine is None:
+        return None
+    try:
+        return ReflexionEngine()
+    except TypeError:
+        return None
 
 
 @dataclass
@@ -41,6 +55,7 @@ class RuntimeState:
     user_vuln_hint: str = ""
     user_vuln_hint_rounds: int = 0
     task_constraints: TaskConstraints = field(default_factory=TaskConstraints)
+    reflexion: Any = field(default_factory=_create_reflexion_engine)
 
     claimed_flag: Optional[str] = None
     flag_verified: bool = False

--- a/vulnclaw/agent/solver.py
+++ b/vulnclaw/agent/solver.py
@@ -1,0 +1,391 @@
+"""目标驱动的 OODA 求解循环 — 用黑板图替代固定轮数工作流。
+
+循环结构（无固定轮数）：
+  1. 用 origin/goal 播种初始 Fact。
+  2. REASON：读全图 → 判断目标是否达成 / 提出新的探索 Intent / 不提出。
+  3. EXPLORE：领取一个 Intent，用工具实际执行，把确认的结论写回为一个新 Fact。
+  4. 终止条件：目标达成 / 探索前沿耗尽（无 Intent 且 Reason 不再提出）/ 触达安全预算。
+
+安全预算（max_steps）只是防止失控的兜底上限，不是工作流阶段计数；
+正常情况下循环会在「目标达成」或「前沿耗尽」时提前结束。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from vulnclaw.agent.blackboard import Blackboard, BoardIntent
+from vulnclaw.agent.llm_client import build_chat_completion_kwargs, call_llm_auto
+from vulnclaw.agent.think_filter import strip_think_tags
+
+# 探索阶段判定「已推进/已确认结论」的信号
+_ADVANCE_MARKERS = [
+    "确认",
+    "成功",
+    "拿到",
+    "获取到",
+    "提取到",
+    "flag{",
+    "flag ",
+    "绕过成功",
+    "回显",
+    "漏洞存在",
+]
+# 探索阶段判定「该方向走不通」的信号
+_DEAD_END_MARKERS = [
+    "不存在",
+    "无法",
+    "失败",
+    "走不通",
+    "没有发现",
+    "无注入",
+    "无回显",
+    "排除",
+]
+
+
+@dataclass
+class SolveResult:
+    completed: bool
+    reason: str
+    steps: int
+    facts: int
+    board: Blackboard
+
+
+# 形如 flag{...} / ctfshow{...} / NSSCTF{...} 的旗标
+_FLAG_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,20}\{[^{}\n]{1,200}\}")
+
+
+def _extract_flags(text: str) -> list[str]:
+    """抽取文本中所有 flag 形态的 token（去重保序）。"""
+    return list(dict.fromkeys(_FLAG_RE.findall(text or "")))
+
+
+def _goal_wants_flag(goal: str) -> bool:
+    g = (goal or "").lower()
+    return any(k in g for k in ("flag", "夺旗", "ctf", "shell", "getshell"))
+
+
+def _unverified_flags(claim: str, evidence: str) -> list[str]:
+    """返回在 claim 中声称、但未在真实工具证据中出现的 flag（疑似幻觉）。"""
+    return [f for f in _extract_flags(claim) if f not in evidence]
+
+
+def _completion_is_grounded(goal: str, evidence: str) -> tuple[bool, str]:
+    """完成判定的证据校验：若目标要求 flag，则真实工具输出里必须真的出现过 flag。"""
+    if not _goal_wants_flag(goal):
+        return True, ""
+    if _extract_flags(evidence):
+        return True, ""
+    return False, "目标要求 flag，但任何真实工具输出中都没有出现 flag，判定为未验证/疑似幻觉"
+
+
+def _extract_json(text: str) -> Optional[dict]:
+    """从 LLM 回复中稳健地抽取一个 JSON 对象。"""
+    if not text:
+        return None
+    cleaned = strip_think_tags(text).strip()
+    # 去掉 ```json ... ``` 代码围栏
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", cleaned, re.DOTALL)
+    if fence:
+        cleaned = fence.group(1)
+    # 直接尝试
+    try:
+        obj = json.loads(cleaned)
+        return obj if isinstance(obj, dict) else None
+    except (ValueError, TypeError):
+        pass
+    # 退化：抓取第一个平衡花括号块
+    start = cleaned.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    for idx in range(start, len(cleaned)):
+        ch = cleaned[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                with_suppress = cleaned[start : idx + 1]
+                try:
+                    obj = json.loads(with_suppress)
+                    return obj if isinstance(obj, dict) else None
+                except (ValueError, TypeError):
+                    return None
+    return None
+
+
+async def _structured_call(agent: Any, prompt: str, *, max_tokens: int = 900) -> str:
+    """无工具的结构化 LLM 调用（用于 Reason / Conclude）。"""
+    client = agent._get_client()
+    messages = [{"role": "user", "content": prompt}]
+    kwargs = build_chat_completion_kwargs(agent, messages, max_tokens=max_tokens, temperature=0.2)
+    response = client.chat.completions.create(**kwargs)
+    if response and response.choices:
+        return response.choices[0].message.content or ""
+    return ""
+
+
+def _reason_prompt(board: Blackboard, max_intents: int) -> str:
+    return (
+        "你是该领域的资深渗透专家。下面是当前任务的「黑板图」快照：facts 是已确认的客观事实，"
+        "intents 是探索方向。图从 facts 出发、通过 intent 探索得到新的 fact，逐步逼近 goal。\n\n"
+        "请判断两件事：① 现有 facts 是否已满足 goal；② 若未满足，是否应提出新的探索方向。\n\n"
+        "只返回一个 JSON 对象，不要输出别的内容：\n"
+        '- 若 goal 已达成： {"complete": "引用具体 fact id 说明为何现有客观事实足以证明目标达成"}\n'
+        '- 若未达成且应提出新方向： {"intents": [{"from": ["f001"], "description": "高价值且独立的探索方向"}]}\n'
+        '- 若未达成但当前不必新增方向： {}\n\n'
+        "规则：\n"
+        "- **完成判定必须基于 facts 里已确认的客观事实**，不得基于猜测或愿望。若 goal 要求 flag，"
+        "则 facts 中必须有一条记录了**真实拿到的 flag 值**才能 complete；只要 flag 来源可疑/未被工具输出证实，"
+        "一律视为未达成，继续提方向去验证，绝不能 complete。\n"
+        "- 若某条 fact 标注了 [未验证]/[拒绝完成]/疑似幻觉，绝对不能据此判定达成。\n"
+        "- 若没有任何处于 open 的 intent，则必须提出新方向。\n"
+        f"- 一次最多提出 {max_intents} 个高价值、互不重叠、可独立推进的方向，每个聚焦核心思路。\n"
+        "- 反思是否走偏：若之前方向无效，提出能纠偏的新方向。\n"
+        "- description 简洁聚焦，不要冗长；不同 intent 覆盖不同维度。\n\n"
+        "## 黑板图\n```\n" + board.to_prompt_graph() + "\n```\n"
+    )
+
+
+def _conclude_prompt(board: Blackboard, intent: BoardIntent, evidence: str) -> str:
+    return (
+        "现在是「结论阶段」。它覆盖之前一切让你继续探索/继续发请求/继续等待结果的指令——立即停止动作，只做总结。\n"
+        "你只能基于「真实工具输出」里**已经实际确认**的信息来总结，不得继续调用工具、不得等待未完成的结果。\n\n"
+        "只返回一个 JSON 对象：\n"
+        '{"advanced": true/false, "fact": "本次新确认的客观事实（增量）"}\n\n'
+        "铁律（违反即视为失败）：\n"
+        "- fact 必须是**已被真实工具输出证实**的客观事实，不得是计划、猜测、推断或填充性描述。\n"
+        "- **严禁编造 flag/shell/密码/数据**。任何 flag 只有在下方「真实工具输出」中**逐字符出现过**才能写进 fact；"
+        "若工具输出里没有，就绝对不能声称拿到了 flag——这种情况 advanced=false。\n"
+        "- advanced=true 仅当本次探索有**工具输出支撑的**实质推进（确认注入点/绕过/拿到真实回显数据等）。\n"
+        "- advanced=false 表示该方向走不通或暂无被证实的结论；此时 fact 写明客观观察（如『响应返回 sql inject error，注入被过滤』）。\n"
+        "- 不要放大段原始数据，不要重复图里已有信息。\n\n"
+        f"## 当前探索方向 {intent.id}\n{intent.description}\n\n"
+        "## 本次探索的真实工具输出（你唯一可信的事实来源）\n```\n" + (evidence.strip() or "(无工具输出)") + "\n```\n\n"
+        "## 黑板图\n```\n" + board.to_prompt_graph() + "\n```\n"
+    )
+
+
+def _explore_context(board: Blackboard, intent: BoardIntent, step: int, max_rounds: int) -> str:
+    from_desc = ""
+    if intent.from_facts:
+        refs = [board.get_fact(fid) for fid in intent.from_facts]
+        from_desc = "\n".join(f"  - {f.id}: {f.description}" for f in refs if f)
+        from_desc = f"\n基于已知事实：\n{from_desc}"
+    return (
+        f"[探索方向 {intent.id} · 第 {step}/{max_rounds} 步]\n"
+        f"目标(goal): {board.goal}\n"
+        f"当前探索方向：{intent.description}{from_desc}\n\n"
+        "请只围绕这个方向用工具实际执行（发请求/构造 payload/解析响应），不要泛泛而谈。\n"
+        "每一步都要有真实的工具调用与对响应的具体分析；若该方向确认走不通就明确说明并停止。\n"
+    )
+
+
+async def reason_step(agent: Any, board: Blackboard, max_intents: int) -> dict:
+    raw = await _structured_call(agent, _reason_prompt(board, max_intents), max_tokens=1200)
+    parsed = _extract_json(raw)
+    return parsed or {}
+
+
+async def explore_step(
+    agent: Any,
+    board: Blackboard,
+    intent: BoardIntent,
+    *,
+    max_tool_rounds: int,
+    evidence_buffer: list[str],
+    stream_sink: Any = None,
+) -> tuple[bool, str]:
+    """围绕一个 Intent 实际探索，返回 (是否推进, 结论事实描述)。
+
+    结论阶段只喂给模型「本次探索真实捕获的工具输出」作为唯一可信事实来源，降低幻觉。
+    """
+    system_prompt = agent._build_system_prompt(
+        agent.context.state.target, auto_mode=True, user_input=intent.description
+    )
+    evidence_start = len(evidence_buffer)
+    last_text = ""
+    for step in range(1, max_tool_rounds + 1):
+        ctx = _explore_context(board, intent, step, max_tool_rounds)
+        text = await call_llm_auto(agent, system_prompt, ctx, stream_sink=stream_sink)
+        last_text = text or ""
+        agent.context.add_assistant_message(f"[探索 {intent.id} 第{step}步] {last_text}")
+        # 复用既有的发现提取逻辑
+        if hasattr(agent, "_finding_parser"):
+            agent._finding_parser.parse(last_text)
+        lowered = last_text.lower()
+        # 早停：明确推进或明确死路
+        if any(m.lower() in lowered for m in _ADVANCE_MARKERS):
+            break
+        if any(m in last_text for m in _DEAD_END_MARKERS) and step >= 2:
+            break
+
+    # 本次探索真实捕获的工具输出（HTTP 响应 / python_execute 输出等）
+    intent_evidence = "\n".join(evidence_buffer[evidence_start:])[-6000:]
+    raw = await _structured_call(
+        agent, _conclude_prompt(board, intent, intent_evidence), max_tokens=600
+    )
+    parsed = _extract_json(raw) or {}
+    advanced = bool(parsed.get("advanced"))
+    fact = str(parsed.get("fact", "")).strip()
+    if not fact:
+        fact = strip_think_tags(last_text).strip()[:200]
+    return advanced, fact
+
+
+async def solve(
+    agent: Any,
+    *,
+    origin: str,
+    goal: str,
+    hints: Optional[list[str]] = None,
+    max_steps: int = 40,
+    max_intents: int = 3,
+    max_tool_rounds: int = 4,
+    stream_sink: Any = None,
+    on_event: Optional[Callable[[str, dict], None]] = None,
+) -> SolveResult:
+    """运行目标驱动的求解循环，直到目标达成 / 前沿耗尽 / 触达安全预算。"""
+    board = agent.context.state.board
+    board.origin = origin or board.origin
+    board.goal = goal or board.goal
+
+    def emit(kind: str, payload: dict) -> None:
+        if on_event is not None:
+            on_event(kind, payload)
+
+    # 真实工具输出缓冲区——所有 flag/完成判定的唯一可信证据来源
+    evidence_buffer: list[str] = []
+    original_execute = agent._execute_mcp_tool
+
+    async def _recording_execute(tool_name: str, tool_args: dict) -> str:
+        output = await original_execute(tool_name, tool_args)
+        evidence_buffer.append(str(output))
+        if len(evidence_buffer) > 400:
+            del evidence_buffer[:200]
+        return output
+
+    agent._execute_mcp_tool = _recording_execute  # type: ignore[method-assign]
+
+    try:
+        # 播种初始事实
+        if not board.facts:
+            seed = f"目标 origin={origin}；目标 goal={goal}"
+            if hints:
+                seed += "；提示：" + " | ".join(hints)
+            board.add_fact(seed, source="origin")
+
+        empty_reason_streak = 0
+        consecutive_errors = 0
+        steps = 0
+
+        while steps < max_steps and not board.completed:
+            try:
+                decision = await reason_step(agent, board, max_intents)
+            except Exception as exc:  # LLM/网络异常：不崩溃，累计熔断
+                consecutive_errors += 1
+                emit("error", {"phase": "reason", "error": str(exc)})
+                if consecutive_errors >= 3:
+                    break
+                continue
+            emit("reason", {"decision": decision, "step": steps})
+
+            complete_reason = decision.get("complete")
+            if complete_reason:
+                full_evidence = "\n".join(evidence_buffer)
+                grounded, why = _completion_is_grounded(board.goal, full_evidence)
+                fake = _unverified_flags(str(complete_reason), full_evidence)
+                if grounded and not fake:
+                    board.mark_complete(str(complete_reason))
+                    break
+                # 完成声明缺乏真实证据 → 拒绝，写入纠偏事实，继续探索
+                reject_reason = why or f"完成声明引用的 flag {fake[0]} 未在真实工具输出中出现"
+                board.add_fact(f"[拒绝完成] {reject_reason}；继续探索验证", source="verify")
+                emit("complete_rejected", {"reason": reject_reason})
+                continue
+
+            for item in decision.get("intents") or []:
+                desc = (item or {}).get("description", "").strip() if isinstance(item, dict) else ""
+                if desc:
+                    board.add_intent(desc, (item or {}).get("from"))
+
+            open_intents = board.open_intents()
+            if not open_intents:
+                empty_reason_streak += 1
+                if empty_reason_streak >= 2:
+                    # 探索前沿耗尽：Reason 连续不再提出新方向
+                    break
+                continue
+            empty_reason_streak = 0
+
+            intent = open_intents[0]
+            board.claim_intent(intent.id)
+            emit("explore_start", {"intent_id": intent.id, "description": intent.description})
+
+            try:
+                advanced, fact = await explore_step(
+                    agent,
+                    board,
+                    intent,
+                    max_tool_rounds=max_tool_rounds,
+                    evidence_buffer=evidence_buffer,
+                    stream_sink=stream_sink,
+                )
+            except Exception as exc:  # 探索异常：放弃该 intent，累计熔断
+                consecutive_errors += 1
+                board.abandon_intent(intent.id, note=f"探索异常: {exc}")
+                emit("error", {"phase": "explore", "intent_id": intent.id, "error": str(exc)})
+                if consecutive_errors >= 3:
+                    break
+                continue
+            consecutive_errors = 0
+
+            # 证据闸门：结论里声称的 flag 必须在真实工具输出里逐字符出现过
+            full_evidence = "\n".join(evidence_buffer)
+            fake_flags = _unverified_flags(fact, full_evidence)
+            if fake_flags:
+                note = f"声称获得 flag {fake_flags[0]} 但未在任何真实工具输出中出现，判定为幻觉，已拒绝"
+                board.abandon_intent(intent.id, note=note)
+                board.add_fact(f"[未验证] 探索 {intent.id}：{note}", source="verify")
+                emit("hallucination", {"intent_id": intent.id, "flags": fake_flags})
+            elif advanced and fact:
+                new_fact = board.conclude_intent(intent.id, fact)
+                emit(
+                    "conclude",
+                    {"intent_id": intent.id, "fact": new_fact.id if new_fact else "", "desc": fact},
+                )
+                # 拿到经证据验证的 flag 即刻收敛，不再多跑验证轮
+                captured = _extract_flags(fact)
+                if captured and _goal_wants_flag(board.goal):
+                    board.mark_complete(
+                        f"已从 {new_fact.id if new_fact else 'fact'} 验证获取 flag: {captured[0]}"
+                    )
+                    emit("reason", {"decision": {"complete": board.complete_reason}, "step": steps})
+                    break
+            else:
+                board.abandon_intent(intent.id, note=(fact or "未推进")[:120])
+                emit("abandon", {"intent_id": intent.id, "note": fact})
+
+            steps += 1
+            agent.context.state.save()
+    finally:
+        agent._execute_mcp_tool = original_execute  # type: ignore[method-assign]
+
+    reason = (
+        board.complete_reason
+        if board.completed
+        else ("探索前沿耗尽" if steps < max_steps else "触达安全预算上限")
+    )
+    return SolveResult(
+        completed=board.completed,
+        reason=reason,
+        steps=steps,
+        facts=len(board.facts),
+        board=board,
+    )

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -178,6 +178,40 @@ def _print_agent_output(output: str, config) -> None:
             console.print("[dim](LLM returned only hidden reasoning and no visible answer.)[/dim]")
 
 
+def _make_solve_event_printer(target_console):
+    """Return an on_event callback that prints solve-engine progress live."""
+
+    def on_event(kind: str, payload: dict) -> None:
+        if kind == "reason":
+            decision = payload.get("decision") or {}
+            if decision.get("complete"):
+                target_console.print("[green]✓ Reason: 目标达成[/green]")
+            elif decision.get("intents"):
+                target_console.print(
+                    f"[cyan]◆ Reason:[/cyan] 提出 {len(decision['intents'])} 个新探索方向"
+                )
+            else:
+                target_console.print("[dim]◆ Reason: 暂不新增方向[/dim]")
+        elif kind == "explore_start":
+            target_console.print(
+                f"[yellow]▶ Explore {payload['intent_id']}:[/yellow] {payload['description'][:90]}"
+            )
+        elif kind == "conclude":
+            target_console.print(
+                f"[green]＋ Fact {payload.get('fact', '')}:[/green] {payload.get('desc', '')[:90]}"
+            )
+        elif kind == "hallucination":
+            target_console.print(
+                f"[red]⚠ 幻觉拦截 {payload['intent_id']}:[/red] 声称的 flag 无真实证据，已拒绝"
+            )
+        elif kind == "complete_rejected":
+            target_console.print(f"[red]⚠ 拒绝完成:[/red] {payload.get('reason', '')[:90]}")
+        elif kind == "abandon":
+            target_console.print(f"[red]✗ 放弃 {payload['intent_id']}[/red]")
+
+    return on_event
+
+
 # 鈹€鈹€ REPL 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 
 
@@ -489,6 +523,43 @@ def _run_repl() -> None:
                     # Autonomous pentest loop
                     console.print(_("cli.enter_auto_mode"))
                     console.print()
+
+                    # 默认走目标驱动 solve 引擎；engine=rounds 时回退到旧固定轮数循环
+                    if getattr(config.session, "engine", "solve") == "solve":
+                        async def _run_auto():
+                            sink = TerminalStreamSink(console, config.session.show_thinking)
+
+                            async def call():
+                                return await agent.solve(
+                                    user_input,
+                                    target=current_target,
+                                    max_steps=config.session.solve_max_steps,
+                                    max_intents=config.session.solve_max_intents,
+                                    max_tool_rounds=config.session.solve_max_tool_rounds,
+                                    stream_sink=sink,
+                                    on_event=_make_solve_event_printer(console),
+                                )
+
+                            async def after_result(result):
+                                board = agent.context.state.board.get_summary()
+                                done = board.get("completed")
+                                console.print()
+                                console.print(
+                                    Panel(
+                                        f"{'✅ 目标达成' if done else '⊘ 未达成'} — "
+                                        f"facts={board.get('facts', 0)} intents={board.get('intents', 0)}\n"
+                                        f"原因: {board.get('complete_reason') or '探索结束'}",
+                                        title="Solve",
+                                        border_style="green" if done else "yellow",
+                                    )
+                                )
+
+                            await _run_repl_agent_call(agent, call=call, after_result=after_result)
+
+                        asyncio.run(_run_auto())
+                        auto_mode_active = True
+                        console.print(_("cli.auto_mode_hint"))
+                        continue
 
                     async def _run_auto():
                         sink = TerminalStreamSink(console, config.session.show_thinking)
@@ -836,9 +907,24 @@ def run(
         err_console.print(f"[!] {violation}")
         raise typer.Exit(1)
 
+    board_holder: dict = {}
+
     async def _run():
         async def runner(agent, shared_config):
             sink = TerminalStreamSink(console, shared_config.session.show_thinking)
+            # 默认走目标驱动 solve 引擎；engine=rounds 时回退到旧的固定轮数循环
+            if getattr(shared_config.session, "engine", "solve") == "solve":
+                result = await agent.solve(
+                    task_prompt,
+                    target=target,
+                    max_steps=shared_config.session.solve_max_steps,
+                    max_intents=shared_config.session.solve_max_intents,
+                    max_tool_rounds=shared_config.session.solve_max_tool_rounds,
+                    stream_sink=sink,
+                    on_event=_make_solve_event_printer(console),
+                )
+                board_holder["board"] = agent.context.state.board.get_summary()
+                return result
             return await agent.auto_pentest(
                 task_prompt,
                 target=target,
@@ -861,8 +947,87 @@ def run(
         return result
 
     orchestrated = asyncio.run(_run())
-    total_findings = orchestrated.summary["findings_count"]
-    console.print(_("cli.pentest_finished", findings=total_findings))
+    if board_holder.get("board"):
+        board = board_holder["board"]
+        status = "✅ 目标达成" if board.get("completed") else "⊘ 未达成"
+        console.print(
+            f"\n[bold]{status}[/bold] — facts={board.get('facts', 0)} "
+            f"intents={board.get('intents', 0)} 原因: {board.get('complete_reason') or '探索结束'}"
+        )
+    else:
+        total_findings = orchestrated.summary["findings_count"]
+        console.print(_("cli.pentest_finished", findings=total_findings))
+
+
+@app.command()
+def solve(
+    target: str = typer.Argument(..., help="Target host/IP/URL"),
+    goal: Optional[str] = typer.Option(
+        None, "--goal", help="Success condition, e.g. 'capture the flag' / 'get a shell'"
+    ),
+    prompt: Optional[str] = typer.Option(
+        None, "--prompt", help="Custom task description (overrides auto-generated)"
+    ),
+    max_steps: int = typer.Option(
+        40, "--max-steps", help="Safety cap on explore steps (NOT a fixed workflow length)"
+    ),
+    max_intents: int = typer.Option(3, "--max-intents", help="Max new intents per reason step"),
+    max_tool_rounds: int = typer.Option(
+        4, "--max-tool-rounds", help="Max tool-calling rounds per intent exploration"
+    ),
+    resume: bool = typer.Option(True, "--resume/--no-resume", help="Resume previous target state"),
+    snapshot: Optional[str] = typer.Option(None, "--snapshot", help="Resume from a snapshot id"),
+) -> None:
+    """Goal-driven solve loop — runs until the goal is met or the exploration frontier is exhausted.
+
+    Unlike `run`, this has no fixed round count. It searches a Fact/Intent graph
+    from the target toward the goal and stops on success or when no path remains.
+    """
+    config = load_config()
+    if not config.llm.api_key:
+        err_console.print("[!] Configure an LLM API key first.")
+        raise typer.Exit(1)
+
+    resolved_goal = goal or "找到 flag / 拿到 shell / 确认并验证高价值漏洞"
+    task_prompt = prompt or (
+        f"对 {target} 进行授权渗透测试。这是明确授权、在范围内的目标。目标(goal)：{resolved_goal}。"
+    )
+    console.print(f"[*] Target: [bold]{target}[/] | Goal: [bold]{resolved_goal}[/]")
+
+    on_event = _make_solve_event_printer(console)
+    holder: dict = {}
+
+    async def _run():
+        async def runner(agent, shared_config):
+            sink = TerminalStreamSink(console, shared_config.session.show_thinking)
+            result = await agent.solve(
+                task_prompt,
+                target=target,
+                goal=resolved_goal,
+                max_steps=max_steps,
+                max_intents=max_intents,
+                max_tool_rounds=max_tool_rounds,
+                stream_sink=sink,
+                on_event=on_event,
+            )
+            holder["board"] = agent.context.state.board.get_summary()
+            return result
+
+        return await _run_cli_orchestrated_task(
+            command="solve",
+            target=target,
+            resume=resume,
+            snapshot=snapshot,
+            runner=runner,
+        )
+
+    asyncio.run(_run())
+    board = holder.get("board") or {}
+    status = "✅ 目标达成" if board.get("completed") else "⊘ 未达成"
+    console.print(
+        f"\n[bold]{status}[/bold] — facts={board.get('facts', 0)} "
+        f"intents={board.get('intents', 0)} 原因: {board.get('complete_reason') or '探索结束'}"
+    )
 
 
 @app.command()
@@ -1474,6 +1639,181 @@ app.add_typer(kb_app, name="kb")
 
 target_state_app = typer.Typer(help="Manage target history state")
 app.add_typer(target_state_app, name="target-state")
+
+plugins_app = typer.Typer(help="Inspect and run vulnerability detection plugins")
+app.add_typer(plugins_app, name="plugins")
+
+
+def _parse_kv_options(pairs: Optional[list[str]]) -> dict[str, object]:
+    """把 --option key=value（可重复）解析为 dict，value 优先按 JSON 解析。"""
+    import json as _json
+
+    options: dict[str, object] = {}
+    for pair in pairs or []:
+        if "=" not in pair:
+            raise typer.BadParameter(f"Expected key=value, got: {pair}")
+        key, _, raw = pair.partition("=")
+        key = key.strip()
+        raw = raw.strip()
+        try:
+            options[key] = _json.loads(raw)
+        except (ValueError, TypeError):
+            options[key] = raw
+    return options
+
+
+@plugins_app.command("list")
+def plugins_list(
+    stage: Optional[str] = typer.Option(None, "--stage", help="Filter by stage"),
+    tag: Optional[str] = typer.Option(None, "--tag", help="Filter by tag"),
+) -> None:
+    """List registered detection plugins."""
+    from rich.table import Table
+
+    from vulnclaw.plugins import registry
+
+    plugin_classes = registry.list()
+    if stage:
+        try:
+            plugin_classes = registry.by_stage(stage)
+        except ValueError:
+            err_console.print(f"[!] Unknown stage: {stage}")
+            raise typer.Exit(1) from None
+    if tag:
+        tag_set = {p.plugin_id for p in registry.by_tag(tag)}
+        plugin_classes = [p for p in plugin_classes if p.plugin_id in tag_set]
+
+    if not plugin_classes:
+        console.print("[yellow]No plugins match the filter.[/yellow]")
+        return
+
+    table = Table(title="VulnClaw Plugins", show_lines=False)
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Name")
+    table.add_column("Stages")
+    table.add_column("Risk")
+    table.add_column("Destructive", justify="center")
+    for plugin_cls in sorted(plugin_classes, key=lambda p: p.plugin_id):
+        meta = plugin_cls.metadata()
+        table.add_row(
+            meta["plugin_id"],
+            meta["name"],
+            ", ".join(meta["stages"]),
+            meta["default_risk"],
+            "⚠️" if meta["destructive"] else "-",
+        )
+    console.print(table)
+
+
+@plugins_app.command("info")
+def plugins_info(plugin_id: str = typer.Argument(..., help="Plugin id")) -> None:
+    """Show full metadata for a single plugin."""
+    import json as _json
+
+    from vulnclaw.plugins import registry
+
+    plugin_cls = registry.get(plugin_id)
+    if plugin_cls is None:
+        err_console.print(f"[!] Plugin not found: {plugin_id}")
+        raise typer.Exit(1)
+    console.print_json(_json.dumps(plugin_cls.metadata(), ensure_ascii=False))
+
+
+@plugins_app.command("run")
+def plugins_run(
+    plugin_id: str = typer.Argument(..., help="Plugin id to run"),
+    target: str = typer.Option("", "--target", help="Target host/IP/URL"),
+    stage: str = typer.Option("discovery", "--stage", help="Plugin stage"),
+    option: Optional[list[str]] = typer.Option(
+        None, "--option", "-o", help="Plugin option key=value (repeatable, value parsed as JSON)"
+    ),
+    input_file: Optional[str] = typer.Option(
+        None, "--input", help="JSON file merged into plugin options"
+    ),
+    allow_destructive: bool = typer.Option(
+        False, "--allow-destructive", help="Permit destructive plugins"
+    ),
+    session_file: Optional[str] = typer.Option(
+        None, "--session", help="Merge findings into this SessionState JSON and save it"
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Print the raw PluginResult as JSON"),
+) -> None:
+    """Run a plugin against supplied data (builtin plugins only analyze provided input)."""
+    import json as _json
+    from pathlib import Path
+
+    from rich.table import Table
+
+    from vulnclaw.plugins import PluginContext, PluginStage, create_builtin_runtime
+    from vulnclaw.plugins.integration import merge_plugin_results_into_session
+
+    try:
+        stage_value = PluginStage(stage)
+    except ValueError:
+        err_console.print(f"[!] Unknown stage: {stage}")
+        raise typer.Exit(1) from None
+
+    options = _parse_kv_options(option)
+    if input_file:
+        path = Path(input_file)
+        if not path.exists():
+            err_console.print(f"[!] Input file not found: {input_file}")
+            raise typer.Exit(1)
+        try:
+            payload = _json.loads(path.read_text(encoding="utf-8"))
+        except (ValueError, OSError) as exc:
+            err_console.print(f"[!] Failed to read input file: {exc}")
+            raise typer.Exit(1) from None
+        if isinstance(payload, dict):
+            options.update(payload)
+        else:
+            options["input"] = payload
+
+    config = load_config()
+    runtime = create_builtin_runtime(config)
+    context = PluginContext(
+        target=target,
+        stage=stage_value,
+        options=options,
+        allow_destructive=allow_destructive,
+    )
+
+    result = asyncio.run(runtime.execute(plugin_id, context))
+
+    if as_json:
+        console.print_json(result.model_dump_json())
+    else:
+        if result.skipped:
+            console.print(f"[yellow]⊘ Skipped[/yellow] ({result.error_type}): {result.error}")
+        elif result.error:
+            console.print(f"[red]✗ Error[/red] ({result.error_type}): {result.error}")
+        for message in result.messages:
+            console.print(f"  [dim]{message}[/dim]")
+        if result.findings:
+            table = Table(title=f"{plugin_id} findings", show_lines=True)
+            table.add_column("Risk", style="magenta", no_wrap=True)
+            table.add_column("Title")
+            table.add_column("Type")
+            table.add_column("Confidence", justify="right")
+            for finding in result.findings:
+                table.add_row(
+                    finding.risk.value,
+                    finding.title,
+                    finding.vuln_type or "-",
+                    f"{finding.confidence:.2f}",
+                )
+            console.print(table)
+        elif not result.error:
+            console.print("[green]✓[/green] Plugin ran; no findings.")
+
+    if session_file:
+        session_path = Path(session_file)
+        from vulnclaw.agent.context import SessionState
+
+        session = SessionState.load(session_path) if session_path.exists() else SessionState()
+        added = merge_plugin_results_into_session(session, result)
+        session.save(session_path)
+        console.print(f"[+] Merged {added} finding(s) into {session_file}")
 
 
 @kb_app.command("update")

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -201,6 +201,18 @@ class SessionConfig(BaseModel):
     )
     poc_language: str = Field(default="python", description="Default PoC language: python, bash")
     max_rounds: int = Field(default=15, description="Max autonomous pentest rounds (1-100)")
+    # Autonomous engine: "solve" = goal-driven OODA (default), "rounds" = legacy fixed-round loop
+    engine: str = Field(
+        default="solve", description="Autonomous engine: solve (goal-driven) or rounds (legacy)"
+    )
+    # Solve-engine knobs
+    solve_max_steps: int = Field(
+        default=40, description="Safety cap on solve explore steps (not a fixed workflow length)"
+    )
+    solve_max_intents: int = Field(default=3, description="Max new intents per reason step")
+    solve_max_tool_rounds: int = Field(
+        default=6, description="Max tool-calling rounds per intent exploration"
+    )
     show_thinking: bool = Field(
         default=False, description="Show LLM thinking/reasoning output (default: off)"
     )
@@ -223,7 +235,33 @@ class SessionConfig(BaseModel):
     language: str = Field(
         default="auto", description="UI language: auto, zh, en"
     )
-
+    reasoning_state_enabled: bool = Field(
+        default=True, description="Enable reasoning state tracking"
+    )
+    reflexion_enabled: bool = Field(
+        default=True, description="Enable reflexion feedback loop"
+    )
+    reflexion_max_same_vuln_fails: int = Field(
+        default=2, description="Max repeated failures for the same vulnerability"
+    )
+    reflexion_max_total_no_progress: int = Field(
+        default=5, description="Max total rounds without progress before reflexion"
+    )
+    escalation_max_level: int = Field(
+        default=4, description="Max escalation level"
+    )
+    plugin_runtime_enabled: bool = Field(
+        default=True, description="Enable plugin runtime"
+    )
+    plugin_default_timeout: int = Field(
+        default=10, description="Default plugin timeout in seconds"
+    )
+    plugin_max_requests_per_target: int = Field(
+        default=30, description="Max plugin requests per target"
+    )
+    evidence_min_report_level: str = Field(
+        default="L4", description="Minimum evidence level for report inclusion"
+    )
 
 class VulnClawConfig(BaseModel):
     """Top-level VulnClaw configuration."""

--- a/vulnclaw/config/settings.py
+++ b/vulnclaw/config/settings.py
@@ -196,6 +196,35 @@ def _overlay_env(config: VulnClawConfig) -> VulnClawConfig:
             config.session.max_rounds = int(v)
     if v := os.environ.get("VULNCLAW_SESSION_SHOW_THINKING"):
         config.session.show_thinking = v.lower() in ("1", "true", "yes", "on")
+    if v := os.environ.get("VULNCLAW_SESSION_STALE_ROUNDS_THRESHOLD"):
+        with suppress(ValueError):
+            config.session.stale_rounds_threshold = int(v)
+
+    # ── Session: 推理状态 / 反思引擎 / 插件运行时 ──────────────
+    _truthy = ("1", "true", "yes", "on")
+    if v := os.environ.get("VULNCLAW_SESSION_REASONING_STATE_ENABLED"):
+        config.session.reasoning_state_enabled = v.lower() in _truthy
+    if v := os.environ.get("VULNCLAW_SESSION_REFLEXION_ENABLED"):
+        config.session.reflexion_enabled = v.lower() in _truthy
+    if v := os.environ.get("VULNCLAW_SESSION_REFLEXION_MAX_SAME_VULN_FAILS"):
+        with suppress(ValueError):
+            config.session.reflexion_max_same_vuln_fails = int(v)
+    if v := os.environ.get("VULNCLAW_SESSION_REFLEXION_MAX_TOTAL_NO_PROGRESS"):
+        with suppress(ValueError):
+            config.session.reflexion_max_total_no_progress = int(v)
+    if v := os.environ.get("VULNCLAW_SESSION_ESCALATION_MAX_LEVEL"):
+        with suppress(ValueError):
+            config.session.escalation_max_level = int(v)
+    if v := os.environ.get("VULNCLAW_SESSION_PLUGIN_RUNTIME_ENABLED"):
+        config.session.plugin_runtime_enabled = v.lower() in _truthy
+    if v := os.environ.get("VULNCLAW_SESSION_PLUGIN_DEFAULT_TIMEOUT"):
+        with suppress(ValueError):
+            config.session.plugin_default_timeout = int(v)
+    if v := os.environ.get("VULNCLAW_SESSION_PLUGIN_MAX_REQUESTS_PER_TARGET"):
+        with suppress(ValueError):
+            config.session.plugin_max_requests_per_target = int(v)
+    if v := os.environ.get("VULNCLAW_SESSION_EVIDENCE_MIN_REPORT_LEVEL"):
+        config.session.evidence_min_report_level = v
 
     # ── Safety ───────────────────────────────────────────────────────
     if v := os.environ.get("VULNCLAW_SAFETY_PYTHON_EXECUTE_ENABLED"):

--- a/vulnclaw/plugins/__init__.py
+++ b/vulnclaw/plugins/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from vulnclaw.plugins.base import PluginContext, VulnPlugin
+from vulnclaw.plugins.registry import PluginRegistry, registry
+from vulnclaw.plugins.result import (
+    PluginFinding,
+    PluginPhase,
+    PluginResult,
+    PluginRisk,
+    PluginStage,
+    RiskLevel,
+)
+from vulnclaw.plugins.runtime import PluginRequest, PluginRuntime
+from vulnclaw.plugins.web import BUILTIN_WEB_PLUGINS
+
+
+def register_builtin_plugins() -> None:
+    for plugin_cls in BUILTIN_WEB_PLUGINS:
+        registry.register(plugin_cls, replace=True)
+
+
+def create_builtin_runtime(
+    config: object = None,
+    *,
+    allowed_targets: set[str] | None = None,
+) -> PluginRuntime:
+    register_builtin_plugins()
+    return PluginRuntime(registry, config=config, allowed_targets=allowed_targets)
+
+
+register_builtin_plugins()
+
+__all__ = [
+    "BUILTIN_WEB_PLUGINS",
+    "PluginContext",
+    "PluginFinding",
+    "PluginPhase",
+    "PluginRegistry",
+    "PluginRequest",
+    "PluginResult",
+    "PluginRisk",
+    "PluginRuntime",
+    "PluginStage",
+    "RiskLevel",
+    "VulnPlugin",
+    "create_builtin_runtime",
+    "register_builtin_plugins",
+    "registry",
+]

--- a/vulnclaw/plugins/base.py
+++ b/vulnclaw/plugins/base.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, Field
+
+from vulnclaw.plugins.result import PluginResult, PluginStage, RiskLevel
+
+
+class PluginContext(BaseModel):
+    target: str = ""
+    stage: PluginStage = PluginStage.DISCOVERY
+    options: dict[str, Any] = Field(default_factory=dict)
+    state: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    timeout_seconds: float | None = Field(default=None, gt=0)
+    allow_destructive: bool = False
+    scope_targets: set[str] = Field(default_factory=set)
+    task_constraints: Any = None
+
+
+class VulnPlugin(ABC):
+    plugin_id: ClassVar[str]
+    name: ClassVar[str] = ""
+    version: ClassVar[str] = "0.1.0"
+    description: ClassVar[str] = ""
+    stages: ClassVar[tuple[PluginStage, ...]] = (PluginStage.DISCOVERY,)
+    default_risk: ClassVar[RiskLevel] = RiskLevel.INFO
+    enabled: ClassVar[bool] = True
+    destructive: ClassVar[bool] = False
+    requires_target: ClassVar[bool] = False
+    timeout_seconds: ClassVar[float | None] = None
+    tags: ClassVar[tuple[str, ...]] = ()
+    request_cost: ClassVar[int] = 1
+
+    @classmethod
+    def metadata(cls) -> dict[str, Any]:
+        return {
+            "plugin_id": cls.plugin_id,
+            "name": cls.name or cls.plugin_id,
+            "version": cls.version,
+            "description": cls.description,
+            "stages": [stage.value for stage in cls.stages],
+            "default_risk": cls.default_risk.value,
+            "enabled": cls.enabled,
+            "destructive": cls.destructive,
+            "requires_target": cls.requires_target,
+            "tags": list(cls.tags),
+        }
+
+    @abstractmethod
+    def run(self, context: PluginContext) -> PluginResult:
+        raise NotImplementedError

--- a/vulnclaw/plugins/integration.py
+++ b/vulnclaw/plugins/integration.py
@@ -1,0 +1,93 @@
+"""插件结果 → SessionState.findings 的桥接层。
+
+把插件输出的 PluginFinding 转换为 Agent 使用的 VulnerabilityFinding，
+并按 finding_id 去重合并进 SessionState，使插件结果进入报告生成链路。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from vulnclaw.agent.context import SessionState, VulnerabilityFinding
+from vulnclaw.plugins.result import PluginFinding, PluginResult, RiskLevel
+
+# 插件风险等级 → 漏洞严重度（与 VulnerabilityFinding.severity 取值对齐）
+RISK_TO_SEVERITY: dict[RiskLevel, str] = {
+    RiskLevel.INFO: "Info",
+    RiskLevel.LOW: "Low",
+    RiskLevel.MEDIUM: "Medium",
+    RiskLevel.HIGH: "High",
+    RiskLevel.CRITICAL: "Critical",
+}
+
+
+def _evidence_level_for(confidence: float) -> str:
+    """按置信度粗略映射证据等级（插件未主动联网验证，最高给 L2）。"""
+    if confidence >= 0.8:
+        return "L2"
+    return "L1"
+
+
+def plugin_finding_to_vuln_finding(
+    finding: PluginFinding,
+    *,
+    plugin_id: str = "",
+) -> VulnerabilityFinding:
+    """把单条 PluginFinding 转换为 VulnerabilityFinding。"""
+    evidence_obj = finding.evidence or {}
+    try:
+        evidence_text = (
+            json.dumps(evidence_obj, ensure_ascii=False)
+            if isinstance(evidence_obj, (dict, list))
+            else str(evidence_obj)
+        )
+    except (TypeError, ValueError):
+        evidence_text = str(evidence_obj)
+
+    source = plugin_id or finding.metadata.get("plugin_id", "")
+    description = finding.description
+    if source:
+        prefix = f"[插件:{source}] "
+        description = f"{prefix}{description}" if description else prefix.strip()
+
+    return VulnerabilityFinding(
+        title=finding.title,
+        severity=RISK_TO_SEVERITY.get(finding.risk, "Info"),
+        vuln_type=finding.vuln_type,
+        description=description,
+        evidence=evidence_text[:500],
+        remediation=finding.remediation,
+        evidence_level=_evidence_level_for(finding.confidence),
+        lifecycle_status="pending_verification",
+    )
+
+
+def merge_plugin_results_into_session(
+    session: SessionState,
+    results: PluginResult | list[PluginResult],
+) -> int:
+    """把一批插件结果中的 finding 合并进 session，返回新增（去重后）数量。"""
+    if isinstance(results, PluginResult):
+        results = [results]
+
+    added = 0
+    for result in results:
+        for finding in result.findings:
+            vuln = plugin_finding_to_vuln_finding(finding, plugin_id=result.plugin_id)
+            if session.add_finding(vuln):
+                added += 1
+    return added
+
+
+def summarize_plugin_results(results: list[PluginResult]) -> dict[str, Any]:
+    """汇总一批插件结果，供 CLI / 报告展示。"""
+    findings = sum(len(result.findings) for result in results)
+    errors = [result for result in results if result.error and not result.skipped]
+    skipped = [result for result in results if result.skipped]
+    return {
+        "plugins": len(results),
+        "findings": findings,
+        "errors": len(errors),
+        "skipped": len(skipped),
+    }

--- a/vulnclaw/plugins/registry.py
+++ b/vulnclaw/plugins/registry.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+from vulnclaw.plugins.base import VulnPlugin
+from vulnclaw.plugins.result import PluginStage
+
+PluginType = TypeVar("PluginType", bound=type[VulnPlugin])
+
+
+class PluginRegistry:
+    def __init__(self) -> None:
+        self._plugins: dict[str, type[VulnPlugin]] = {}
+
+    def register(self, plugin_cls: PluginType, *, replace: bool = False) -> PluginType:
+        plugin_id = getattr(plugin_cls, "plugin_id", "")
+        if not plugin_id:
+            raise ValueError("Plugin class must define plugin_id")
+        if plugin_id in self._plugins and not replace:
+            raise ValueError(f"Plugin already registered: {plugin_id}")
+        self._plugins[plugin_id] = plugin_cls
+        return plugin_cls
+
+    def unregister(self, plugin_id: str) -> None:
+        self._plugins.pop(plugin_id, None)
+
+    def clear(self) -> None:
+        self._plugins.clear()
+
+    def get(self, plugin_id: str) -> type[VulnPlugin] | None:
+        return self._plugins.get(plugin_id)
+
+    def require(self, plugin_id: str) -> type[VulnPlugin]:
+        plugin_cls = self.get(plugin_id)
+        if plugin_cls is None:
+            raise KeyError(f"Plugin not found: {plugin_id}")
+        return plugin_cls
+
+    def list(self) -> list[type[VulnPlugin]]:
+        return list(self._plugins.values())
+
+    def names(self) -> list[str]:
+        return sorted(self._plugins)
+
+    def metadata(self) -> list[dict[str, object]]:
+        return [plugin_cls.metadata() for plugin_cls in self._plugins.values()]
+
+    def by_stage(self, stage: PluginStage | str) -> list[type[VulnPlugin]]:
+        stage_value = PluginStage(stage) if isinstance(stage, str) else stage
+        return [plugin_cls for plugin_cls in self._plugins.values() if stage_value in plugin_cls.stages]
+
+    def by_tag(self, tag: str) -> list[type[VulnPlugin]]:
+        return [plugin_cls for plugin_cls in self._plugins.values() if tag in plugin_cls.tags]
+
+    @property
+    def count(self) -> int:
+        return len(self._plugins)
+
+
+registry = PluginRegistry()

--- a/vulnclaw/plugins/result.py
+++ b/vulnclaw/plugins/result.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RiskLevel(str, Enum):
+    INFO = "info"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class PluginStage(str, Enum):
+    RECON = "recon"
+    DISCOVERY = "discovery"
+    VERIFICATION = "verification"
+    EXPLOITATION = "exploitation"
+    POST_EXPLOITATION = "post_exploitation"
+    REPORTING = "reporting"
+
+
+PluginRisk = RiskLevel
+PluginPhase = PluginStage
+
+
+class PluginFinding(BaseModel):
+    title: str
+    risk: RiskLevel = RiskLevel.INFO
+    target: str = ""
+    vuln_type: str = ""
+    description: str = ""
+    evidence: dict[str, Any] = Field(default_factory=dict)
+    remediation: str = ""
+    references: list[str] = Field(default_factory=list)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class PluginResult(BaseModel):
+    plugin_id: str
+    stage: PluginStage = PluginStage.DISCOVERY
+    ok: bool = True
+    skipped: bool = False
+    findings: list[PluginFinding] = Field(default_factory=list)
+    messages: list[str] = Field(default_factory=list)
+    error: str | None = None
+    error_type: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    elapsed_seconds: float = 0.0
+    remaining_requests: int | None = None
+
+    @classmethod
+    def skipped_result(
+        cls,
+        plugin_id: str,
+        message: str,
+        *,
+        stage: PluginStage = PluginStage.DISCOVERY,
+        error_type: str = "skipped",
+        remaining_requests: int | None = None,
+    ) -> "PluginResult":
+        return cls(
+            plugin_id=plugin_id,
+            stage=stage,
+            ok=False,
+            skipped=True,
+            messages=[message],
+            error=message,
+            error_type=error_type,
+            remaining_requests=remaining_requests,
+        )
+
+    @classmethod
+    def error_result(
+        cls,
+        plugin_id: str,
+        message: str,
+        *,
+        stage: PluginStage = PluginStage.DISCOVERY,
+        error_type: str = "error",
+        remaining_requests: int | None = None,
+    ) -> "PluginResult":
+        return cls(
+            plugin_id=plugin_id,
+            stage=stage,
+            ok=False,
+            error=message,
+            error_type=error_type,
+            messages=[message],
+            remaining_requests=remaining_requests,
+        )

--- a/vulnclaw/plugins/runtime.py
+++ b/vulnclaw/plugins/runtime.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+from vulnclaw.agent.constraint_policy import validate_action_constraints
+from vulnclaw.plugins.base import PluginContext, VulnPlugin
+from vulnclaw.plugins.registry import PluginRegistry, registry
+from vulnclaw.plugins.result import PluginResult, PluginStage
+
+PluginRequest = PluginContext
+
+
+class PluginRuntime:
+    def __init__(
+        self,
+        plugin_registry: PluginRegistry | None = None,
+        *,
+        config: Any = None,
+        allowed_targets: set[str] | None = None,
+    ) -> None:
+        self.registry = plugin_registry or registry
+        self.config = config
+        self.allowed_targets = set(allowed_targets or ())
+        self._request_counts: dict[str, int] = {}
+
+    async def execute(
+        self,
+        plugin_id: str,
+        context: PluginContext | dict[str, Any] | None = None,
+    ) -> PluginResult:
+        normalized_context = self._coerce_context(context)
+        plugin_cls = self.registry.get(plugin_id)
+        stage = normalized_context.stage
+        started = time.monotonic()
+
+        gate = self._preflight(plugin_id, plugin_cls, normalized_context)
+        if gate is not None:
+            return gate
+
+        assert plugin_cls is not None
+        self._consume_budget(normalized_context.target, plugin_cls.request_cost)
+        remaining = self.remaining_requests(normalized_context.target)
+        timeout = self._timeout_for(plugin_cls, normalized_context)
+        plugin = plugin_cls()
+
+        try:
+            raw = plugin.run(normalized_context)
+            if inspect.isawaitable(raw):
+                raw = await asyncio.wait_for(raw, timeout=timeout)
+            elif timeout is not None:
+                raw = await asyncio.wait_for(asyncio.to_thread(lambda: raw), timeout=timeout)
+        except (asyncio.TimeoutError, TimeoutError):
+            # Python 3.10 下 asyncio.wait_for 抛 asyncio.TimeoutError（与内置 TimeoutError
+            # 不是同一类，3.11 起才合并），两者都捕获以保证跨版本一致
+            result = PluginResult.error_result(
+                plugin_id,
+                "Plugin execution timed out",
+                stage=stage,
+                error_type="timeout",
+                remaining_requests=remaining,
+            )
+        except Exception as exc:
+            result = PluginResult.error_result(
+                plugin_id,
+                f"{type(exc).__name__}: {exc}",
+                stage=stage,
+                error_type="error",
+                remaining_requests=remaining,
+            )
+        else:
+            result = self._coerce_result(plugin_id, raw, stage=stage, remaining_requests=remaining)
+
+        result.elapsed_seconds = time.monotonic() - started
+        return result
+
+    run = execute
+
+    def remaining_requests(self, target: str | None) -> int | None:
+        limit = self._max_requests_per_target()
+        if limit is None:
+            return None
+        return max(limit - self._request_counts.get(self._budget_key(target), 0), 0)
+
+    def _preflight(
+        self,
+        plugin_id: str,
+        plugin_cls: type[VulnPlugin] | None,
+        context: PluginContext,
+    ) -> PluginResult | None:
+        if not self._runtime_enabled():
+            return PluginResult.skipped_result(
+                plugin_id,
+                "Plugin runtime is disabled",
+                stage=context.stage,
+                error_type="disabled",
+            )
+
+        remaining = self.remaining_requests(context.target)
+        if plugin_cls is None:
+            return PluginResult.skipped_result(
+                plugin_id,
+                "Plugin was not found",
+                stage=context.stage,
+                error_type="not_found",
+                remaining_requests=remaining,
+            )
+
+        if not plugin_cls.enabled:
+            return PluginResult.skipped_result(
+                plugin_id,
+                "Plugin is disabled",
+                stage=context.stage,
+                error_type="disabled",
+                remaining_requests=remaining,
+            )
+
+        if plugin_cls.destructive and not context.allow_destructive:
+            return PluginResult.skipped_result(
+                plugin_id,
+                "Destructive plugin execution requires explicit permission",
+                stage=context.stage,
+                error_type="blocked",
+                remaining_requests=remaining,
+            )
+
+        target_error = self._target_error(plugin_cls, context)
+        if target_error is not None:
+            return PluginResult.skipped_result(
+                plugin_id,
+                target_error,
+                stage=context.stage,
+                error_type="target_blocked",
+                remaining_requests=remaining,
+            )
+
+        policy_error = self._policy_error(plugin_cls, context)
+        if policy_error is not None:
+            return PluginResult.skipped_result(
+                plugin_id,
+                policy_error,
+                stage=context.stage,
+                error_type="constraint_violation",
+                remaining_requests=remaining,
+            )
+
+        if remaining == 0:
+            return PluginResult.skipped_result(
+                plugin_id,
+                "Plugin request budget is exhausted for target",
+                stage=context.stage,
+                error_type="budget_exhausted",
+                remaining_requests=0,
+            )
+
+        return None
+
+    def _target_error(self, plugin_cls: type[VulnPlugin], context: PluginContext) -> str | None:
+        if plugin_cls.requires_target and not context.target:
+            return "Plugin requires a target"
+
+        target = context.target
+        if not target:
+            return None
+
+        host = self._host_for(target)
+        if self.allowed_targets and target not in self.allowed_targets and host not in self.allowed_targets:
+            return "Target is outside runtime scope"
+
+        if context.scope_targets and target not in context.scope_targets and host not in context.scope_targets:
+            return "Target is outside request scope"
+
+        return None
+
+    def _policy_error(self, plugin_cls: type[VulnPlugin], context: PluginContext) -> str | None:
+        constraints = context.task_constraints
+        if constraints is None or getattr(constraints, "is_empty", lambda: True)():
+            return None
+
+        action = self._action_for(plugin_cls, context.stage)
+        action_error = validate_action_constraints(action, constraints)
+        if action_error is not None:
+            return action_error
+
+        host = self._host_for(context.target)
+        port = self._port_for(context.target)
+        path = self._path_for(context.target)
+
+        if host:
+            allowed_hosts = set(getattr(constraints, "allowed_hosts", []) or [])
+            blocked_hosts = set(getattr(constraints, "blocked_hosts", []) or [])
+            if allowed_hosts and host not in allowed_hosts and context.target not in allowed_hosts:
+                return f"constraint_violation: host '{host}' is outside allowed hosts"
+            if host in blocked_hosts or context.target in blocked_hosts:
+                return f"constraint_violation: host '{host}' is blocked"
+
+        if port is not None:
+            allowed_ports = set(getattr(constraints, "allowed_ports", []) or [])
+            blocked_ports = set(getattr(constraints, "blocked_ports", []) or [])
+            if allowed_ports and port not in allowed_ports:
+                return f"constraint_violation: port '{port}' is outside allowed ports"
+            if port in blocked_ports:
+                return f"constraint_violation: port '{port}' is blocked"
+
+        if path:
+            allowed_paths = set(getattr(constraints, "allowed_paths", []) or [])
+            blocked_paths = set(getattr(constraints, "blocked_paths", []) or [])
+            if allowed_paths and path not in allowed_paths:
+                return f"constraint_violation: path '{path}' is outside allowed paths"
+            if path in blocked_paths:
+                return f"constraint_violation: path '{path}' is blocked"
+
+        return None
+
+    def _coerce_context(self, context: PluginContext | dict[str, Any] | None) -> PluginContext:
+        if context is None:
+            return PluginContext()
+        if isinstance(context, PluginContext):
+            return context
+        return PluginContext(**context)
+
+    def _coerce_result(
+        self,
+        plugin_id: str,
+        raw: Any,
+        *,
+        stage: PluginStage,
+        remaining_requests: int | None,
+    ) -> PluginResult:
+        if isinstance(raw, PluginResult):
+            raw.remaining_requests = remaining_requests
+            return raw
+        if isinstance(raw, dict):
+            return PluginResult(
+                plugin_id=plugin_id,
+                stage=stage,
+                metadata=dict(raw),
+                remaining_requests=remaining_requests,
+            )
+        return PluginResult(
+            plugin_id=plugin_id,
+            stage=stage,
+            metadata={"result": raw},
+            remaining_requests=remaining_requests,
+        )
+
+    def _runtime_enabled(self) -> bool:
+        return bool(self._session_value("plugin_runtime_enabled", True))
+
+    def _timeout_for(self, plugin_cls: type[VulnPlugin], context: PluginContext) -> float | None:
+        value = context.timeout_seconds or plugin_cls.timeout_seconds
+        if value is None:
+            value = self._session_value("plugin_default_timeout", None)
+        if value is None:
+            return None
+        return float(value)
+
+    def _max_requests_per_target(self) -> int | None:
+        value = self._session_value("plugin_max_requests_per_target", None)
+        if value is None:
+            return None
+        limit = int(value)
+        if limit < 1:
+            return None
+        return limit
+
+    def _consume_budget(self, target: str | None, cost: int) -> None:
+        key = self._budget_key(target)
+        self._request_counts[key] = self._request_counts.get(key, 0) + max(1, cost)
+
+    def _budget_key(self, target: str | None) -> str:
+        return target or "__global__"
+
+    def _session_value(self, name: str, default: Any) -> Any:
+        session = getattr(self.config, "session", self.config)
+        return getattr(session, name, default)
+
+    def _action_for(self, plugin_cls: type[VulnPlugin], stage: PluginStage) -> str:
+        if plugin_cls.destructive:
+            return "exploit"
+        if stage == PluginStage.RECON:
+            return "recon"
+        if stage == PluginStage.EXPLOITATION:
+            return "exploit"
+        if stage == PluginStage.POST_EXPLOITATION:
+            return "post_exploitation"
+        if stage == PluginStage.REPORTING:
+            return "report"
+        return "scan"
+
+    def _host_for(self, target: str) -> str:
+        if not target:
+            return ""
+        parsed = urlparse(target if "://" in target else f"//{target}")
+        return (parsed.hostname or target).lower().rstrip(".")
+
+    def _port_for(self, target: str) -> int | None:
+        if not target:
+            return None
+        parsed = urlparse(target if "://" in target else f"//{target}")
+        if parsed.port is not None:
+            return parsed.port
+        if parsed.scheme == "https":
+            return 443
+        if parsed.scheme == "http":
+            return 80
+        return None
+
+    def _path_for(self, target: str) -> str:
+        if not target:
+            return ""
+        parsed = urlparse(target if "://" in target else f"//{target}")
+        return parsed.path or ""

--- a/vulnclaw/plugins/web/__init__.py
+++ b/vulnclaw/plugins/web/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from vulnclaw.plugins.web.headers import SecurityHeadersPlugin
+from vulnclaw.plugins.web.js_endpoints import JavaScriptEndpointsPlugin
+from vulnclaw.plugins.web.jwt import JWTClaimsPlugin
+
+BUILTIN_WEB_PLUGINS = (
+    SecurityHeadersPlugin,
+    JWTClaimsPlugin,
+    JavaScriptEndpointsPlugin,
+)
+
+
+__all__ = [
+    "BUILTIN_WEB_PLUGINS",
+    "JWTClaimsPlugin",
+    "JavaScriptEndpointsPlugin",
+    "SecurityHeadersPlugin",
+]

--- a/vulnclaw/plugins/web/headers.py
+++ b/vulnclaw/plugins/web/headers.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from vulnclaw.plugins.base import PluginContext, VulnPlugin
+from vulnclaw.plugins.result import PluginFinding, PluginResult, PluginStage, RiskLevel
+
+IMPORTANT_HEADERS: dict[str, str] = {
+    "content-security-policy": "Define a restrictive Content-Security-Policy.",
+    "x-frame-options": "Set X-Frame-Options or use CSP frame-ancestors.",
+    "x-content-type-options": "Set X-Content-Type-Options to nosniff.",
+    "referrer-policy": "Set a privacy-aware Referrer-Policy.",
+    "strict-transport-security": "Set Strict-Transport-Security on HTTPS responses.",
+}
+
+
+class SecurityHeadersPlugin(VulnPlugin):
+    plugin_id = "builtin.web.headers"
+    name = "Security Headers"
+    version = "0.1.0"
+    description = "Analyze supplied HTTP response headers for common low-risk hardening gaps."
+    stages = (PluginStage.DISCOVERY, PluginStage.VERIFICATION)
+    default_risk = RiskLevel.LOW
+
+    def run(self, context: PluginContext) -> PluginResult:
+        headers = _normalize_headers(context.options.get("headers"))
+        if not headers:
+            return PluginResult(
+                plugin_id=self.plugin_id,
+                stage=context.stage,
+                messages=["No headers were supplied."],
+            )
+
+        findings: list[PluginFinding] = []
+        missing = [name for name in IMPORTANT_HEADERS if name not in headers]
+        if missing:
+            findings.append(
+                PluginFinding(
+                    title="Missing common security headers",
+                    risk=RiskLevel.LOW,
+                    target=context.target,
+                    vuln_type="security_headers",
+                    description="One or more common browser hardening headers were not present in the supplied headers.",
+                    evidence={"missing_headers": missing},
+                    remediation="Add the missing headers where they match the application's deployment model.",
+                    confidence=0.75,
+                )
+            )
+
+        weak_csp = _weak_csp_reason(headers.get("content-security-policy", ""))
+        if weak_csp:
+            findings.append(
+                PluginFinding(
+                    title="Weak Content-Security-Policy",
+                    risk=RiskLevel.LOW,
+                    target=context.target,
+                    vuln_type="security_headers",
+                    description=weak_csp,
+                    evidence={"content_security_policy": headers["content-security-policy"]},
+                    remediation=IMPORTANT_HEADERS["content-security-policy"],
+                    confidence=0.7,
+                )
+            )
+
+        hsts = headers.get("strict-transport-security", "")
+        if hsts and "max-age=0" in hsts.lower():
+            findings.append(
+                PluginFinding(
+                    title="Strict-Transport-Security disables HSTS",
+                    risk=RiskLevel.LOW,
+                    target=context.target,
+                    vuln_type="security_headers",
+                    description="The supplied Strict-Transport-Security header disables HSTS.",
+                    evidence={"strict_transport_security": hsts},
+                    remediation=IMPORTANT_HEADERS["strict-transport-security"],
+                    confidence=0.85,
+                )
+            )
+
+        return PluginResult(
+            plugin_id=self.plugin_id,
+            stage=context.stage,
+            findings=findings,
+            metadata={"checked_headers": sorted(headers)},
+        )
+
+
+def _normalize_headers(value: Any) -> dict[str, str]:
+    if isinstance(value, Mapping):
+        return {str(key).strip().lower(): str(item).strip() for key, item in value.items() if key}
+    return {}
+
+
+def _weak_csp_reason(value: str) -> str:
+    normalized = value.lower()
+    if not normalized:
+        return ""
+    if "'unsafe-inline'" in normalized or "'unsafe-eval'" in normalized:
+        return "The supplied Content-Security-Policy allows unsafe script execution patterns."
+    if "default-src" not in normalized and "script-src" not in normalized:
+        return "The supplied Content-Security-Policy does not define default-src or script-src."
+    return ""

--- a/vulnclaw/plugins/web/js_endpoints.py
+++ b/vulnclaw/plugins/web/js_endpoints.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+
+from vulnclaw.plugins.base import PluginContext, VulnPlugin
+from vulnclaw.plugins.result import PluginFinding, PluginResult, PluginStage, RiskLevel
+
+ENDPOINT_PATTERN = re.compile(
+    r"""(?P<quote>["'`])(?P<value>(?:https?://[^"'`\s<>()]+|/(?:api|admin|auth|graphql|v\d|static|assets|internal)[^"'`\s<>()]*))(?P=quote)""",
+    re.IGNORECASE,
+)
+SENSITIVE_WORDS = ("admin", "debug", "internal", "graphql", "token", "secret")
+
+
+class JavaScriptEndpointsPlugin(VulnPlugin):
+    plugin_id = "builtin.web.js_endpoints"
+    name = "JavaScript Endpoints"
+    version = "0.1.0"
+    description = "Extract interesting endpoints from supplied JavaScript content."
+    stages = (PluginStage.RECON, PluginStage.DISCOVERY)
+    default_risk = RiskLevel.INFO
+
+    def run(self, context: PluginContext) -> PluginResult:
+        content = str(context.options.get("content") or "")
+        if not content:
+            return PluginResult(
+                plugin_id=self.plugin_id,
+                stage=context.stage,
+                messages=["No content was supplied."],
+            )
+
+        endpoints = sorted({match.group("value").rstrip(".,;") for match in ENDPOINT_PATTERN.finditer(content)})
+        if not endpoints:
+            return PluginResult(
+                plugin_id=self.plugin_id,
+                stage=context.stage,
+                messages=["No endpoints were found."],
+            )
+
+        interesting = [
+            endpoint
+            for endpoint in endpoints
+            if any(word in endpoint.lower() for word in SENSITIVE_WORDS)
+        ]
+        finding = PluginFinding(
+            title="JavaScript endpoints discovered",
+            risk=RiskLevel.INFO,
+            target=context.target,
+            vuln_type="javascript_endpoint_discovery",
+            description="The supplied JavaScript content contains endpoints useful for manual review.",
+            evidence={"endpoints": endpoints, "interesting_endpoints": interesting},
+            remediation="Review discovered endpoints for exposure, authorization, and environment leakage.",
+            confidence=0.8,
+        )
+        return PluginResult(
+            plugin_id=self.plugin_id,
+            stage=context.stage,
+            findings=[finding],
+            metadata={"endpoint_count": len(endpoints)},
+        )

--- a/vulnclaw/plugins/web/jwt.py
+++ b/vulnclaw/plugins/web/jwt.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from vulnclaw.plugins.base import PluginContext, VulnPlugin
+from vulnclaw.plugins.result import PluginFinding, PluginResult, PluginStage, RiskLevel
+
+
+class JWTClaimsPlugin(VulnPlugin):
+    plugin_id = "builtin.web.jwt"
+    name = "JWT Claims"
+    version = "0.1.0"
+    description = "Analyze a supplied JWT without verifying signatures or making network calls."
+    stages = (PluginStage.DISCOVERY, PluginStage.VERIFICATION)
+    default_risk = RiskLevel.LOW
+
+    def run(self, context: PluginContext) -> PluginResult:
+        token = str(context.options.get("token") or "").strip()
+        if not token:
+            return PluginResult(
+                plugin_id=self.plugin_id,
+                stage=context.stage,
+                messages=["No token was supplied."],
+            )
+
+        decoded = _decode_jwt(token)
+        if decoded is None:
+            return PluginResult(
+                plugin_id=self.plugin_id,
+                stage=context.stage,
+                ok=False,
+                error="Invalid JWT format.",
+            )
+
+        header, payload = decoded
+        findings: list[PluginFinding] = []
+        algorithm = str(header.get("alg", "")).lower()
+        if algorithm in {"", "none"}:
+            findings.append(
+                PluginFinding(
+                    title="JWT uses an unsigned or missing algorithm",
+                    risk=RiskLevel.LOW,
+                    target=context.target,
+                    vuln_type="jwt",
+                    description="The supplied token header does not require a signing algorithm.",
+                    evidence={"alg": header.get("alg")},
+                    remediation="Reject unsigned tokens and enforce an expected signing algorithm.",
+                    confidence=0.9,
+                )
+            )
+
+        missing_claims = [claim for claim in ("exp", "iat", "iss", "aud") if claim not in payload]
+        if missing_claims:
+            findings.append(
+                PluginFinding(
+                    title="JWT is missing common validation claims",
+                    risk=RiskLevel.LOW,
+                    target=context.target,
+                    vuln_type="jwt",
+                    description="The supplied token payload lacks claims commonly used during validation.",
+                    evidence={"missing_claims": missing_claims},
+                    remediation="Require appropriate issuer, audience, issued-at, and expiration validation.",
+                    confidence=0.75,
+                )
+            )
+
+        return PluginResult(
+            plugin_id=self.plugin_id,
+            stage=context.stage,
+            findings=findings,
+            metadata={
+                "header_keys": sorted(str(key) for key in header),
+                "payload_keys": sorted(str(key) for key in payload),
+            },
+        )
+
+
+def _decode_jwt(token: str) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        header = _decode_segment(parts[0])
+        payload = _decode_segment(parts[1])
+    except (ValueError, TypeError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(header, dict) or not isinstance(payload, dict):
+        return None
+    return header, payload
+
+
+def _decode_segment(segment: str) -> Any:
+    padding = "=" * (-len(segment) % 4)
+    raw = base64.urlsafe_b64decode(f"{segment}{padding}")
+    return json.loads(raw.decode("utf-8"))


### PR DESCRIPTION
## 概述
重构了自主渗透的核心循环引擎。之前是固定轮数的工作流——跑满 18 轮才停，弱模型经常卡在重复操作里空转；现在改成按目标驱动，达成目标、或者实在没有新方向可探索时就自动收敛，不再死磕轮数。顺带把推理、反思、插件这几块配套能力补齐了，并修复了 #45。

## 主要改动

### 目标驱动求解引擎
- Fact/Intent 黑板图 + OODA 循环（REASON 提方向 → EXPLORE 用工具执行 → 结论写回 Fact）。终止条件为「目标达成 / 探索前沿耗尽 / 安全预算」，不再是固定轮数，结构上杜绝原地打转。
- 证据级反幻觉：录制全部真实工具输出作为唯一可信证据；声称的 flag/完成必须在真实输出里逐字符出现才采信，否则判为幻觉并继续；验证过的 flag 即时收敛。新增 `vulnclaw solve`；`run`/REPL 默认走 solve（`session.engine=rounds` 回退旧逻辑）。

### 结构化推理 + 自适应反思
- 事实（带置信度）/约束/攻击链结构化沉淀并注入提示词。
- 失败自动归类 + L0–L4 渐进式 payload 升级；persistent 跨周期保留失败记忆。

### 漏洞检测插件体系
- 低耦合插件运行时 + 内置只读 Web 插件，结果汇入 findings/报告。新增 `vulnclaw plugins list/info/run`。

### 修复 #45 工具被误约束
- 动作约束不再把 HTTP 方法（OPTIONS/POST）或使用 requests 误判为「利用」；仅实际攻击载荷（SQLi/RCE/路径穿越等）算 exploit；`load_skill_reference` / `crypto_decode` 等纯本地工具豁免范围约束。

## 兼容性
- 旧固定轮数引擎完整保留（`session.engine=rounds`）。
- 新增 `session.engine` / `solve_*` / `reflexion_*` / `plugin_*` 配置均带默认值，支持环境变量注入。引擎