### PR TITLE
fix(web): 修复 py3.10 下任务流式循环超时未捕获导致中断

### DIFF
--- a/vulnclaw/web/task_manager.py
+++ b/vulnclaw/web/task_manager.py
@@ -127,7 +127,9 @@ class WebTaskManager:
             try:
                 item = await asyncio.wait_for(queue.get(), timeout=0.5)
                 yield item
-            except TimeoutError:
+            except (asyncio.TimeoutError, TimeoutError):
+                # Python 3.10 下 asyncio.wait_for 抛 asyncio.TimeoutError（3.11 起才与
+                # 内置 TimeoutError 合并），两者都捕获以保证流式循环跨版本不中断
                 continue
 
     def bind_runtime_task(self, task_id: str, task: asyncio.Task) -> None:


### PR DESCRIPTION
## 问题
`web/task_manager.py` 的流式输出循环用 `except TimeoutError` 接 `asyncio.wait_for` 的轮询超时。但 Python 3.10 下 `asyncio.wait_for` 抛的是 `asyncio.TimeoutError`（3.11 起才和内置 `TimeoutError` 合并），所以 3.10 上每次轮询超时不会被接住，异常会逐出异步生成器、直接中断流式推送。

## 修复
改成 `except (asyncio.TimeoutError, TimeoutError)`，3.10 / 3.11+ 都能正常续跑。

> 与 #52 中 `plugins/runtime.py` 是同一类（py3.10 timeout）问题的另一处，独立修复。