### PR TITLE
feat: 并行探索 / 信息收集工具链 / MCP streamable-http

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -515,7 +515,7 @@ class TestMCPLifecycleManager:
         manager._start_server(
             "chrome-devtools", MCPServerConfig(**BUILTIN_MCP_SERVERS["chrome-devtools"])
         )
-        result = await manager.call_tool("navigate", {"url": "https://example.com"})
+        result = await manager.call_tool("chrome_navigate", {"url": "https://example.com"})
 
         assert result["ok"] is False
         assert result["server"] == "chrome-devtools"

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -222,7 +222,7 @@ class TestAutoRestart:
         m.registry.register_server("chrome-devtools")
         m.registry.register_tool(
             "chrome-devtools",
-            {"name": "navigate", "description": "", "inputSchema": {"type": "object"}},
+            {"name": "chrome_navigate", "description": "", "inputSchema": {"type": "object"}},
         )
         m.config.mcp.servers["chrome-devtools"] = MCPServerConfig(
             **BUILTIN_MCP_SERVERS["chrome-devtools"]
@@ -247,7 +247,7 @@ class TestAutoRestart:
         monkeypatch.setattr(m, "_restart_server", fake_restart)
         monkeypatch.setattr(m, "_get_or_create_persistent_stdio_session", fake_session)
 
-        await m.call_tool("navigate", {"url": "https://example.com"})
+        await m.call_tool("chrome_navigate", {"url": "https://example.com"})
 
         assert restarted["called"] is True
 
@@ -361,6 +361,83 @@ class TestStats:
         stats = m.registry.get_server_stats("memory")
         assert stats["call_count"] == 1
         assert stats["avg_latency_ms"] >= 0.0
+
+
+def _http_server_config(name: str = "streamable-mcp-server") -> MCPServerConfig:
+    return MCPServerConfig(
+        name=name,
+        enabled=True,
+        transport={"type": "streamable-http", "url": "http://127.0.0.1:12306/mcp"},
+    )
+
+
+class TestStreamableHttp:
+    def test_attach_success_registers_known_tools(self, monkeypatch):
+        m = _manager()
+        cfg = _http_server_config("chrome-devtools")
+        m.config.mcp.servers["chrome-devtools"] = cfg
+        m.registry.register_server("chrome-devtools")
+
+        monkeypatch.setattr(m, "_check_http_reachable", lambda url, timeout: True)
+
+        assert m._start_server("chrome-devtools", cfg) is True
+        state = m.registry.get_all_servers()["chrome-devtools"]
+        assert state.running is True
+        assert state.execution_mode == "http"
+        assert state.health_status == HealthStatus.HEALTHY.value
+        # Static known tools registered at startup; real tools discovered lazily on first call
+        assert "chrome_navigate" in m.list_available_tools()
+
+    def test_attach_failure_degrades_and_falls_back(self, monkeypatch):
+        m = _manager()
+        cfg = _http_server_config("chrome-devtools")
+        m.config.mcp.servers["chrome-devtools"] = cfg
+        m.registry.register_server("chrome-devtools")
+
+        monkeypatch.setattr(m, "_check_http_reachable", lambda url, timeout: False)
+
+        assert m._start_server("chrome-devtools", cfg) is True
+        state = m.registry.get_all_servers()["chrome-devtools"]
+        assert state.running is False
+        assert state.health_status == HealthStatus.DEGRADED.value
+        assert "chrome_navigate" in m.list_available_tools()
+
+    async def test_get_or_create_session_dispatches_http(self, monkeypatch):
+        m = _manager()
+        m.config.mcp.servers["streamable-mcp-server"] = _http_server_config()
+        sentinel = object()
+
+        async def fake_http(name):
+            assert name == "streamable-mcp-server"
+            return sentinel
+
+        monkeypatch.setattr(m, "_get_or_create_persistent_http_session", fake_http)
+        got = await m._get_or_create_session("streamable-mcp-server")
+        assert got is sentinel
+
+    async def test_call_tool_routes_streamable_http_server(self, monkeypatch):
+        m = _manager()
+        m.config.mcp.servers["streamable-mcp-server"] = _http_server_config()
+        m.registry.register_server("streamable-mcp-server")
+        m.registry.register_tool(
+            "streamable-mcp-server",
+            {"name": "do_thing", "description": "", "inputSchema": {"type": "object"}},
+        )
+        m.registry.set_server_execution_mode("streamable-mcp-server", "http")
+
+        class DummySession:
+            async def call_tool(self, tool_name, arguments=None):
+                return {"echo": tool_name, "args": arguments}
+
+        async def fake_http(name):
+            return DummySession()
+
+        monkeypatch.setattr(m, "_get_or_create_persistent_http_session", fake_http)
+
+        result = await m.call_tool("do_thing", {"x": 1})
+        assert result["ok"] is True
+        assert result["server"] == "streamable-mcp-server"
+        assert "do_thing" in str(result["content"])
 
 
 def test_smoke_event_loop_isolation():

--- a/tests/test_recon_tools.py
+++ b/tests/test_recon_tools.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from vulnclaw.agent import recon_tools
+from vulnclaw.config.schema import ReconConfig, VulnClawConfig
+
+
+def _agent(recon: ReconConfig | None = None):
+    cfg = VulnClawConfig()
+    if recon is not None:
+        cfg.recon = recon
+    return SimpleNamespace(config=cfg, session_state=SimpleNamespace(task_constraints=None))
+
+
+class _Resp:
+    def __init__(self, *, json_data=None, text="", content=b"", status=200, headers=None):
+        self._json = json_data
+        self.text = text
+        self.content = content or text.encode()
+        self.status_code = status
+        self.headers = headers or {}
+
+    def json(self):
+        return self._json
+
+
+class _FakeClient:
+    """Minimal httpx.AsyncClient stand-in driven by a routing callable."""
+
+    def __init__(self, router):
+        self._router = router
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, params=None, headers=None):
+        return self._router("GET", url, params, None)
+
+    async def post(self, url, headers=None, content=None):
+        return self._router("POST", url, None, content)
+
+
+# ── JS 提取（纯函数）────────────────────────────────────────────────
+
+
+def test_extract_from_js_pulls_paths_domains_secrets():
+    content = """
+        var api = "/api/v1/user/list";
+        fetch("https://cdn.example.com/static/app.js");
+        const k = {api_key: "AKIAABCDEFGHIJKLMNOP"};
+        let t = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36";
+        url: "/admin/login.action"
+    """
+    out = recon_tools.extract_from_js(content, base_host="example.com")
+    assert "/api/v1/user/list" in out["paths"]
+    assert "/admin/login.action" in out["paths"]
+    assert "cdn.example.com" in out["domains"]
+    assert any("aws_ak" in s for s in out["secrets"])
+    assert any("jwt" in s for s in out["secrets"])
+
+
+def test_extract_from_js_infers_rest_crud_from_base_and_entity():
+    """base path + entity name → CRUD 动词推断（修复 User/list、Org/list 漏判）。"""
+    content = """
+        var baseUrl = "/jalis/rest";
+        var smBase = "/smweb/rest";
+        var entity = "User";
+        var org = "Org";
+    """
+    out = recon_tools.extract_from_js(content)
+    paths = out["paths"]
+    assert "/jalis/rest/User/list" in paths
+    assert "/jalis/rest/Org/list" in paths
+    assert "/smweb/rest/User/list" in paths
+    assert "/smweb/rest/Org/list" in paths
+
+
+def test_extract_from_js_discovers_dynamic_entities():
+    """PascalCase 实体名动态提取——不依赖硬编码实体列表。"""
+    content = """
+        var base = "/smweb/rest";
+        url: "AppRoleService";
+        var c = "Count";
+        var art = "Article";
+    """
+    out = recon_tools.extract_from_js(content)
+    paths = out["paths"]
+    assert "/smweb/rest/AppRoleService/list" in paths
+    assert "/smweb/rest/Count/list" in paths
+    assert "/smweb/rest/Article/list" in paths
+
+
+def test_extract_from_js_captures_short_fragments():
+    """不以 / 开头的 REST 片段（如 "User/list"）也要提取。"""
+    content = """$.post(baseUrl + "User/list", data);"""
+    out = recon_tools.extract_from_js(content)
+    assert any("User/list" in p for p in out["paths"])
+
+
+def test_extract_from_js_captures_framework_verb_variants():
+    """listForLayUI / getAllByType 等框架变体也匹配。"""
+    content = """$.post(base + "Article/listForLayUI", data);"""
+    out = recon_tools.extract_from_js(content)
+    assert any("Article/listForLayUI" in p for p in out["paths"])
+
+
+# ── 空间测绘：查询构造 + 解析 ───────────────────────────────────────
+
+
+async def test_space_search_fofa_builds_b64_query_and_parses(monkeypatch):
+    captured = {}
+
+    def router(method, url, params, content):
+        captured["url"] = url
+        captured["params"] = params
+        # FOFA results: [host, ip, port, title, domain, server, protocol]
+        return _Resp(json_data={
+            "error": False, "size": 1,
+            "results": [["http://t.example.com", "1.2.3.4", "80", "Home", "example.com", "nginx", "http"]],
+        })
+
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(router))
+    agent = _agent(ReconConfig(fofa_email="a@b.com", fofa_key="k"))
+    res = await recon_tools.execute_space_search(agent, {"engine": "fofa", "domain": "example.com"})
+
+    assert "fofa.info" in captured["url"]
+    # qbase64 should decode to domain="example.com"
+    import base64
+    assert base64.b64decode(captured["params"]["qbase64"]).decode() == 'domain="example.com"'
+    assert "1.2.3.4" in res and "example.com" in res
+
+
+async def test_space_search_missing_key_reports_gracefully(monkeypatch):
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(lambda *a: _Resp()))
+    agent = _agent(ReconConfig())  # no keys
+    res = await recon_tools.execute_space_search(agent, {"engine": "fofa", "domain": "x.com"})
+    assert "未配置" in res
+
+
+async def test_space_search_quake_uses_token_header_and_post(monkeypatch):
+    seen = {}
+
+    def router(method, url, params, content):
+        seen["method"] = method
+        seen["body"] = json.loads(content) if content else None
+        return _Resp(json_data={
+            "code": 0, "meta": {"pagination": {"total": 1}},
+            "data": [{"ip": "9.9.9.9", "port": 443, "domain": "x.com",
+                      "service": {"name": "http", "http": {"title": "T", "host": "x.com"}}}],
+        })
+
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(router))
+    agent = _agent(ReconConfig(quake_key="tok"))
+    res = await recon_tools.execute_space_search(agent, {"engine": "quake", "query": 'domain:"x.com"'})
+    assert seen["method"] == "POST"
+    assert seen["body"]["query"] == 'domain:"x.com"'
+    assert "9.9.9.9" in res
+
+
+# ── 目录枚举：全局伪装 200 识别 ─────────────────────────────────────
+
+
+async def test_dir_enum_aborts_on_global_200(monkeypatch):
+    def router(method, url, params, content):
+        # 任何路径都返回 200 → 伪装
+        return _Resp(text="ok", status=200)
+
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(router))
+    agent = _agent(ReconConfig())
+    res = await recon_tools.execute_dir_enum(agent, {"url": "http://t.example.com"})
+    assert "终止" in res and "200" in res
+
+
+async def test_dir_enum_filters_and_reports_hits(monkeypatch):
+    def router(method, url, params, content):
+        if "vulnclaw_nope" in url:
+            return _Resp(text="not found", status=404)
+        if url.rstrip("/").endswith("/admin"):
+            return _Resp(text="ADMIN PANEL " * 20, status=200)
+        return _Resp(text="nope", status=404)
+
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(router))
+    agent = _agent(ReconConfig())
+    res = await recon_tools.execute_dir_enum(agent, {"url": "http://t.example.com"})
+    assert "/admin" in res
+    assert "[200]" in res
+
+
+async def test_dir_enum_respects_host_constraint(monkeypatch):
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(lambda *a: _Resp()))
+    agent = _agent(ReconConfig())
+    # constrain scope to a different host
+    agent.session_state.task_constraints = SimpleNamespace(
+        is_empty=lambda: False,
+        allowed_hosts=["only-this.com"], blocked_hosts=[],
+        allowed_paths=[], blocked_paths=[],
+    )
+    res = await recon_tools.execute_dir_enum(agent, {"url": "http://t.example.com"})
+    assert "constraint_violation" in res
+
+
+# ── 子域名枚举：被动聚合 + 字典爆破关闭时不解析 ─────────────────────
+
+
+async def test_unauth_classify():
+    assert recon_tools._classify_unauth(401, "x", "")[1] is False
+    assert recon_tools._classify_unauth(403, "x", "")[1] is False
+    assert recon_tools._classify_unauth(404, "x", "")[1] is False
+    # 200 returning JSON data → lead
+    v, lead = recon_tools._classify_unauth(200, '{"users":[1,2,3]}', "application/json")
+    assert lead is True and "未授权" in v
+    # 200 but login page → not a lead
+    v2, lead2 = recon_tools._classify_unauth(200, "请登录后访问", "text/html")
+    assert lead2 is False
+
+
+async def test_unauth_test_skips_destructive_and_flags_data(monkeypatch):
+    def router(method, url, params, content):
+        if url.endswith("/api/user/list"):
+            return _Resp(json_data=None, text='{"data":[{"uid":1}]}', status=200)
+        if url.endswith("/api/user/profile"):
+            return _Resp(text="<html>请登录</html>", status=200)
+        return _Resp(text="nope", status=404)
+
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(router))
+    # patch content-type via header — _FakeClient returns _Resp; add headers attr
+    agent = _agent(ReconConfig())
+    res = await recon_tools.execute_unauth_test(agent, {
+        "base_url": "http://t.example.com",
+        "endpoints": ["/api/user/list", "/api/user/profile", "/api/user/delete?id=1"],
+    })
+    assert "跳过(破坏性接口)" in res  # delete endpoint skipped
+    assert "/api/user/list" in res
+
+
+async def test_js_recon_auto_probes_endpoints(monkeypatch):
+    calls = {"n": 0}
+
+    def router(method, url, params, content):
+        calls["n"] += 1
+        if url.endswith("/index.html") or url.endswith("t.example.com/"):
+            return _Resp(text='<script src="/app.js"></script>', status=200)
+        if url.endswith("/app.js"):
+            return _Resp(text='fetch("/api/v1/admin/users")', status=200)
+        if "/api/v1/admin/users" in url:
+            return _Resp(text='{"ok":true}', status=200)
+        return _Resp(text="x", status=404)
+
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(router))
+    agent = _agent(ReconConfig())
+    res = await recon_tools.execute_js_recon(agent, {"url": "http://t.example.com/index.html"})
+    # discovered endpoint should appear in the auto unauth-probe section
+    assert "未授权访问探测" in res
+    assert "/api/v1/admin/users" in res
+
+
+async def test_subdomain_enum_passive_only(monkeypatch):
+    def router(method, url, params, content):
+        return _Resp(json_data={
+            "error": False, "size": 2,
+            "results": [
+                ["http://api.example.com", "1.1.1.1", "80", "", "api.example.com", "", ""],
+                ["http://mail.example.com", "2.2.2.2", "443", "", "mail.example.com", "", ""],
+            ],
+        })
+
+    monkeypatch.setattr(recon_tools, "_make_client", lambda cfg: _FakeClient(router))
+    agent = _agent(ReconConfig(fofa_email="a@b.com", fofa_key="k"))
+    res = await recon_tools.execute_subdomain_enum(agent, {"domain": "example.com", "brute": False})
+    assert "api.example.com" in res
+    assert "mail.example.com" in res

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 from vulnclaw.agent import solver
@@ -8,7 +9,11 @@ from vulnclaw.agent.blackboard import Blackboard, IntentStatus
 
 def _fake_agent(tool_outputs: list[str] | None = None):
     state = SimpleNamespace(board=Blackboard(), save=lambda: None)
-    context = SimpleNamespace(state=state, add_user_message=lambda *a: None)
+    context = SimpleNamespace(
+        state=state,
+        add_user_message=lambda *a: None,
+        add_assistant_message=lambda *a: None,
+    )
     queue = list(tool_outputs or [])
 
     async def _execute(tool_name, tool_args):
@@ -156,6 +161,96 @@ async def test_solve_rejects_ungrounded_completion(monkeypatch):
     assert "complete_rejected" in events
 
 
+async def test_solve_rejects_negated_completion_claim(monkeypatch):
+    """模型把「未达成」写进 complete 字段 → 绝不能误判达成（复现 i004 误报）。"""
+    reason_calls = {"n": 0}
+
+    async def fake_reason(agent, board, max_intents):
+        reason_calls["n"] += 1
+        if reason_calls["n"] == 1:
+            # complete=true 但 reason 是否定结论（应被否定闸门拦截）
+            return {
+                "complete": True,
+                "reason": "f001 仅确认端口与指纹，未达到 goal 要求的渗透完成标准",
+                "evidence": ["f001"],
+            }
+        return {"complete": False}  # 之后不再提出 → 前沿耗尽
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        return True, "x"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(),
+        origin="t",
+        goal="渗透分析站点",  # 非 flag 目标，旧逻辑无任何闸门会误判达成
+        max_steps=10,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert result.completed is False
+    assert "complete_rejected" in events
+    assert "completed" not in events
+
+
+async def test_solve_rejects_completion_without_explicit_bool(monkeypatch):
+    """旧式 {"complete": "<文字>"}（非显式 true）一律按未达成处理。"""
+
+    async def fake_reason(agent, board, max_intents):
+        return {"complete": "我认为已经分析完了"}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        return True, "x"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(),
+        origin="t",
+        goal="渗透分析站点",
+        max_steps=10,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert result.completed is False
+    assert "complete_rejected" in events
+
+
+async def test_solve_completes_nonflag_goal_with_evidence(monkeypatch):
+    """非 flag 目标：complete=true + 无否定理由 + 引用真实 fact → 正常达成。"""
+
+    async def fake_reason(agent, board, max_intents):
+        return {
+            "complete": True,
+            "reason": "f001 已确认存在未授权访问接口，目标达成",
+            "evidence": ["f001"],
+        }
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
+        return True, "x"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(),
+        origin="t",
+        goal="检测未授权访问",
+        max_steps=10,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert result.completed is True
+    assert "completed" in events
+    assert "未授权访问" in result.board.complete_reason
+
+
 async def test_solve_stops_when_frontier_exhausted(monkeypatch):
     async def fake_reason_noop(agent, board, max_intents):
         return {}  # never proposes intents
@@ -198,9 +293,12 @@ async def test_solve_abandons_unproductive_intent(monkeypatch):
 
 
 async def test_solve_respects_safety_step_budget(monkeypatch):
+    counter = {"n": 0}
+
     async def fake_reason(agent, board, max_intents):
-        # always propose a fresh intent -> would loop forever without the cap
-        return {"intents": [{"from": [], "description": "endless"}]}
+        counter["n"] += 1
+        # each intent has a unique description to avoid dedup filtering
+        return {"intents": [{"from": [], "description": f"unique direction {counter['n']}"}]}
 
     async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
         return True, "step fact"
@@ -213,3 +311,184 @@ async def test_solve_respects_safety_step_budget(monkeypatch):
     assert result.completed is False
     assert result.reason == "触达安全预算上限"
     assert result.steps == 3
+
+
+# ── Parallel exploration tests ──────────────────────────────────────
+
+
+async def test_solve_parallel_explores_multiple_intents(monkeypatch):
+    """3 intents proposed → all 3 explored concurrently → each produces a fact."""
+    reason_calls = {"n": 0}
+
+    async def fake_reason(agent, board, max_intents):
+        reason_calls["n"] += 1
+        if reason_calls["n"] == 1:
+            return {"intents": [
+                {"from": [], "description": "sqli probe"},
+                {"from": [], "description": "xss probe"},
+                {"from": [], "description": "ssrf probe"},
+            ]}
+        return {"complete": True, "reason": "all probed", "evidence": ["f001"]}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None, skip_context_write=False):
+        await asyncio.sleep(0)
+        return True, f"found via {intent.description}"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(), origin="t", goal="test", max_steps=10, max_parallel=3,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert events.count("explore_start") == 3
+    concluded = [i for i in result.board.intents if i.status == IntentStatus.CONCLUDED]
+    assert len(concluded) == 3
+
+
+async def test_solve_parallel_evidence_isolation(monkeypatch):
+    """Each parallel worker gets its own evidence buffer, no cross-contamination."""
+    collected_evidence: dict[str, list[str]] = {}
+
+    async def fake_reason(agent, board, max_intents):
+        if not board.intents:
+            return {"intents": [
+                {"from": [], "description": "path A"},
+                {"from": [], "description": "path B"},
+            ]}
+        return {}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None, skip_context_write=False):
+        marker = f"evidence_for_{intent.id}"
+        evidence_buffer.append(marker)
+        collected_evidence[intent.id] = list(evidence_buffer)
+        await asyncio.sleep(0)
+        return True, f"result {intent.id}"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    await solver.solve(_fake_agent(), origin="t", goal="g", max_steps=10, max_parallel=2)
+
+    if "i001" in collected_evidence and "i002" in collected_evidence:
+        assert "evidence_for_i002" not in collected_evidence["i001"]
+        assert "evidence_for_i001" not in collected_evidence["i002"]
+
+
+async def test_solve_parallel_one_failure_others_continue(monkeypatch):
+    """One intent raises an exception, others complete normally."""
+    async def fake_reason(agent, board, max_intents):
+        if not board.intents:
+            return {"intents": [
+                {"from": [], "description": "will fail"},
+                {"from": [], "description": "will succeed"},
+            ]}
+        return {}
+
+    call_count = {"n": 0}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None, skip_context_write=False):
+        call_count["n"] += 1
+        if "fail" in intent.description:
+            raise RuntimeError("simulated crash")
+        return True, "success result"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(), origin="t", goal="g", max_steps=10, max_parallel=2,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert "error" in events
+    concluded = [i for i in result.board.intents if i.status == IntentStatus.CONCLUDED]
+    abandoned = [i for i in result.board.intents if i.status == IntentStatus.ABANDONED]
+    assert len(concluded) == 1
+    assert len(abandoned) >= 1
+
+
+async def test_solve_parallel_board_fact_ids_sequential(monkeypatch):
+    """Concurrent conclude operations produce unique, sequential fact IDs."""
+    async def fake_reason(agent, board, max_intents):
+        if not board.intents:
+            return {"intents": [
+                {"from": [], "description": f"dir {i}"} for i in range(3)
+            ]}
+        return {}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None, skip_context_write=False):
+        await asyncio.sleep(0)
+        return True, f"fact from {intent.id}"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    result = await solver.solve(_fake_agent(), origin="t", goal="g", max_steps=10, max_parallel=3)
+
+    fact_ids = [f.id for f in result.board.facts]
+    assert len(fact_ids) == len(set(fact_ids)), f"duplicate fact IDs: {fact_ids}"
+
+
+async def test_solve_serial_fallback(monkeypatch):
+    """With only 1 open intent, solve takes the serial path (no gather overhead)."""
+    async def fake_reason(agent, board, max_intents):
+        if not board.intents:
+            return {"intents": [{"from": [], "description": "single path"}]}
+        return {}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None, skip_context_write=False):
+        return True, "serial result"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    result = await solver.solve(_fake_agent(), origin="t", goal="g", max_steps=10, max_parallel=3)
+
+    concluded = [i for i in result.board.intents if i.status == IntentStatus.CONCLUDED]
+    assert len(concluded) == 1
+
+
+async def test_solve_parallel_max_caps_batch(monkeypatch):
+    """max_parallel=2 caps the batch even when 3 intents are open."""
+    explored_intents: list[str] = []
+
+    async def fake_reason(agent, board, max_intents):
+        if not board.intents:
+            return {"intents": [
+                {"from": [], "description": f"path {i}"} for i in range(3)
+            ]}
+        return {}
+
+    async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None, skip_context_write=False):
+        explored_intents.append(intent.id)
+        return True, f"done {intent.id}"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    await solver.solve(_fake_agent(), origin="t", goal="g", max_steps=10, max_parallel=2)
+
+    assert len(explored_intents) == 3
+
+
+# ── Blackboard seq restore test ─────────────────────────────────────
+
+
+def test_blackboard_seq_restores_from_existing_facts():
+    """After deserialisation, fact/intent seq counters recover from existing items."""
+    board = Blackboard()
+    board.add_fact("first", source="test")
+    board.add_fact("second", source="test")
+    board.add_intent("intent one")
+
+    data = board.model_dump()
+    restored = Blackboard.model_validate(data)
+
+    new_fact = restored.add_fact("third", source="test")
+    assert new_fact.id == "f003"
+    new_intent = restored.add_intent("intent two")
+    assert new_intent.id == "i002"

--- a/vulnclaw/agent/blackboard.py
+++ b/vulnclaw/agent/blackboard.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -37,22 +38,45 @@ class BoardIntent(BaseModel):
     note: str = ""  # 放弃原因 / 备注
 
 
+class ToolCallRecord(BaseModel):
+    """已执行工具调用的紧凑记录——防止跨 intent 重复调用同一工具+同一参数。"""
+    tool: str
+    key_args: str = ""
+    intent_id: str = ""
+    status: int = 0
+    note: str = ""
+
+
 class Blackboard(BaseModel):
-    """Fact/Intent 图。从 origin 增长到 goal。"""
+    """Fact/Intent 图。从 origin 增长到 goal。
+
+    参考 Cairn：除了 Fact/Intent，还维护一份 **tool_calls 执行日志**，
+    每次 explore 中调用的工具都会记录到这里。Reason 和 Explore 的上下文
+    prompt 均包含此日志的摘要，使 LLM 能看到"已经做过什么"并避免重复。
+    """
 
     origin: str = ""
     goal: str = ""
     facts: list[BoardFact] = Field(default_factory=list)
     intents: list[BoardIntent] = Field(default_factory=list)
+    tool_calls: list[ToolCallRecord] = Field(default_factory=list)
     completed: bool = False
     complete_reason: str = ""
-    _fact_seq: int = 0
-    _intent_seq: int = 0
+    fact_seq: int = Field(default=0, exclude=True)
+    intent_seq: int = Field(default=0, exclude=True)
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.facts and self.fact_seq == 0:
+            nums = [int(f.id[1:]) for f in self.facts if f.id[1:].isdigit()]
+            self.fact_seq = max(nums) if nums else len(self.facts)
+        if self.intents and self.intent_seq == 0:
+            nums = [int(i.id[1:]) for i in self.intents if i.id[1:].isdigit()]
+            self.intent_seq = max(nums) if nums else len(self.intents)
 
     # ── Fact ────────────────────────────────────────────────────────
     def add_fact(self, description: str, source: str = "") -> BoardFact:
-        self._fact_seq += 1
-        fact = BoardFact(id=f"f{self._fact_seq:03d}", description=description.strip(), source=source)
+        self.fact_seq += 1
+        fact = BoardFact(id=f"f{self.fact_seq:03d}", description=description.strip(), source=source)
         self.facts.append(fact)
         return fact
 
@@ -64,10 +88,10 @@ class Blackboard(BaseModel):
 
     # ── Intent ──────────────────────────────────────────────────────
     def add_intent(self, description: str, from_facts: list[str] | None = None) -> BoardIntent:
-        self._intent_seq += 1
+        self.intent_seq += 1
         valid_from = [fid for fid in (from_facts or []) if self.get_fact(fid)]
         intent = BoardIntent(
-            id=f"i{self._intent_seq:03d}",
+            id=f"i{self.intent_seq:03d}",
             from_facts=valid_from,
             description=description.strip(),
         )
@@ -112,6 +136,37 @@ class Blackboard(BaseModel):
         self.completed = True
         self.complete_reason = reason.strip()
 
+    # ── Tool call memory ───────────────────────────────────────────
+    def record_tool_call(
+        self, tool: str, key_args: str, intent_id: str = "",
+        status: int = 0, note: str = "",
+    ) -> None:
+        self.tool_calls.append(ToolCallRecord(
+            tool=tool, key_args=key_args[:200], intent_id=intent_id,
+            status=status, note=note[:120],
+        ))
+        if len(self.tool_calls) > 200:
+            del self.tool_calls[:100]
+
+    def has_called(self, tool: str, key_args: str) -> bool:
+        return any(
+            tc.tool == tool and tc.key_args == key_args[:200]
+            for tc in self.tool_calls
+        )
+
+    def tool_call_summary(self, max_lines: int = 40) -> str:
+        if not self.tool_calls:
+            return ""
+        seen: dict[str, str] = {}
+        for tc in self.tool_calls:
+            key = f"{tc.tool}({tc.key_args})"
+            if key not in seen:
+                seen[key] = f"  {tc.intent_id or '-'}: {tc.tool}({tc.key_args})" + (
+                    f" → {tc.note}" if tc.note else ""
+                )
+        lines = list(seen.values())[-max_lines:]
+        return "\n".join(lines)
+
     # ── 渲染 ────────────────────────────────────────────────────────
     def to_prompt_graph(self, *, include_concluded: bool = True) -> str:
         """把图渲染成给 LLM 阅读的紧凑文本（YAML 风格）。"""
@@ -135,6 +190,11 @@ class Blackboard(BaseModel):
                 lines.append(f"  - {intent.id} [{intent.status.value}]{frm}{res}: {intent.description}{note}")
         else:
             lines.append("  (暂无)")
+
+        tc_summary = self.tool_call_summary(30)
+        if tc_summary:
+            lines.append("executed_tools (禁止重复调用已执行的工具+参数):")
+            lines.append(tc_summary)
 
         return "\n".join(lines)
 

--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -129,6 +129,21 @@ async def execute_mcp_tool(agent: Any, tool_name: str, args: dict[str, Any]) -> 
     if tool_name == "brute_force_login":
         return await execute_brute_force(agent, args)
 
+    if tool_name in {"space_search", "subdomain_enum", "js_recon", "dir_enum", "unauth_test"}:
+        from vulnclaw.agent import recon_tools
+
+        dispatch = {
+            "space_search": recon_tools.execute_space_search,
+            "subdomain_enum": recon_tools.execute_subdomain_enum,
+            "js_recon": recon_tools.execute_js_recon,
+            "dir_enum": recon_tools.execute_dir_enum,
+            "unauth_test": recon_tools.execute_unauth_test,
+        }
+        try:
+            return await dispatch[tool_name](agent, args)
+        except Exception as e:
+            return f"[!] 工具执行错误 ({tool_name}): {e}"
+
     if not agent.mcp_manager:
         return f"[!] MCP 管理器未初始化，无法执行工具: {tool_name}"
 
@@ -156,7 +171,10 @@ async def execute_mcp_tool(agent: Any, tool_name: str, args: dict[str, Any]) -> 
                 return f"[{error_type}] {message}\n[suggestion] {suggestion}".strip()
             return f"[{error_type}] {message}".strip()
 
-        return str(result)
+        text = str(result)
+        if text.strip() in ("undefined", "null", "None"):
+            return f"[!] 工具 {tool_name} 返回空结果 (undefined)，调用可能失败"
+        return text
     except Exception as e:
         return f"[!] 工具执行错误 ({tool_name}): {e}"
 
@@ -455,6 +473,163 @@ def build_openai_tools(mcp_manager: Any) -> list[dict[str, Any]]:
                         },
                     },
                     "required": ["url", "password_field", "passwords"],
+                },
+            },
+        }
+    )
+
+    tools.append(
+        {
+            "type": "function",
+            "function": {
+                "name": "space_search",
+                "description": (
+                    "空间测绘资产搜索（FOFA/Hunter/Quake/Shodan/ZoomEye/0.zone 零零信安）。"
+                    "信息收集阶段用于被动发现目标资产、IP、端口、子域、标题、组件指纹，不直接接触目标。"
+                    "给 domain 自动按各引擎语法构造 domain 查询；也可传完整 query 语法。"
+                    "engine=all 时并发查询所有已配置 key 的引擎。"
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "engine": {
+                            "type": "string",
+                            "description": "fofa/hunter/quake/shodan/zoomeye/zerozone/all，默认 fofa",
+                        },
+                        "query": {
+                            "type": "string",
+                            "description": "引擎原生查询语法，如 'domain=\"x.com\"'、'app=\"Struts2\"'（可选）",
+                        },
+                        "domain": {
+                            "type": "string",
+                            "description": "目标主域名，自动构造各引擎 domain 查询（query 未给时使用）",
+                        },
+                        "size": {"type": "integer", "description": "返回条数，默认 100"},
+                    },
+                },
+            },
+        }
+    )
+
+    tools.append(
+        {
+            "type": "function",
+            "function": {
+                "name": "subdomain_enum",
+                "description": (
+                    "子域名枚举。先用已配置的空间测绘引擎被动聚合，再用内置小字典做 DNS 解析爆破，"
+                    "返回去重后的存活子域名列表。优先于 python_execute 自己写爆破。"
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "domain": {"type": "string", "description": "主域名，如 nju.edu.cn"},
+                        "brute": {
+                            "type": "boolean",
+                            "description": "是否启用内置字典 DNS 爆破（默认 true）",
+                        },
+                    },
+                    "required": ["domain"],
+                },
+            },
+        }
+    )
+
+    tools.append(
+        {
+            "type": "function",
+            "function": {
+                "name": "js_recon",
+                "description": (
+                    "JS 信息收集（参考 URLFinder）。抓取目标页面及其引用的全部 .js 文件，"
+                    "提取 API 接口/路径、关联域名、绝对 URL，以及疑似硬编码密钥（AK/SK、token、JWT、私钥等）。"
+                    "默认 auto_probe=true：自动对收集到的同源接口逐个做未授权访问探测（仅安全 GET，跳过破坏性接口）。"
+                    "信息收集阶段优先调用，用真实提取的端点反哺后续测试，而非凭空猜接口。"
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "目标页面 URL"},
+                        "max_js": {
+                            "type": "integer",
+                            "description": "最多抓取的 JS 文件数（默认 30）",
+                        },
+                        "auto_probe": {
+                            "type": "boolean",
+                            "description": "是否自动对收集到的接口做未授权探测（默认 true）",
+                        },
+                        "auth_header": {
+                            "type": "string",
+                            "description": "可选鉴权头做差分对比，如 'Authorization: Bearer xxx'，验证无 token 是否也能拿到数据",
+                        },
+                    },
+                    "required": ["url"],
+                },
+            },
+        }
+    )
+
+    tools.append(
+        {
+            "type": "function",
+            "function": {
+                "name": "unauth_test",
+                "description": (
+                    "未授权访问探测。对一批接口（通常来自 js_recon 收集的端点）逐个无凭据请求，"
+                    "按状态码/响应体/内容类型判定：⚠疑似未授权(返回数据) / ✓已鉴权拦截 / ↪跳转登录 / —不存在。"
+                    "提供 auth_header 时做有/无 token 差分对比，无 token 也能拿到同样数据则判定 🔴未授权确认。"
+                    "严守读写分离：仅发安全 GET，自动跳过 delete/update/sms 等破坏性接口，不批量遍历 ID。"
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "base_url": {"type": "string", "description": "目标基础 URL（确定同源范围）"},
+                        "endpoints": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "待测接口路径/URL 列表（来自 js_recon 的接口/路径）",
+                        },
+                        "auth_header": {
+                            "type": "string",
+                            "description": "可选鉴权头做差分，如 'Authorization: Bearer xxx' 或 'Cookie: session=...'",
+                        },
+                        "max_endpoints": {
+                            "type": "integer",
+                            "description": "最多探测的接口数（默认 60）",
+                        },
+                    },
+                    "required": ["base_url", "endpoints"],
+                },
+            },
+        }
+    )
+
+    tools.append(
+        {
+            "type": "function",
+            "function": {
+                "name": "dir_enum",
+                "description": (
+                    "目录/文件枚举（参考 dirsearch）。并发字典爆破，自带 404 基线与全局伪装响应识别"
+                    "（随机路径返回 200 即判定伪装并停止）、状态码与响应长度过滤。"
+                    "仅做安全的 GET 探测，不碰 delete/update 等破坏性路径。"
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "目标基础 URL，如 https://x.com/"},
+                        "extensions": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "扩展名展开，如 ['php','jsp','bak','zip']（可选）",
+                        },
+                        "wordlist": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "追加的自定义路径（基于命名规律的启发式字典，可选）",
+                        },
+                    },
+                    "required": ["url"],
                 },
             },
         }

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -430,6 +430,7 @@ class AgentCore:
 
         resolved_goal = goal or user_input
         origin = detected_target or self.context.state.target or user_input
+        max_parallel = getattr(self.config.session, "solve_max_parallel", 1)
         return await run_solve(
             self,
             origin=origin,
@@ -437,6 +438,7 @@ class AgentCore:
             max_steps=max_steps,
             max_intents=max_intents,
             max_tool_rounds=max_tool_rounds,
+            max_parallel=max_parallel,
             stream_sink=stream_sink,
             on_event=on_event,
         )

--- a/vulnclaw/agent/prompts.py
+++ b/vulnclaw/agent/prompts.py
@@ -256,11 +256,20 @@ RECON_INSTRUCTION = """\
 | `syn` | SYN 半开扫描（需管理员权限） |
 示例：`nmap_scan(target="192.168.1.1", scan_type="service", timing=4)`
 
+**⭐ 信息收集专用内置工具（优先于 python_execute 手写爆破/抓取）**
+- 空间测绘资产发现 → `space_search(engine="fofa"|"hunter"|"quake"|"shodan"|"all", domain="目标主域")`：被动获取 IP/端口/子域/指纹，不接触目标
+- 子域名枚举 → `subdomain_enum(domain="目标主域")`：空间测绘被动聚合 + 字典 DNS 爆破，自动去重
+- JS 信息收集 → `js_recon(url="目标URL")`：抓页面+全部 .js，提取 API 接口/路径/关联域名/硬编码密钥，**默认自动对收集到的接口做未授权探测**，用真实端点反哺后续测试
+- 未授权访问验证 → `unauth_test(base_url, endpoints=[...])`：对 JS/目录收集到的接口逐个无凭据请求，判定是否未授权可访问；给 auth_header 可做有/无 token 差分确认
+- 目录/文件枚举 → `dir_enum(url="目标URL", extensions=["php","jsp","bak","zip"])`：并发字典爆破，自带 404 基线与全局伪装识别、状态码过滤
+> 标准链路：`js_recon` 拿接口 →（自动/手动）`unauth_test` 逐个验未授权 → `dir_enum` 补攻击面 → 有主域再 `subdomain_enum`/`space_search` 扩面。**JS 里收集到的每个接口都要过一遍未授权**，不要只列不测，也不要用 python_execute 凭空猜接口。
+
 ### 维度二：网站信息
 - [ ] 网站架构（OS + 中间件 + 数据库 + 语言 + 框架 → 完整技术栈）
 - [ ] Web 指纹（CMS 类型、前端框架、JS 库、模板引擎）
 - [ ] WAF 检测（wafw00f 逻辑 + 响应特征匹配 — WAF 拦截页面/特殊响应头）
-- [ ] 敏感目录 & 敏感文件（常见目录字典 + 状态码筛选 200/403/401）
+- [ ] 敏感目录 & 敏感文件（用 `dir_enum`：字典爆破 + 状态码筛选 200/403/401）
+- [ ] JS 端点/密钥提取（用 `js_recon`：API 路径、关联域名、硬编码 AK/SK/token/JWT）
 - [ ] 源码泄露（.git/.svn/.DS_Store/.env/web.config/备份文件/.bak/.swp/.old）
 - [ ] 旁站查询（同 IP 反查域名 — 同服务器上的其他站点）
 - [ ] C 段查询（同网段存活主机扫描 — 255 个 IP 探测）
@@ -268,7 +277,7 @@ RECON_INSTRUCTION = """\
 ### 维度三：域名信息
 - [ ] WHOIS 注册信息（注册人/注册商/NS 服务器/注册日期/到期日期）
 - [ ] ICP 备案信息（工信部备案查询 — 仅中国大陆域名）
-- [ ] 子域名发现（crt.sh + 爆破 + 搜索引擎 + DNS 区域传送）
+- [ ] 子域名发现（用 `subdomain_enum` / `space_search`：空间测绘 + 爆破 + crt.sh）
 - [ ] DNS 记录全量（A/CNAME/MX/TXT/NS/SPF/SOA）
 - [ ] 证书透明度日志（crt.sh / Censys / certspotter）
 - [ ] **子域名渗透**：发现子域名后，主动对每个子域名进行渗透测试（端口扫描 + Web 指纹 + 漏洞发现）

--- a/vulnclaw/agent/recon_tools.py
+++ b/vulnclaw/agent/recon_tools.py
@@ -1,0 +1,858 @@
+"""Information-gathering tools: space-mapping, subdomain/JS/dir enumeration.
+
+These are built-in agent tools (wired in builtin_tools.py) that give the agent
+real reconnaissance capability instead of guessing:
+
+- space_search      统一空间测绘 (FOFA / Hunter / Quake / Shodan / ZoomEye / 0.zone)
+- subdomain_enum    子域名枚举 (空间测绘被动聚合 + 可选小字典 DNS 爆破)
+- js_recon          JS 信息收集 (参考 URLFinder：抓 JS 提端点/域名/密钥)
+- dir_enum          目录枚举 (参考 dirsearch：并发字典爆破 + 404 基线/伪装识别)
+
+设计原则：被动优先、严格遵守 host/path/port 约束、所有外呼带超时与并发上限、
+绝不在源码里硬编码任何 API key（从 config.recon 或环境变量读取）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import re
+import socket
+from datetime import datetime, timedelta
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+from vulnclaw.agent.builtin_tools import enforce_host_path_constraints
+
+# ── 内置目录字典（紧凑版；config.recon.dir_wordlist_path 可覆盖为大字典）────────
+_BUILTIN_DIR_WORDLIST: tuple[str, ...] = (
+    # 后台 / 管理
+    "admin", "admin/login", "administrator", "manage", "manager", "backend", "system",
+    "console", "ht", "qd", "dashboard", "admin.php", "admin.jsp", "admin.do", "login",
+    "login.jsp", "login.php", "login.action", "signin", "auth", "sso", "cas",
+    # API / 文档
+    "api", "api/v1", "api/v2", "v1", "v2", "graphql", "swagger", "swagger-ui.html",
+    "swagger/index.html", "v2/api-docs", "openapi.json", "api-docs", "actuator",
+    "actuator/env", "actuator/health", "druid", "druid/index.html",
+    # 配置 / 调试 / 信息泄露
+    "config", "config.json", "config.php", "configuration", "env", ".env", ".git/config",
+    ".git/HEAD", ".svn/entries", ".DS_Store", "debug", "test", "demo", "info", "info.php",
+    "phpinfo.php", "status", "health", "metrics", "monitor", "console", "server-status",
+    "robots.txt", "sitemap.xml", "crossdomain.xml", "web.config", "WEB-INF/web.xml",
+    # 备份 / 临时
+    "backup", "backup.zip", "backup.tar.gz", "bak", "old", "www.zip", "web.zip",
+    "site.zip", "data.zip", "db.sql", "database.sql", "dump.sql", "test.txt", "1.txt",
+    # 上传 / 文件
+    "upload", "uploads", "files", "file", "download", "static", "assets", "public",
+    "tmp", "temp", "images", "img", "data", "doc", "docs",
+    # 业务常见（中英混杂拼音）
+    "user", "users", "member", "hy", "order", "dd", "pay", "payment", "list", "index",
+    "home", "main", "portal", "wx", "mp", "xcx", "miniprogram", "h5", "mobile",
+)
+
+# ── 端点提取正则（参考 URLFinder）──────────────────────────────────────────────
+_URL_RE = re.compile(r"""https?://[a-zA-Z0-9.\-]+(?::\d+)?(?:/[^\s"'`<>()\\{}|^]*)?""")
+# 宽泛路径提取：任何引号内以 / 开头、含 2+ 段的路径（参考 URLFinder 的宽匹配策略）
+_PATH_RE = re.compile(
+    r"""(?P<q>["'`])(?P<v>/[a-zA-Z0-9_\-]+/[a-zA-Z0-9_\-./?=&%]*)(?P=q)""",
+    re.IGNORECASE,
+)
+# 短片段提取：不以 / 开头但看起来像 REST 端点的引号内字符串（如 "User/list"）
+# 动词后允许跟 ForXxx / All / ById 等框架变体（listForLayUI、getAllByType...）
+_FRAG_RE = re.compile(
+    r"""(?P<q>["'`])(?P<v>[A-Za-z][A-Za-z0-9_]*/(?:list|save|get|add|edit|delete|update|"""
+    r"""detail|query|search|info|check|export|import|download|upload|count|page|batch|"""
+    r"""remove|create|modify|status|enable|disable|reset|send|verify|login|logout|"""
+    r"""register|authorize|token|refresh|config|setting|menu|role|permission|tree|"""
+    r"""all|find|select|insert|submit|audit|approve|reject|publish|cancel|close|open|"""
+    r"""start|stop|run|execute|invoke|call|notify|push|pull|sync|async)"""
+    r"""(?:[A-Z][a-zA-Z0-9]*)*"""
+    r"""[a-zA-Z0-9_\-./?=&%]*)(?P=q)""",
+    re.IGNORECASE,
+)
+# REST base path 提取：如 "/jalis/rest"、"/smweb/rest"、"/api/v1"
+_BASE_PATH_RE = re.compile(
+    r"""(?P<q>["'`])(?P<v>/[a-zA-Z0-9_\-]+/(?:rest|api(?:/v\d+)?))(?P=q)""",
+    re.IGNORECASE,
+)
+_SCRIPT_SRC_RE = re.compile(r"""<script[^>]+src=["']?([^"'\s>]+)""", re.IGNORECASE)
+
+# CRUD 动词模板——与 base path 和 JS 中出现的实体名排列组合
+_CRUD_VERBS = ("list", "get", "save", "add", "delete", "update", "detail", "query",
+               "info", "export", "tree", "page", "count", "all", "search")
+# 动态实体名提取：从 JS 中找所有 PascalCase 标识符（首字母大写、2+ 字母），
+# 而非硬编码实体列表——任何业务实体都能被捕获
+_PASCAL_CASE_RE = re.compile(
+    r"""(?P<q>["'`])(?P<v>[A-Z][a-zA-Z0-9]{1,30}(?:[A-Z][a-zA-Z0-9]*)*)(?P=q)"""
+)
+
+# 敏感信息 / 凭证泄露指纹
+_SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("aws_ak", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("google_api", re.compile(r"AIza[0-9A-Za-z_\-]{35}")),
+    ("jwt", re.compile(r"eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}")),
+    ("private_key", re.compile(r"-----BEGIN (?:RSA|EC|DSA|OPENSSH|PRIVATE) ?(?:PRIVATE )?KEY-----")),
+    ("generic_key", re.compile(
+        r"""(?i)(?:api[_-]?key|access[_-]?key|secret[_-]?key|app[_-]?secret|token|password|passwd)"""
+        r"""["'`]?\s*[:=]\s*["'`]([A-Za-z0-9_\-]{12,64})["'`]"""
+    )),
+    ("aliyun_ak", re.compile(r"LTAI[0-9A-Za-z]{12,24}")),
+)
+
+
+def _get_recon_cfg(agent: Any) -> Any:
+    from vulnclaw.config.schema import ReconConfig
+
+    cfg = getattr(getattr(agent, "config", None), "recon", None)
+    return cfg if cfg is not None else ReconConfig()
+
+
+def _b64(text: str) -> str:
+    return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def _host_of(url_or_host: str) -> str:
+    if "://" in url_or_host:
+        return (urlparse(url_or_host).hostname or "").lower()
+    return url_or_host.split("/")[0].split(":")[0].lower()
+
+
+def _dedup_cap(items: list[str], cap: int) -> list[str]:
+    return list(dict.fromkeys(i for i in items if i))[:cap]
+
+
+# ── 空间测绘引擎 ───────────────────────────────────────────────────────────────
+
+
+async def _engine_fofa(client: Any, query: str, size: int, cfg: Any) -> tuple[list[dict], str]:
+    if not (cfg.fofa_email and cfg.fofa_key):
+        return [], "fofa: 未配置 fofa_email/fofa_key"
+    fields = "host,ip,port,title,domain,server,protocol"
+    params = {
+        "email": cfg.fofa_email,
+        "key": cfg.fofa_key,
+        "qbase64": _b64(query),
+        "fields": fields,
+        "size": str(min(size, 10000)),
+    }
+    r = await client.get("https://fofa.info/api/v1/search/all", params=params)
+    data = r.json()
+    if data.get("error"):
+        return [], f"fofa: {data.get('errmsg', 'error')}"
+    recs = []
+    for row in data.get("results", []) or []:
+        row = (list(row) + [""] * 7)[:7]
+        recs.append({
+            "host": row[0], "ip": row[1], "port": row[2], "title": row[3],
+            "domain": row[4], "server": row[5], "url": row[0],
+        })
+    return recs, f"fofa: {data.get('size', len(recs))} 命中"
+
+
+async def _engine_hunter(client: Any, query: str, size: int, cfg: Any) -> tuple[list[dict], str]:
+    if not cfg.hunter_key:
+        return [], "hunter: 未配置 hunter_key"
+    end = datetime.now()
+    start = end - timedelta(days=365)
+    params = {
+        "api-key": cfg.hunter_key,
+        "search": _b64(query),
+        "page": "1",
+        # Hunter 仅接受 [10,100] 的 page_size，过小会报「页面大小不合法」
+        "page_size": str(min(max(size, 10), 100)),
+        "is_web": "3",
+        "start_time": start.strftime("%Y-%m-%d"),
+        "end_time": end.strftime("%Y-%m-%d"),
+    }
+    r = await client.get("https://hunter.qianxin.com/openApi/search", params=params)
+    data = r.json()
+    if data.get("code") != 200:
+        return [], f"hunter: {data.get('message', data.get('code'))}"
+    arr = (data.get("data") or {}).get("arr") or []
+    recs = []
+    for it in arr:
+        recs.append({
+            "host": it.get("url") or it.get("domain", ""), "ip": it.get("ip", ""),
+            "port": it.get("port", ""), "title": it.get("web_title", ""),
+            "domain": it.get("domain", ""), "server": it.get("component", ""),
+            "url": it.get("url", ""),
+        })
+    return recs, f"hunter: {(data.get('data') or {}).get('total', len(recs))} 命中"
+
+
+async def _engine_quake(client: Any, query: str, size: int, cfg: Any) -> tuple[list[dict], str]:
+    if not cfg.quake_key:
+        return [], "quake: 未配置 quake_key"
+    body = {"query": query, "start": 0, "size": min(size, 100), "ignore_cache": True}
+    r = await client.post(
+        "https://quake.360.net/api/v3/search/quake_service",
+        headers={"X-QuakeToken": cfg.quake_key, "Content-Type": "application/json"},
+        content=json.dumps(body),
+    )
+    data = r.json()
+    if data.get("code") not in (0, "0"):
+        return [], f"quake: {data.get('message', data.get('code'))}"
+    recs = []
+    for it in data.get("data", []) or []:
+        svc = it.get("service", {}) or {}
+        http = svc.get("http", {}) or {}
+        recs.append({
+            "host": http.get("host") or it.get("ip", ""), "ip": it.get("ip", ""),
+            "port": it.get("port", ""), "title": http.get("title", ""),
+            "domain": it.get("domain", ""), "server": svc.get("name", ""),
+            "url": http.get("host", ""),
+        })
+    return recs, f"quake: {(data.get('meta') or {}).get('pagination', {}).get('total', len(recs))} 命中"
+
+
+async def _engine_shodan(client: Any, query: str, size: int, cfg: Any) -> tuple[list[dict], str]:
+    if not cfg.shodan_key:
+        return [], "shodan: 未配置 shodan_key"
+    r = await client.get(
+        "https://api.shodan.io/shodan/host/search",
+        params={"key": cfg.shodan_key, "query": query},
+    )
+    data = r.json()
+    if "matches" not in data:
+        return [], f"shodan: {data.get('error', 'no matches')}"
+    recs = []
+    for it in data.get("matches", []):
+        hostnames = it.get("hostnames") or []
+        recs.append({
+            "host": (hostnames[0] if hostnames else it.get("ip_str", "")),
+            "ip": it.get("ip_str", ""), "port": it.get("port", ""),
+            "title": (it.get("http", {}) or {}).get("title", ""),
+            "domain": ",".join(it.get("domains") or []),
+            "server": it.get("product", ""), "url": (hostnames[0] if hostnames else ""),
+        })
+    return recs, f"shodan: {data.get('total', len(recs))} 命中"
+
+
+async def _engine_zoomeye(client: Any, query: str, size: int, cfg: Any) -> tuple[list[dict], str]:
+    if not cfg.zoomeye_key:
+        return [], "zoomeye: 未配置 zoomeye_key"
+    body = {"qbase64": _b64(query), "page": 1, "pagesize": min(size, 100)}
+    r = await client.post(
+        "https://api.zoomeye.org/v2/search",
+        headers={"API-KEY": cfg.zoomeye_key, "Content-Type": "application/json"},
+        content=json.dumps(body),
+    )
+    data = r.json()
+    if data.get("code") not in (60000, 0, None) and "data" not in data:
+        return [], f"zoomeye: {data.get('message', data.get('code'))}"
+    recs = []
+    for it in data.get("data", []) or []:
+        recs.append({
+            "host": it.get("url") or it.get("domain") or it.get("ip", ""),
+            "ip": it.get("ip", ""), "port": it.get("port", ""),
+            "title": it.get("title", ""), "domain": it.get("domain", ""),
+            "server": it.get("product", ""), "url": it.get("url", ""),
+        })
+    return recs, f"zoomeye: {data.get('total', len(recs))} 命中"
+
+
+async def _engine_zerozone(client: Any, query: str, size: int, cfg: Any) -> tuple[list[dict], str]:
+    if not cfg.zerozone_key:
+        return [], "zerozone: 未配置 zerozone_key"
+    body = {
+        "title": query, "query_type": "site", "page": 1,
+        "pagesize": min(size, 100), "zone_key_id": cfg.zerozone_key,
+    }
+    r = await client.post(
+        "https://0.zone/api/data/",
+        headers={"Content-Type": "application/json"},
+        content=json.dumps(body),
+    )
+    data = r.json()
+    items = data.get("data") if isinstance(data.get("data"), list) else []
+    if not items and data.get("code") not in (0, 200, None):
+        return [], f"zerozone: {data.get('message', data.get('code'))}"
+    recs = []
+    for it in items:
+        recs.append({
+            "host": it.get("url") or it.get("domain", ""), "ip": it.get("ip", ""),
+            "port": it.get("port", ""), "title": it.get("title", ""),
+            "domain": it.get("domain", ""), "server": it.get("server", ""),
+            "url": it.get("url", ""),
+        })
+    return recs, f"zerozone: {data.get('total', len(recs))} 命中"
+
+
+_ENGINES = {
+    "fofa": _engine_fofa, "hunter": _engine_hunter, "quake": _engine_quake,
+    "shodan": _engine_shodan, "zoomeye": _engine_zoomeye, "zerozone": _engine_zerozone,
+}
+
+# 仅给定 domain 时，各引擎的默认查询语法
+_DOMAIN_QUERY = {
+    "fofa": 'domain="{d}"', "hunter": 'domain="{d}"', "quake": 'domain:"{d}"',
+    "shodan": "hostname:{d}", "zoomeye": 'hostname:"{d}"', "zerozone": "{d}",
+}
+
+
+def _make_client(cfg: Any):
+    import httpx
+
+    return httpx.AsyncClient(verify=False, timeout=cfg.http_timeout, follow_redirects=True)
+
+
+async def execute_space_search(agent: Any, args: dict[str, Any]) -> str:
+    """统一空间测绘查询。engine ∈ {fofa,hunter,quake,shodan,zoomeye,zerozone,all}。"""
+    cfg = _get_recon_cfg(agent)
+    engine = str(args.get("engine", "fofa") or "fofa").strip().lower()
+    query = str(args.get("query", "") or "").strip()
+    domain = str(args.get("domain", "") or "").strip()
+    size = int(args.get("size", cfg.space_size) or cfg.space_size)
+
+    if not query and not domain:
+        return "[!] space_search 需要 query 或 domain 参数"
+
+    engines = list(_ENGINES) if engine == "all" else [engine]
+    invalid = [e for e in engines if e not in _ENGINES]
+    if invalid:
+        return f"[!] 不支持的 engine: {', '.join(invalid)}；可选: {', '.join(_ENGINES)}, all"
+
+    out: list[str] = [f"# 空间测绘 — {'/'.join(engines)}  query={query or domain}"]
+    try:
+        async with _make_client(cfg) as client:
+            async def run(eng: str) -> tuple[str, list[dict], str]:
+                q = query or _DOMAIN_QUERY[eng].format(d=domain)
+                try:
+                    recs, note = await _ENGINES[eng](client, q, size, cfg)
+                    return eng, recs, note
+                except Exception as e:  # 单引擎失败不影响其他引擎
+                    return eng, [], f"{eng}: 请求异常 {e}"
+
+            results = await asyncio.gather(*(run(e) for e in engines))
+    except Exception as e:
+        return f"[!] space_search 执行错误: {e}"
+
+    for eng, recs, note in results:
+        out.append(f"\n## {note}")
+        for rec in recs[:size]:
+            line = f"  {rec.get('ip',''):<16}:{str(rec.get('port','')):<6} {rec.get('host','')}"
+            extra = " | ".join(x for x in (rec.get("title", ""), rec.get("server", "")) if x)
+            out.append(line + (f"  [{extra}]" if extra else ""))
+        if not recs:
+            out.append("  (无结果或未配置 key)")
+    return "\n".join(out)
+
+
+# ── 子域名枚举 ─────────────────────────────────────────────────────────────────
+
+_SUBDOMAIN_BRUTE = (
+    "www", "api", "app", "m", "mail", "admin", "test", "dev", "stage", "uat", "pre",
+    "static", "cdn", "img", "static1", "oa", "vpn", "sso", "cas", "auth", "portal",
+    "gateway", "gw", "open", "service", "wx", "mp", "h5", "pay", "passport", "id",
+    "data", "db", "file", "files", "upload", "download", "docs", "wiki", "git", "svn",
+    "jenkins", "ci", "monitor", "grafana", "kibana", "es", "redis", "mysql", "nacos",
+)
+
+
+async def execute_subdomain_enum(agent: Any, args: dict[str, Any]) -> str:
+    """子域名枚举：空间测绘被动聚合 + 可选小字典 DNS 爆破。"""
+    cfg = _get_recon_cfg(agent)
+    domain = str(args.get("domain", "") or "").strip().lower()
+    if not domain:
+        return "[!] subdomain_enum 需要 domain 参数"
+    if "://" in domain:
+        domain = _host_of(domain)
+
+    do_brute = bool(args.get("brute", True))
+    found: set[str] = set()
+    notes: list[str] = []
+
+    # 1) 被动：从各空间测绘引擎聚合
+    engines = [e for e in _ENGINES if getattr(cfg, _key_field(e))]
+    if engines:
+        try:
+            async with _make_client(cfg) as client:
+                async def run(eng: str):
+                    q = _DOMAIN_QUERY[eng].format(d=domain)
+                    try:
+                        recs, note = await _ENGINES[eng](client, q, cfg.space_size, cfg)
+                        notes.append(note)
+                        for rec in recs:
+                            for f in (rec.get("domain", ""), _host_of(rec.get("host", ""))):
+                                if f and f.endswith(domain):
+                                    found.add(f.lstrip("*.").lower())
+                    except Exception as e:
+                        notes.append(f"{eng}: 异常 {e}")
+                await asyncio.gather(*(run(e) for e in engines))
+        except Exception as e:
+            notes.append(f"被动聚合异常: {e}")
+    else:
+        notes.append("未配置任何空间测绘 key，跳过被动聚合")
+
+    # 2) 主动：小字典 DNS 解析爆破
+    if do_brute:
+        sem = asyncio.Semaphore(cfg.max_concurrency)
+        loop = asyncio.get_running_loop()
+
+        async def resolve(sub: str) -> None:
+            host = f"{sub}.{domain}"
+            async with sem:
+                try:
+                    await asyncio.wait_for(
+                        loop.run_in_executor(None, socket.gethostbyname, host), timeout=5
+                    )
+                    found.add(host)
+                except Exception:
+                    pass
+
+        await asyncio.gather(*(resolve(s) for s in _SUBDOMAIN_BRUTE))
+        notes.append(f"DNS 爆破字典 {len(_SUBDOMAIN_BRUTE)} 条")
+
+    subs = sorted(found)
+    head = [f"# 子域名枚举 — {domain}  共 {len(subs)} 个", "  " + "; ".join(notes)]
+    return "\n".join(head + [f"  {s}" for s in subs]) if subs else "\n".join(head + ["  (未发现子域名)"])
+
+
+def _key_field(engine: str) -> str:
+    return {
+        "fofa": "fofa_key", "hunter": "hunter_key", "quake": "quake_key",
+        "shodan": "shodan_key", "zoomeye": "zoomeye_key", "zerozone": "zerozone_key",
+    }[engine]
+
+
+# ── JS 信息收集（参考 URLFinder）──────────────────────────────────────────────
+
+
+def extract_from_js(content: str, base_host: str = "") -> dict[str, list[str]]:
+    """从 HTML/JS 文本中提取 urls / paths / domains / secrets（纯函数，便于测试）。
+
+    关键改进（参考 URLFinder）：
+    1. 宽泛路径匹配——任何引号内 /xxx/yyy 都提取，不限关键字白名单
+    2. 短片段提取——"User/list" 这类不以 / 开头的 CRUD 片段也捕获
+    3. base path + 实体名 + CRUD 动词排列组合推断——即便 JS 里只出现 "/jalis/rest"
+       和 "User"，也能自动推断出 /jalis/rest/User/list 等隐含端点
+    """
+    urls = _URL_RE.findall(content)
+    paths = [m.group("v") for m in _PATH_RE.finditer(content)]
+
+    # 短片段（如 "User/list"）
+    frags = [m.group("v") for m in _FRAG_RE.finditer(content)]
+
+    # base path 提取（如 "/jalis/rest"、"/smweb/rest"）
+    bases = list(dict.fromkeys(m.group("v").rstrip("/") for m in _BASE_PATH_RE.finditer(content)))
+
+    # 实体名动态提取：从 JS 中找所有 PascalCase 标识符（排除常见 JS 关键字/类名噪音）
+    _JS_NOISE = frozenset({
+        "Object", "Array", "String", "Number", "Boolean", "Function", "Date", "Error",
+        "Math", "JSON", "Promise", "RegExp", "Map", "Set", "Symbol", "Proxy", "Reflect",
+        "Infinity", "NaN", "Null", "True", "False", "Undefined", "Arguments", "This",
+        "Window", "Document", "Element", "Node", "Event", "Console", "Navigator",
+        "History", "Location", "Storage", "XMLHttpRequest", "FormData", "Headers",
+        "Request", "Response", "Blob", "File", "FileReader", "FileList", "Image",
+        "Canvas", "Context", "Worker", "WebSocket", "AbortController", "AbortSignal",
+        "TypeError", "RangeError", "SyntaxError", "ReferenceError", "URIError",
+        "EvalError", "InternalError", "AggregateError", "WeakMap", "WeakSet",
+        "ArrayBuffer", "DataView", "Float32Array", "Float64Array", "Int8Array",
+        "Int16Array", "Int32Array", "Uint8Array", "Uint16Array", "Uint32Array",
+        "Intl", "Atomics", "SharedArrayBuffer", "Generator", "AsyncFunction",
+        "Iterator", "AsyncIterator", "BigInt", "FinalizationRegistry",
+        "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
+        "Content", "Accept", "Authorization", "Cache", "Origin", "Referer",
+        "Script", "Link", "Style", "Div", "Span", "Input", "Button", "Form",
+        "Table", "Html", "Body", "Head", "Meta", "Title", "Base", "Href",
+    })
+    entities = list(dict.fromkeys(
+        m.group("v") for m in _PASCAL_CASE_RE.finditer(content)
+        if m.group("v") not in _JS_NOISE and len(m.group("v")) <= 30
+    ))
+
+    # base + entity + CRUD 推断
+    inferred: list[str] = []
+    if bases and entities:
+        for base in bases[:5]:
+            for entity in entities[:30]:
+                for verb in _CRUD_VERBS:
+                    inferred.append(f"{base}/{entity}/{verb}")
+    # base + 短片段拼接
+    for base in bases[:5]:
+        for frag in frags:
+            if not frag.startswith("/"):
+                inferred.append(f"{base}/{frag}")
+
+    all_paths = paths + [f"/{f}" if not f.startswith("/") else f for f in frags] + inferred
+
+    domains = sorted({_host_of(u) for u in urls if _host_of(u)})
+    if base_host:
+        base_root = ".".join(base_host.split(".")[-2:])
+        domains = [d for d in domains if base_root in d] + [d for d in domains if base_root not in d]
+    secrets: list[str] = []
+    for label, pat in _SECRET_PATTERNS:
+        for m in pat.finditer(content):
+            secrets.append(f"{label}: {m.group(0)[:80]}")
+    return {
+        "urls": _dedup_cap(urls, 200),
+        "paths": _dedup_cap(all_paths, 500),
+        "domains": _dedup_cap(domains, 100),
+        "secrets": _dedup_cap(secrets, 50),
+    }
+
+
+async def execute_js_recon(agent: Any, args: dict[str, Any]) -> str:
+    """抓取目标页面及其引用的 JS 文件，提取端点 / 域名 / 密钥。"""
+    cfg = _get_recon_cfg(agent)
+    url = str(args.get("url", "") or "").strip()
+    if not url:
+        return "[!] js_recon 需要 url 参数"
+    if "://" not in url:
+        url = "http://" + url
+    host = _host_of(url)
+
+    violation = enforce_host_path_constraints(agent, host=host, target=host)
+    if violation:
+        return violation
+
+    max_js = int(args.get("max_js", cfg.js_max_files) or cfg.js_max_files)
+    agg = {"urls": [], "paths": [], "domains": [], "secrets": []}
+    fetched = 0
+    try:
+        async with _make_client(cfg) as client:
+            resp = await client.get(url)
+            html = resp.text
+            for k, v in extract_from_js(html, host).items():
+                agg[k].extend(v)
+
+            # 收集 <script src> 并补全为绝对 URL
+            js_urls = []
+            for src in _SCRIPT_SRC_RE.findall(html):
+                full = urljoin(url, src)
+                if full.lower().split("?")[0].endswith(".js"):
+                    js_urls.append(full)
+            js_urls = _dedup_cap(js_urls, max_js)
+
+            sem = asyncio.Semaphore(cfg.max_concurrency)
+
+            async def grab(js_url: str) -> None:
+                nonlocal fetched
+                async with sem:
+                    try:
+                        jr = await client.get(js_url)
+                        fetched += 1
+                        for k, v in extract_from_js(jr.text, host).items():
+                            agg[k].extend(v)
+                    except Exception:
+                        pass
+
+            await asyncio.gather(*(grab(j) for j in js_urls))
+    except Exception as e:
+        return f"[!] js_recon 执行错误: {e}"
+
+    for k in agg:
+        agg[k] = _dedup_cap(agg[k], 200 if k != "secrets" else 50)
+
+    out = [f"# JS 信息收集 — {url}  (抓取 {fetched} 个 JS)"]
+
+    # 关键发现提前：敏感信息和未授权探测结果放最前面，减少被截断后 LLM 反复重调
+    if agg["secrets"]:
+        out.append(f"\n## ⚠ 疑似敏感信息 ({len(agg['secrets'])})")
+        out += [f"  {s}" for s in agg["secrets"]]
+
+    auto_probe = args.get("auto_probe", True)
+    probe_targets = agg["paths"] + [u for u in agg["urls"] if _host_of(u) == host]
+    if auto_probe and probe_targets:
+        probe_out = await execute_unauth_test(
+            agent,
+            {
+                "base_url": url,
+                "endpoints": probe_targets,
+                "auth_header": args.get("auth_header"),
+                "max_endpoints": int(args.get("max_endpoints", 60) or 60),
+            },
+        )
+        out.append("\n" + probe_out)
+
+    out.append(f"\n## 接口/路径 ({len(agg['paths'])})")
+    out += [f"  {p}" for p in agg["paths"][:120]]
+    out.append(f"\n## 关联域名 ({len(agg['domains'])})")
+    out += [f"  {d}" for d in agg["domains"][:60]]
+    out.append(f"\n## 绝对 URL ({len(agg['urls'])})")
+    out += [f"  {u}" for u in agg["urls"][:60]]
+    return "\n".join(out)
+
+
+# ── 未授权访问探测（JS 收集到的接口逐个验证）────────────────────────────────────
+
+# 破坏性动作：即便只发 GET 也可能触发副作用（短信轰炸/改数据），一律跳过
+_DESTRUCTIVE_RE = re.compile(
+    r"(?i)(delete|remove|destroy|update|modify|edit|/add|/create|insert|/save|clear|"
+    r"reset|drop|logout|sign ?out|sms|sendcode|send_?sms|captcha|verifycode|/pay|/order/cancel)"
+)
+# 强鉴权墙信号：出现即判定为登录/拦截页（避免把含 "login" 导航链接的公开页误判）
+_AUTHWALL_MARKERS = (
+    "请登录", "请先登录", "未登录", "未授权", "无权限", "权限不足", "登录后查看",
+    "unauthorized", "access denied", "not logged in", "please log in",
+    "authentication required", "需要登录",
+)
+_PASSWORD_FIELD_RE = re.compile(r"""(?i)(?:type|name)\s*=\s*["']password["']""")
+
+
+def _parse_auth_header(raw: Any) -> dict[str, str]:
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return {str(k): str(v) for k, v in raw.items()}
+    text = str(raw)
+    if ":" in text:
+        name, _, value = text.partition(":")
+        return {name.strip(): value.strip()}
+    # 裸 token → 当作 Bearer
+    return {"Authorization": f"Bearer {text.strip()}"}
+
+
+def _is_auth_wall(body: str) -> bool:
+    """是否为登录/鉴权拦截页：强文案信号或存在密码输入框（不靠裸 login 字样误判）。"""
+    head = body[:4000]
+    low = head.lower()
+    if any(m.lower() in low for m in _AUTHWALL_MARKERS):
+        return True
+    return bool(_PASSWORD_FIELD_RE.search(head))
+
+
+def _classify_unauth(status: int, body: str, ctype: str) -> tuple[str, bool]:
+    """返回 (判定文案, 是否疑似未授权线索)。"""
+    if status in (401, 403):
+        return "✓ 已鉴权拦截", False
+    if status in (301, 302, 307, 308):
+        return "↪ 跳转(疑似登录)", False
+    if status == 404:
+        return "— 不存在", False
+    if status == 405:
+        return "· 方法不允许", False
+    if status == 200:
+        if not body.strip():
+            return "· 200 空响应", False
+        if _is_auth_wall(body):
+            return "· 200 登录/鉴权墙", False
+        is_data = ("json" in ctype.lower()) or body.lstrip()[:1] in ("{", "[")
+        if is_data:
+            return "⚠ 疑似未授权(返回数据)", True
+        if "html" in ctype.lower() or body.lstrip()[:1] == "<":
+            return "· 200 HTML 页面(非接口)", False  # 公开页面，非接口未授权
+        return "⚠ 200 需人工确认", True
+    return f"? HTTP {status}", False
+
+
+async def _probe_endpoints(
+    client: Any, base: str, endpoints: list[str], auth: dict[str, str],
+    cap: int, sem: asyncio.Semaphore,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    base_host = _host_of(base)
+    seen: set[str] = set()
+    todo: list[str] = []
+    for ep in endpoints:
+        full = ep if "://" in ep else urljoin(base, ep)
+        if _host_of(full) != base_host:  # 不打非授权范围的关联域名
+            continue
+        if _DESTRUCTIVE_RE.search(full):  # 读写分离红线：跳过破坏性接口
+            results.append({"url": full, "status": "-", "verdict": "🚫 跳过(破坏性接口)", "lead": False, "length": 0})
+            continue
+        if full in seen:
+            continue
+        seen.add(full)
+        todo.append(full)
+    todo = todo[:cap]
+
+    # REST CRUD list/query/search 端点通常需要 POST（含框架变体如 listForLayUI）
+    _POST_VERBS_RE = re.compile(
+        r"(?i)/(?:list|query|search|page|find|select|export|count|batch|all)"
+        r"(?:[A-Z][a-zA-Z0-9]*)*(?:\?|$)"
+    )
+
+    async def one(url: str) -> None:
+        async with sem:
+            # 优先 GET；对 REST CRUD list/query 端点额外尝试 POST
+            methods = ["GET"]
+            if _POST_VERBS_RE.search(url):
+                methods.append("POST")
+
+            best_row: dict[str, Any] | None = None
+            for method in methods:
+                try:
+                    if method == "GET":
+                        r = await client.get(url)
+                    else:
+                        r = await client.post(url, content="{}", headers={"Content-Type": "application/json"})
+                except Exception as e:
+                    if best_row is None:
+                        best_row = {"url": url, "status": "ERR", "verdict": f"请求失败:{e}",
+                                    "lead": False, "length": 0, "method": method}
+                    continue
+                body = r.text
+                ctype = r.headers.get("content-type", "")
+                verdict, lead = _classify_unauth(r.status_code, body, ctype)
+                row = {"url": url, "status": r.status_code, "verdict": verdict,
+                       "lead": lead, "length": len(r.content), "method": method}
+                if lead and auth:
+                    try:
+                        hdrs = dict(auth)
+                        if method == "POST":
+                            hdrs["Content-Type"] = "application/json"
+                            ra = await client.post(url, content="{}", headers=hdrs)
+                        else:
+                            ra = await client.get(url, headers=hdrs)
+                        if ra.status_code == 200 and abs(len(ra.content) - len(r.content)) <= max(50, len(r.content) * 0.1):
+                            row["verdict"] = "🔴 未授权确认(无token=有token)"
+                    except Exception:
+                        pass
+                # 保留发现线索更强的那个方法
+                if best_row is None or (lead and not best_row.get("lead")) or (lead and len(r.content) > best_row.get("length", 0)):
+                    best_row = row
+            if best_row is not None:
+                results.append(best_row)
+
+    await asyncio.gather(*(one(u) for u in todo))
+    # 线索优先、再按状态排序
+    results.sort(key=lambda x: (not x.get("lead"), str(x.get("status"))))
+    return results
+
+
+async def execute_unauth_test(agent: Any, args: dict[str, Any]) -> str:
+    """对一批接口逐个做未授权访问探测（仅安全 GET，跳过破坏性接口）。"""
+    cfg = _get_recon_cfg(agent)
+    base = str(args.get("base_url") or args.get("url") or "").strip()
+    endpoints = args.get("endpoints") or []
+    if isinstance(endpoints, str):
+        endpoints = [e.strip() for e in re.split(r"[\s,]+", endpoints) if e.strip()]
+    if not base and endpoints:
+        base = endpoints[0]
+    if not base:
+        return "[!] unauth_test 需要 base_url（或在 endpoints 中给出完整 URL）"
+    if "://" not in base:
+        base = "http://" + base
+    host = _host_of(base)
+
+    violation = enforce_host_path_constraints(agent, host=host, target=host)
+    if violation:
+        return violation
+    if not endpoints:
+        return "[!] unauth_test 需要 endpoints（接口路径/URL 列表，通常来自 js_recon）"
+
+    auth = _parse_auth_header(args.get("auth_header"))
+    cap = int(args.get("max_endpoints", 60) or 60)
+    try:
+        async with _make_client(cfg) as client:
+            sem = asyncio.Semaphore(cfg.max_concurrency)
+            rows = await _probe_endpoints(client, base, endpoints, auth, cap, sem)
+    except Exception as e:
+        return f"[!] unauth_test 执行错误: {e}"
+
+    leads = [r for r in rows if r.get("lead")]
+    out = [f"# 未授权访问探测 — {host}  探测 {len(rows)} 个接口，疑似线索 {len(leads)}"]
+    if auth:
+        out.append("  (已启用 有/无 token 差分对比)")
+    for r in rows:
+        st = r.get("status")
+        method = r.get("method", "GET")
+        tag = f"[{str(st):>3}]" if method == "GET" else f"[{str(st):>3} {method}]"
+        out.append(f"  {tag:>12} {str(r.get('length','')):>7}B  {r['verdict']:<22} {r['url']}")
+    if leads:
+        out.append("\n⚠ 重点人工复核（确认是否能读他人数据/是否敏感）：")
+        out += [f"  {r['url']}" for r in leads]
+    return "\n".join(out)
+
+
+# ── 目录枚举（参考 dirsearch）──────────────────────────────────────────────────
+
+
+def _load_wordlist(cfg: Any) -> list[str]:
+    path = (cfg.dir_wordlist_path or "").strip()
+    if path:
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                words = [ln.strip().lstrip("/") for ln in f if ln.strip() and not ln.startswith("#")]
+            if words:
+                return words
+        except OSError:
+            pass
+    return list(_BUILTIN_DIR_WORDLIST)
+
+
+_HIT_CODES = {200, 201, 204, 301, 302, 307, 401, 403, 405, 500}
+
+
+async def execute_dir_enum(agent: Any, args: dict[str, Any]) -> str:
+    """目录枚举：并发字典爆破，带 404 基线 / 全局伪装识别与状态码过滤。"""
+    cfg = _get_recon_cfg(agent)
+    base = str(args.get("url", "") or "").strip()
+    if not base:
+        return "[!] dir_enum 需要 url 参数"
+    if "://" not in base:
+        base = "http://" + base
+    base = base.rstrip("/") + "/"
+    host = _host_of(base)
+
+    violation = enforce_host_path_constraints(agent, host=host, target=host)
+    if violation:
+        return violation
+
+    extensions = args.get("extensions") or []
+    if isinstance(extensions, str):
+        extensions = [e.strip() for e in extensions.split(",") if e.strip()]
+    words = _load_wordlist(cfg)
+    if args.get("wordlist"):
+        extra = args["wordlist"]
+        words = (extra if isinstance(extra, list) else [extra]) + words
+
+    # 展开扩展名
+    candidates: list[str] = []
+    for w in words:
+        candidates.append(w)
+        for ext in extensions:
+            ext = ext.lstrip(".")
+            if "." not in w.split("/")[-1]:
+                candidates.append(f"{w}.{ext}")
+    candidates = _dedup_cap(candidates, cfg.dir_max_requests)
+
+    try:
+        import httpx
+
+        async with _make_client(cfg) as client:
+            # 404 基线 + 全局伪装识别：请求随机不存在路径
+            baseline_len = None
+            try:
+                rnd = await client.get(urljoin(base, "vulnclaw_nope_8f3a2c1e9b/"))
+                if rnd.status_code in (200, 301, 302):
+                    baseline_len = len(rnd.text)
+                    # 随机路径竟返回 200 → 全局伪装响应，停止爆破（CLAUDE.md 铁律）
+                    if rnd.status_code == 200:
+                        return (
+                            f"[!] dir_enum 终止：随机路径 {base}vulnclaw_nope_... 返回 200"
+                            f"（长度 {baseline_len}），目标疑似对任意路径返回 200，目录爆破无意义。"
+                        )
+            except Exception:
+                pass
+
+            sem = asyncio.Semaphore(cfg.max_concurrency)
+            hits: list[tuple[int, int, str]] = []
+
+            async def probe(path: str) -> None:
+                target = urljoin(base, path)
+                async with sem:
+                    try:
+                        r = await client.get(target)
+                    except Exception:
+                        return
+                code = r.status_code
+                length = len(r.content)
+                if code in _HIT_CODES:
+                    if baseline_len is not None and code in (200, 301, 302) and length == baseline_len:
+                        return  # 与伪装基线同长，判为噪音
+                    hits.append((code, length, path))
+
+            await asyncio.gather(*(probe(p) for p in candidates))
+    except Exception as e:
+        return f"[!] dir_enum 执行错误: {e}"
+
+    hits.sort(key=lambda x: (x[0], -x[1]))
+    out = [f"# 目录枚举 — {base}  请求 {len(candidates)} 条，命中 {len(hits)}"]
+    if baseline_len is not None:
+        out.append(f"  (404 基线长度 ≈ {baseline_len})")
+    for code, length, path in hits:
+        out.append(f"  [{code}] {length:>8}B  {base}{path}")
+    return "\n".join(out) if hits else "\n".join(out + ["  (无有效命中)"])

--- a/vulnclaw/agent/solver.py
+++ b/vulnclaw/agent/solver.py
@@ -12,16 +12,18 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextvars
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
-from vulnclaw.agent.blackboard import Blackboard, BoardIntent
+from vulnclaw.agent.blackboard import Blackboard, BoardIntent, IntentStatus
 from vulnclaw.agent.llm_client import build_chat_completion_kwargs, call_llm_auto
 from vulnclaw.agent.think_filter import strip_think_tags
 
-# 探索阶段判定「已推进/已确认结论」的信号
+# 探索阶段判定「已推进/已确认结论」的信号（宽泛匹配，避免漏判有进展的 intent）
 _ADVANCE_MARKERS = [
     "确认",
     "成功",
@@ -33,6 +35,27 @@ _ADVANCE_MARKERS = [
     "绕过成功",
     "回显",
     "漏洞存在",
+    "发现",
+    "返回200",
+    "返回 200",
+    "status: 200",
+    "未授权",
+    "无需认证",
+    "接口可访问",
+    "信息泄露",
+    "关键发现",
+    "重大发现",
+    "暴露",
+    "泄露",
+    "200 ok",
+    "cors",
+    "可写入",
+    "可上传",
+    "可下载",
+    "弱口令",
+    "注入点",
+    "xss",
+    "sql inject",
 ]
 # 探索阶段判定「该方向走不通」的信号
 _DEAD_END_MARKERS = [
@@ -45,6 +68,100 @@ _DEAD_END_MARKERS = [
     "无回显",
     "排除",
 ]
+# 完成理由里的否定表述——模型把「未达成」写进完成字段时据此识别并拒绝
+_NEGATION_MARKERS = [
+    "未达到",
+    "未达成",
+    "未记录",
+    "未发现",
+    "未完成",
+    "未能",
+    "尚未",
+    "没有",
+    "不足以",
+    "无法证明",
+    "无法确认",
+    "不能证明",
+    "不满足",
+]
+
+
+def _has_negation(text: str) -> bool:
+    """完成理由中是否含否定表述（说明实际未达成）。"""
+    return any(m in (text or "") for m in _NEGATION_MARKERS)
+
+
+_current_worker: contextvars.ContextVar["ExploreWorker | None"] = contextvars.ContextVar(
+    "_current_worker", default=None
+)
+
+
+@dataclass
+class ExploreWorker:
+    intent_id: str
+    evidence_buffer: list[str] = field(default_factory=list)
+    tc_start: int = 0
+
+
+class BoardGuard:
+    """Serialise mutating Blackboard operations with an asyncio.Lock."""
+
+    def __init__(self, board: Blackboard) -> None:
+        self._board = board
+        self._lock = asyncio.Lock()
+
+    async def add_fact(self, description: str, source: str = "") -> Any:
+        async with self._lock:
+            return self._board.add_fact(description, source)
+
+    async def conclude_intent(self, intent_id: str, fact_desc: str, source: str = "") -> Any:
+        async with self._lock:
+            return self._board.conclude_intent(intent_id, fact_desc, source)
+
+    async def abandon_intent(self, intent_id: str, note: str = "") -> Any:
+        async with self._lock:
+            return self._board.abandon_intent(intent_id, note)
+
+    async def record_tool_call(self, **kwargs: Any) -> None:
+        async with self._lock:
+            self._board.record_tool_call(**kwargs)
+
+
+class IntentStreamSink:
+    """Wraps a StreamSink to prefix output with ``[i00x]``."""
+
+    def __init__(self, inner: Any, intent_id: str) -> None:
+        self._inner = inner
+        self._prefix = f"[{intent_id}] "
+        self._first = True
+
+    def on_status(self, message: str) -> None:
+        if self._inner:
+            self._inner.on_status(f"{self._prefix}{message}")
+
+    def on_thinking_token(self, token: str) -> None:
+        if self._inner:
+            self._inner.on_thinking_token(token)
+
+    def on_content_token(self, token: str) -> None:
+        if self._inner:
+            if self._first:
+                self._inner.on_content_token(self._prefix)
+                self._first = False
+            self._inner.on_content_token(token)
+
+    def on_tool_call(self, tool_name: str, args: str) -> None:
+        if self._inner:
+            self._inner.on_tool_call(f"{self._prefix}{tool_name}", args)
+
+    def on_tool_result(self, result_summary: str) -> None:
+        if self._inner:
+            self._inner.on_tool_result(result_summary)
+
+    def on_stream_end(self) -> None:
+        if self._inner:
+            self._inner.on_stream_end()
+        self._first = True
 
 
 @dataclass
@@ -132,22 +249,51 @@ async def _structured_call(agent: Any, prompt: str, *, max_tokens: int = 900) ->
 
 
 def _reason_prompt(board: Blackboard, max_intents: int) -> str:
+    # 参考 Cairn reason.md：显式列出 open intents 和 abandoned intents，防重复提出
+    open_list = board.open_intents()
+    abandoned = [i for i in board.intents if i.status == IntentStatus.ABANDONED]
+    concluded = [i for i in board.intents if i.status == IntentStatus.CONCLUDED]
+
+    open_block = ""
+    if open_list:
+        open_block = "当前处于 OPEN 状态的 intents（正在探索或等待探索）：\n"
+        for i in open_list:
+            open_block += f"  - {i.id}: {i.description}\n"
+        open_block += "如果 open intents 已覆盖所有有价值的方向，不要提新的。\n\n"
+
+    abandoned_block = ""
+    if abandoned:
+        abandoned_block = "已放弃的 intents（走不通或已验证过）：\n"
+        for i in abandoned[-10:]:
+            note = f" — {i.note[:60]}" if i.note else ""
+            abandoned_block += f"  - {i.id}: {i.description}{note}\n"
+        abandoned_block += "⚠ **严禁重复提出与上述 abandoned intents 相同或高度重叠的方向。** 它们已被验证为走不通。\n\n"
+
+    concluded_block = ""
+    if concluded:
+        concluded_block = "已完成的 intents（有结论的）：\n"
+        for i in concluded[-5:]:
+            concluded_block += f"  - {i.id} → {i.result_fact}: {i.description}\n"
+        concluded_block += "\n"
+
     return (
         "你是该领域的资深渗透专家。下面是当前任务的「黑板图」快照：facts 是已确认的客观事实，"
         "intents 是探索方向。图从 facts 出发、通过 intent 探索得到新的 fact，逐步逼近 goal。\n\n"
+        f"{open_block}{abandoned_block}{concluded_block}"
         "请判断两件事：① 现有 facts 是否已满足 goal；② 若未满足，是否应提出新的探索方向。\n\n"
         "只返回一个 JSON 对象，不要输出别的内容：\n"
-        '- 若 goal 已达成： {"complete": "引用具体 fact id 说明为何现有客观事实足以证明目标达成"}\n'
-        '- 若未达成且应提出新方向： {"intents": [{"from": ["f001"], "description": "高价值且独立的探索方向"}]}\n'
-        '- 若未达成但当前不必新增方向： {}\n\n'
+        '- 若 goal 已达成： {"complete": true, "reason": "说明为何已达成", "evidence": ["f002"]}'
+        "（complete 必须是布尔 true；evidence 必须引用证明达成的真实 fact id，至少一个）\n"
+        '- 若未达成且应提出新方向： {"complete": false, "intents": [{"from": ["f001"], "description": "高价值且独立的探索方向"}]}\n'
+        '- 若未达成但当前不必新增方向： {"complete": false}\n\n'
         "规则：\n"
-        "- **完成判定必须基于 facts 里已确认的客观事实**，不得基于猜测或愿望。若 goal 要求 flag，"
-        "则 facts 中必须有一条记录了**真实拿到的 flag 值**才能 complete；只要 flag 来源可疑/未被工具输出证实，"
-        "一律视为未达成，继续提方向去验证，绝不能 complete。\n"
+        "- **complete 字段只能是布尔 true 或 false**。\n"
+        "- **完成判定必须基于 facts 里已确认的客观事实**，不得基于猜测或愿望，且 evidence 必须引用真实 fact id。\n"
         "- 若某条 fact 标注了 [未验证]/[拒绝完成]/疑似幻觉，绝对不能据此判定达成。\n"
-        "- 若没有任何处于 open 的 intent，则必须提出新方向。\n"
+        "- **严禁重复提出与 abandoned intents 相同或高度重叠的方向**——它们已被探索过且走不通。\n"
+        "- 若还有处于 open 的 intent 且当前 facts 没有揭示比 open intents 更有价值的新方向，"
+        "返回 {\"complete\": false}（不提新方向），让 open intents 继续推进。\n"
         f"- 一次最多提出 {max_intents} 个高价值、互不重叠、可独立推进的方向，每个聚焦核心思路。\n"
-        "- 反思是否走偏：若之前方向无效，提出能纠偏的新方向。\n"
         "- description 简洁聚焦，不要冗长；不同 intent 覆盖不同维度。\n\n"
         "## 黑板图\n```\n" + board.to_prompt_graph() + "\n```\n"
     )
@@ -159,13 +305,19 @@ def _conclude_prompt(board: Blackboard, intent: BoardIntent, evidence: str) -> s
         "你只能基于「真实工具输出」里**已经实际确认**的信息来总结，不得继续调用工具、不得等待未完成的结果。\n\n"
         "只返回一个 JSON 对象：\n"
         '{"advanced": true/false, "fact": "本次新确认的客观事实（增量）"}\n\n'
-        "铁律（违反即视为失败）：\n"
-        "- fact 必须是**已被真实工具输出证实**的客观事实，不得是计划、猜测、推断或填充性描述。\n"
-        "- **严禁编造 flag/shell/密码/数据**。任何 flag 只有在下方「真实工具输出」中**逐字符出现过**才能写进 fact；"
-        "若工具输出里没有，就绝对不能声称拿到了 flag——这种情况 advanced=false。\n"
-        "- advanced=true 仅当本次探索有**工具输出支撑的**实质推进（确认注入点/绕过/拿到真实回显数据等）。\n"
-        "- advanced=false 表示该方向走不通或暂无被证实的结论；此时 fact 写明客观观察（如『响应返回 sql inject error，注入被过滤』）。\n"
-        "- 不要放大段原始数据，不要重复图里已有信息。\n\n"
+        "## advanced 判定标准（宽泛偏向 true）\n"
+        "advanced=true 的情况（有**任何一项**即算推进）：\n"
+        "- 发现了新的可访问接口/端点（即便只是确认 200 返回）\n"
+        "- 确认了未授权可访问的 API（无需 token 即返回数据）\n"
+        "- 发现了技术栈/版本/配置信息（Server 头、错误页泄露等）\n"
+        "- 发现了安全配置问题（CORS 通配符、缺失安全头、敏感路径 403 等）\n"
+        "- 确认了漏洞存在（注入点/XSS/SSRF/文件读取等）\n"
+        "- 获取到了真实的 flag/shell/凭据\n\n"
+        "advanced=false 仅当**完全没有任何新发现**：所有请求都是 404/超时/已知信息重复。\n\n"
+        "## 铁律\n"
+        "- fact 必须是**已被真实工具输出证实**的客观事实，不得是计划、猜测、推断。\n"
+        "- **严禁编造 flag/shell/密码/数据**——工具输出里没出现过就不能声称拿到。\n"
+        "- fact 只写增量信息，不要重复图里已有的内容。\n\n"
         f"## 当前探索方向 {intent.id}\n{intent.description}\n\n"
         "## 本次探索的真实工具输出（你唯一可信的事实来源）\n```\n" + (evidence.strip() or "(无工具输出)") + "\n```\n\n"
         "## 黑板图\n```\n" + board.to_prompt_graph() + "\n```\n"
@@ -178,13 +330,69 @@ def _explore_context(board: Blackboard, intent: BoardIntent, step: int, max_roun
         refs = [board.get_fact(fid) for fid in intent.from_facts]
         from_desc = "\n".join(f"  - {f.id}: {f.description}" for f in refs if f)
         from_desc = f"\n基于已知事实：\n{from_desc}"
+
+    # 已执行工具摘要——防跨 intent 重复
+    tc_summary = board.tool_call_summary(20)
+    tc_block = ""
+    if tc_summary:
+        tc_block = (
+            "\n## 已执行过的工具（禁止重复调用同一工具+同一参数）\n"
+            + tc_summary + "\n"
+        )
+
+    # Cairn 改进 #5: 最后一步时注入 conclude override 指令
+    conclude_override = ""
+    if step == max_rounds:
+        conclude_override = (
+            "\n## ⚠ 这是最后一步——立即停止探索并总结\n"
+            "不要再发起新的工具调用、不要等待未完成的结果。\n"
+            "基于已有的工具输出，总结本方向发现的所有客观事实。\n\n"
+        )
+
     return (
         f"[探索方向 {intent.id} · 第 {step}/{max_rounds} 步]\n"
         f"目标(goal): {board.goal}\n"
-        f"当前探索方向：{intent.description}{from_desc}\n\n"
-        "请只围绕这个方向用工具实际执行（发请求/构造 payload/解析响应），不要泛泛而谈。\n"
-        "每一步都要有真实的工具调用与对响应的具体分析；若该方向确认走不通就明确说明并停止。\n"
+        f"当前探索方向：{intent.description}{from_desc}\n"
+        f"{conclude_override}"
+        f"{tc_block}\n"
+        "## 执行规则（必须遵守）\n"
+        "1. 围绕当前方向用工具实际执行，每步必须有工具调用+响应分析。\n"
+        "2. ⚠ 绝对禁止重复调用上面「已执行过的工具」列表中出现过的同一工具+同一参数。\n"
+        "3. ⚠ 同一 URL 只 fetch 一次——如果已经 fetch 过，直接基于已有结果分析。\n"
+        "4. 若该方向走不通，明确说明原因并停止。\n"
+        "\n## 工具使用链路（按目标类型选择）\n"
+        "Web 渗透标准链路：\n"
+        "  ① js_recon(url=目标) — 抓 JS 提接口 + 自动未授权探测（**最先调用**）\n"
+        "  ② dir_enum(url=目标) — 目录枚举\n"
+        "  ③ space_search(domain=域名) — 空间测绘\n"
+        "  ④ subdomain_enum(domain=域名) — 子域名枚举\n"
+        "  ⑤ unauth_test(base_url, endpoints) — 对发现的接口做未授权验证\n"
+        "  ⑥ fetch(url, method) — 单个请求探测（仅用于 js_recon/dir_enum 未覆盖的特定路径）\n"
+        "Chrome MCP 链路：chrome_navigate → chrome_read_page/chrome_get_web_content → 分析（不要反复 navigate）\n"
     )
+
+
+def _is_duplicate_intent(board: Blackboard, new_desc: str) -> bool:
+    """检查新提案是否与已 abandoned 的 intent 高度重叠（仅检查 abandoned，不检查 concluded）。
+
+    只阻止重复已失败的方向；已成功的方向可以在新事实基础上再次深入。
+    """
+    abandoned = [i for i in board.intents if i.status == IntentStatus.ABANDONED]
+    if not abandoned:
+        return False
+    new_lower = new_desc.lower()
+    new_words = set(re.findall(r"[a-zA-Z一-鿿]{2,}", new_lower))
+    if len(new_words) < 3:
+        return False
+    for existing in abandoned:
+        old_lower = existing.description.lower()
+        old_words = set(re.findall(r"[a-zA-Z一-鿿]{2,}", old_lower))
+        if len(old_words) < 3:
+            continue
+        overlap = len(new_words & old_words) / max(len(new_words | old_words), 1)
+        if overlap > 0.65:
+            return True
+    return False
 
 
 async def reason_step(agent: Any, board: Blackboard, max_intents: int) -> dict:
@@ -201,32 +409,58 @@ async def explore_step(
     max_tool_rounds: int,
     evidence_buffer: list[str],
     stream_sink: Any = None,
+    skip_context_write: bool = False,
 ) -> tuple[bool, str]:
     """围绕一个 Intent 实际探索，返回 (是否推进, 结论事实描述)。
 
     结论阶段只喂给模型「本次探索真实捕获的工具输出」作为唯一可信事实来源，降低幻觉。
+    skip_context_write: 并行模式下跳过 agent.context.messages 写入（避免交叉写入）。
     """
     system_prompt = agent._build_system_prompt(
         agent.context.state.target, auto_mode=True, user_input=intent.description
     )
     evidence_start = len(evidence_buffer)
+    tc_start = len(board.tool_calls)
     last_text = ""
+    prev_tc_count = tc_start
+    no_new_tc_streak = 0
     for step in range(1, max_tool_rounds + 1):
         ctx = _explore_context(board, intent, step, max_tool_rounds)
         text = await call_llm_auto(agent, system_prompt, ctx, stream_sink=stream_sink)
         last_text = text or ""
-        agent.context.add_assistant_message(f"[探索 {intent.id} 第{step}步] {last_text}")
-        # 复用既有的发现提取逻辑
+        if not skip_context_write:
+            agent.context.add_assistant_message(f"[探索 {intent.id} 第{step}步] {last_text}")
         if hasattr(agent, "_finding_parser"):
             agent._finding_parser.parse(last_text)
         lowered = last_text.lower()
-        # 早停：明确推进或明确死路
         if any(m.lower() in lowered for m in _ADVANCE_MARKERS):
             break
         if any(m in last_text for m in _DEAD_END_MARKERS) and step >= 2:
             break
+        # 参考 Cairn checkpoint：比较本步前后 tool_calls 数量——没有新增说明模型空转
+        cur_tc_count = len(board.tool_calls)
+        if cur_tc_count == prev_tc_count:
+            no_new_tc_streak += 1
+            if no_new_tc_streak >= 2:
+                last_text += "\n[!] 连续 2 步无新工具调用（空转），终止本方向。"
+                break
+        else:
+            # 检查本步新增的调用是否全部是重复的（同 tool+key_args 已在之前出现）
+            new_tcs = board.tool_calls[prev_tc_count:]
+            all_repeated = all(
+                any(old.tool == tc.tool and old.key_args == tc.key_args
+                    for old in board.tool_calls[:prev_tc_count])
+                for tc in new_tcs
+            ) if new_tcs else True
+            if all_repeated and step >= 2:
+                last_text += "\n[!] 本步所有工具调用均为重复调用，终止本方向。"
+                break
+            no_new_tc_streak = 0
+        prev_tc_count = cur_tc_count
 
-    # 本次探索真实捕获的工具输出（HTTP 响应 / python_execute 输出等）
+    # ── Cairn 改进 #2: Conclude 阶段（参考 explore-conclude.md）──────
+    # 无论 explore 如何结束（轮数耗尽/advance/dead-end/空转），都进入 conclude 阶段。
+    # conclude 基于真实工具输出总结，偏向保留有价值的发现。
     intent_evidence = "\n".join(evidence_buffer[evidence_start:])[-6000:]
     raw = await _structured_call(
         agent, _conclude_prompt(board, intent, intent_evidence), max_tokens=600
@@ -236,6 +470,20 @@ async def explore_step(
     fact = str(parsed.get("fact", "")).strip()
     if not fact:
         fact = strip_think_tags(last_text).strip()[:200]
+
+    # ── Cairn 改进 #2b: 证据兜底 ─────────────────────────────────
+    # 如果 conclude 说 advanced=false，但工具输出里明确有 200 响应或新发现，
+    # 强制提升为 advanced=true（防止弱模型的 conclude 丢弃有价值的发现）。
+    if not advanced and intent_evidence:
+        evidence_lower = intent_evidence.lower()
+        has_data = any(marker in evidence_lower for marker in [
+            "status: 200", "200 ok", '"success"', "'success'",
+            "未授权", "疑似未授权", "返回数据",
+            "接口/路径", "命中",
+        ])
+        if has_data and fact:
+            advanced = True
+
     return advanced, fact
 
 
@@ -248,6 +496,7 @@ async def solve(
     max_steps: int = 40,
     max_intents: int = 3,
     max_tool_rounds: int = 4,
+    max_parallel: int = 1,
     stream_sink: Any = None,
     on_event: Optional[Callable[[str, dict], None]] = None,
 ) -> SolveResult:
@@ -255,20 +504,48 @@ async def solve(
     board = agent.context.state.board
     board.origin = origin or board.origin
     board.goal = goal or board.goal
+    guard = BoardGuard(board)
 
     def emit(kind: str, payload: dict) -> None:
         if on_event is not None:
             on_event(kind, payload)
 
-    # 真实工具输出缓冲区——所有 flag/完成判定的唯一可信证据来源
+    # 全局证据缓冲区——所有 flag/完成判定的唯一可信证据来源
     evidence_buffer: list[str] = []
     original_execute = agent._execute_mcp_tool
 
     async def _recording_execute(tool_name: str, tool_args: dict) -> str:
+        import json as _json
+
+        key_args = _json.dumps(tool_args, ensure_ascii=False, sort_keys=True)[:200]
         output = await original_execute(tool_name, tool_args)
-        evidence_buffer.append(str(output))
+        out_str = str(output)
+
+        worker = _current_worker.get()
+        if worker is not None:
+            worker.evidence_buffer.append(out_str)
+            if len(worker.evidence_buffer) > 400:
+                del worker.evidence_buffer[:200]
+            intent_id = worker.intent_id
+        else:
+            intent_id = ""
+
+        evidence_buffer.append(out_str)
         if len(evidence_buffer) > 400:
             del evidence_buffer[:200]
+
+        status = 0
+        if "Status: 200" in out_str:
+            status = 200
+        elif "Status: 403" in out_str:
+            status = 403
+        elif "Status: 404" in out_str:
+            status = 404
+        note = out_str[:100].replace("\n", " ")
+        await guard.record_tool_call(
+            tool=tool_name, key_args=key_args,
+            intent_id=intent_id, status=status, note=note,
+        )
         return output
 
     agent._execute_mcp_tool = _recording_execute  # type: ignore[method-assign]
@@ -283,97 +560,188 @@ async def solve(
 
         empty_reason_streak = 0
         consecutive_errors = 0
+        complete_reject_streak = 0
         steps = 0
 
+        last_checkpoint = (-1, -1, -1)
+
+        def _graph_checkpoint() -> tuple[int, int, int]:
+            return (
+                len(board.facts),
+                sum(1 for i in board.intents if i.status == IntentStatus.CONCLUDED),
+                sum(1 for i in board.intents if i.status == IntentStatus.ABANDONED),
+            )
+
         while steps < max_steps and not board.completed:
-            try:
-                decision = await reason_step(agent, board, max_intents)
-            except Exception as exc:  # LLM/网络异常：不崩溃，累计熔断
-                consecutive_errors += 1
-                emit("error", {"phase": "reason", "error": str(exc)})
-                if consecutive_errors >= 3:
-                    break
-                continue
-            emit("reason", {"decision": decision, "step": steps})
+            cur_checkpoint = _graph_checkpoint()
+            open_intents = board.open_intents()
+            skip_reason = (cur_checkpoint == last_checkpoint and open_intents)
+            last_checkpoint = cur_checkpoint
 
-            complete_reason = decision.get("complete")
-            if complete_reason:
-                full_evidence = "\n".join(evidence_buffer)
-                grounded, why = _completion_is_grounded(board.goal, full_evidence)
-                fake = _unverified_flags(str(complete_reason), full_evidence)
-                if grounded and not fake:
-                    board.mark_complete(str(complete_reason))
-                    break
-                # 完成声明缺乏真实证据 → 拒绝，写入纠偏事实，继续探索
-                reject_reason = why or f"完成声明引用的 flag {fake[0]} 未在真实工具输出中出现"
-                board.add_fact(f"[拒绝完成] {reject_reason}；继续探索验证", source="verify")
-                emit("complete_rejected", {"reason": reject_reason})
-                continue
+            if skip_reason:
+                pass
+            else:
+                try:
+                    decision = await reason_step(agent, board, max_intents)
+                except Exception as exc:
+                    consecutive_errors += 1
+                    emit("error", {"phase": "reason", "error": str(exc)})
+                    if consecutive_errors >= 3:
+                        break
+                    continue
+                emit("reason", {"decision": decision, "step": steps})
 
-            for item in decision.get("intents") or []:
-                desc = (item or {}).get("description", "").strip() if isinstance(item, dict) else ""
-                if desc:
+                complete_flag = decision.get("complete")
+                if complete_flag is not None and complete_flag is not False:
+                    full_evidence = "\n".join(evidence_buffer)
+                    reason_text = str(
+                        decision.get("reason")
+                        or (complete_flag if isinstance(complete_flag, str) else "")
+                    ).strip()
+                    evidence_ids = [
+                        fid for fid in (decision.get("evidence") or []) if board.get_fact(fid)
+                    ]
+                    grounded, why = _completion_is_grounded(board.goal, full_evidence)
+                    fake = _unverified_flags(reason_text, full_evidence)
+
+                    reject_reason: Optional[str] = None
+                    if complete_flag is not True:
+                        reject_reason = "完成判定未使用显式 complete=true，按未达成处理"
+                    elif not reason_text:
+                        reject_reason = "完成声明缺少 reason 说明"
+                    elif _has_negation(reason_text):
+                        reject_reason = f"完成理由含否定表述，实际未达成：{reason_text[:80]}"
+                    elif not evidence_ids:
+                        reject_reason = "完成声明未引用任何已确认 fact 作为证据"
+                    elif not grounded:
+                        reject_reason = why
+                    elif fake:
+                        reject_reason = f"完成声明引用的 flag {fake[0]} 未在真实工具输出中出现"
+
+                    if reject_reason is None:
+                        board.mark_complete(reason_text)
+                        emit("completed", {"reason": reason_text})
+                        break
+                    board.add_fact(f"[拒绝完成] {reject_reason}；继续探索验证", source="verify")
+                    emit("complete_rejected", {"reason": reject_reason})
+                    complete_reject_streak += 1
+                    if complete_reject_streak >= 3:
+                        break
+                    continue
+                complete_reject_streak = 0
+
+                for item in decision.get("intents") or []:
+                    desc = (item or {}).get("description", "").strip() if isinstance(item, dict) else ""
+                    if not desc:
+                        continue
+                    if _is_duplicate_intent(board, desc):
+                        continue
                     board.add_intent(desc, (item or {}).get("from"))
 
+                open_intents = board.open_intents()
+                if not open_intents:
+                    empty_reason_streak += 1
+                    if empty_reason_streak >= 3:
+                        break
+                    continue
+                empty_reason_streak = 0
+
+            # ── 选取 intent batch 去探索 ──────────────────────────────
             open_intents = board.open_intents()
             if not open_intents:
                 empty_reason_streak += 1
-                if empty_reason_streak >= 2:
-                    # 探索前沿耗尽：Reason 连续不再提出新方向
+                if empty_reason_streak >= 3:
                     break
                 continue
             empty_reason_streak = 0
 
-            intent = open_intents[0]
-            board.claim_intent(intent.id)
-            emit("explore_start", {"intent_id": intent.id, "description": intent.description})
+            batch = open_intents[:max_parallel]
+            is_parallel = len(batch) > 1 and max_parallel > 1
 
-            try:
-                advanced, fact = await explore_step(
-                    agent,
-                    board,
-                    intent,
+            for intent in batch:
+                board.claim_intent(intent.id)
+                emit("explore_start", {"intent_id": intent.id, "description": intent.description})
+
+            if is_parallel:
+                results = await _explore_batch(
+                    agent, board, batch,
                     max_tool_rounds=max_tool_rounds,
                     evidence_buffer=evidence_buffer,
                     stream_sink=stream_sink,
                 )
-            except Exception as exc:  # 探索异常：放弃该 intent，累计熔断
-                consecutive_errors += 1
-                board.abandon_intent(intent.id, note=f"探索异常: {exc}")
-                emit("error", {"phase": "explore", "intent_id": intent.id, "error": str(exc)})
-                if consecutive_errors >= 3:
-                    break
-                continue
-            consecutive_errors = 0
-
-            # 证据闸门：结论里声称的 flag 必须在真实工具输出里逐字符出现过
-            full_evidence = "\n".join(evidence_buffer)
-            fake_flags = _unverified_flags(fact, full_evidence)
-            if fake_flags:
-                note = f"声称获得 flag {fake_flags[0]} 但未在任何真实工具输出中出现，判定为幻觉，已拒绝"
-                board.abandon_intent(intent.id, note=note)
-                board.add_fact(f"[未验证] 探索 {intent.id}：{note}", source="verify")
-                emit("hallucination", {"intent_id": intent.id, "flags": fake_flags})
-            elif advanced and fact:
-                new_fact = board.conclude_intent(intent.id, fact)
-                emit(
-                    "conclude",
-                    {"intent_id": intent.id, "fact": new_fact.id if new_fact else "", "desc": fact},
-                )
-                # 拿到经证据验证的 flag 即刻收敛，不再多跑验证轮
-                captured = _extract_flags(fact)
-                if captured and _goal_wants_flag(board.goal):
-                    board.mark_complete(
-                        f"已从 {new_fact.id if new_fact else 'fact'} 验证获取 flag: {captured[0]}"
-                    )
-                    emit("reason", {"decision": {"complete": board.complete_reason}, "step": steps})
-                    break
             else:
-                board.abandon_intent(intent.id, note=(fact or "未推进")[:120])
-                emit("abandon", {"intent_id": intent.id, "note": fact})
+                intent = batch[0]
+                worker = ExploreWorker(intent_id=intent.id, evidence_buffer=list(evidence_buffer), tc_start=len(board.tool_calls))
+                _current_worker.set(worker)
+                try:
+                    advanced, fact = await explore_step(
+                        agent, board, intent,
+                        max_tool_rounds=max_tool_rounds,
+                        evidence_buffer=worker.evidence_buffer,
+                        stream_sink=stream_sink,
+                    )
+                except Exception as exc:
+                    advanced, fact = False, ""
+                    results = [(intent, False, f"探索异常: {exc}", True)]
+                else:
+                    results = [(intent, advanced, fact, False)]
+                finally:
+                    _current_worker.set(None)
+                    evidence_buffer.extend(
+                        e for e in worker.evidence_buffer if e not in evidence_buffer
+                    )
 
-            steps += 1
+            any_error = False
+            for intent, advanced, fact, is_error in results:
+                if is_error:
+                    consecutive_errors += 1
+                    board.abandon_intent(intent.id, note=fact[:120])
+                    emit("error", {"phase": "explore", "intent_id": intent.id, "error": fact})
+                    any_error = True
+                    continue
+                consecutive_errors = 0
+
+                full_evidence = "\n".join(evidence_buffer)
+                fake_flags = _unverified_flags(fact, full_evidence)
+                if fake_flags:
+                    note = f"声称获得 flag {fake_flags[0]} 但未在任何真实工具输出中出现，判定为幻觉，已拒绝"
+                    board.abandon_intent(intent.id, note=note)
+                    board.add_fact(f"[未验证] 探索 {intent.id}：{note}", source="verify")
+                    emit("hallucination", {"intent_id": intent.id, "flags": fake_flags})
+                elif advanced and fact:
+                    new_fact = board.conclude_intent(intent.id, fact)
+                    emit(
+                        "conclude",
+                        {"intent_id": intent.id, "fact": new_fact.id if new_fact else "", "desc": fact},
+                    )
+                    captured = _extract_flags(fact)
+                    if captured and _goal_wants_flag(board.goal):
+                        board.mark_complete(
+                            f"已从 {new_fact.id if new_fact else 'fact'} 验证获取 flag: {captured[0]}"
+                        )
+                        emit("completed", {"reason": board.complete_reason})
+                        break
+                else:
+                    board.abandon_intent(intent.id, note=(fact or "未推进")[:120])
+                    emit("abandon", {"intent_id": intent.id, "note": fact})
+
+            if board.completed:
+                break
+
+            if any_error and consecutive_errors >= 3:
+                break
+
+            steps += len(batch)
             agent.context.state.save()
+
+            if is_parallel:
+                summaries = []
+                for intent, advanced, fact, is_error in results:
+                    tag = "✓" if advanced else ("✗ ERR" if is_error else "—")
+                    summaries.append(f"[{intent.id} {tag}] {fact[:120]}")
+                agent.context.add_assistant_message(
+                    "[并行探索摘要]\n" + "\n".join(summaries)
+                )
     finally:
         agent._execute_mcp_tool = original_execute  # type: ignore[method-assign]
 
@@ -389,3 +757,52 @@ async def solve(
         facts=len(board.facts),
         board=board,
     )
+
+
+async def _explore_batch(
+    agent: Any,
+    board: Blackboard,
+    intents: list[BoardIntent],
+    *,
+    max_tool_rounds: int,
+    evidence_buffer: list[str],
+    stream_sink: Any = None,
+) -> list[tuple[BoardIntent, bool, str, bool]]:
+    """Run multiple intent explorations concurrently via asyncio.gather.
+
+    Returns list of (intent, advanced, fact, is_error) tuples.
+    """
+
+    async def _run_one(intent: BoardIntent) -> tuple[BoardIntent, bool, str, bool]:
+        worker = ExploreWorker(
+            intent_id=intent.id,
+            evidence_buffer=list(evidence_buffer),
+            tc_start=len(board.tool_calls),
+        )
+        sink = IntentStreamSink(stream_sink, intent.id) if stream_sink else None
+        ctx_token = _current_worker.set(worker)
+        try:
+            advanced, fact = await explore_step(
+                agent, board, intent,
+                max_tool_rounds=max_tool_rounds,
+                evidence_buffer=worker.evidence_buffer,
+                stream_sink=sink,
+                skip_context_write=True,
+            )
+            return (intent, advanced, fact, False)
+        except Exception as exc:
+            return (intent, False, f"探索异常: {exc}", True)
+        finally:
+            _current_worker.reset(ctx_token)
+            for e in worker.evidence_buffer:
+                if e not in evidence_buffer:
+                    evidence_buffer.append(e)
+
+    raw = await asyncio.gather(*(_run_one(i) for i in intents), return_exceptions=True)
+    results: list[tuple[BoardIntent, bool, str, bool]] = []
+    for idx, r in enumerate(raw):
+        if isinstance(r, BaseException):
+            results.append((intents[idx], False, f"探索异常: {r}", True))
+        else:
+            results.append(r)
+    return results

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -184,14 +184,19 @@ def _make_solve_event_printer(target_console):
     def on_event(kind: str, payload: dict) -> None:
         if kind == "reason":
             decision = payload.get("decision") or {}
-            if decision.get("complete"):
-                target_console.print("[green]✓ Reason: 目标达成[/green]")
+            complete_flag = decision.get("complete")
+            if complete_flag is not None and complete_flag is not False:
+                # 完成声明留给校验后的 completed / complete_rejected 事件输出，
+                # 避免「先打目标达成、后被拒绝」的错位
+                pass
             elif decision.get("intents"):
                 target_console.print(
                     f"[cyan]◆ Reason:[/cyan] 提出 {len(decision['intents'])} 个新探索方向"
                 )
             else:
                 target_console.print("[dim]◆ Reason: 暂不新增方向[/dim]")
+        elif kind == "completed":
+            target_console.print("[green]✓ Reason: 目标达成[/green]")
         elif kind == "explore_start":
             target_console.print(
                 f"[yellow]▶ Explore {payload['intent_id']}:[/yellow] {payload['description'][:90]}"
@@ -259,6 +264,12 @@ def _run_repl() -> None:
     mcp_manager = MCPLifecycleManager(config)
     started = mcp_manager.start_enabled_servers()
     console.print(_("cli.mcp_registered", count=started))
+    # Report any servers that failed to attach so the user knows immediately
+    for srv_name, srv_state in mcp_manager.registry.get_all_servers().items():
+        if srv_state.health_status in ("degraded", "unavailable") and srv_state.execution_mode in ("placeholder",):
+            err_msg = getattr(srv_state, "error", "") or ""
+            if err_msg:
+                console.print(f"[yellow]  ⚠ {srv_name}: {err_msg[:120]}[/yellow]")
 
     # Initialize agent
     agent = AgentCore(config, mcp_manager)

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -125,11 +125,13 @@ class LLMConfig(BaseModel):
 class MCPTransportConfig(BaseModel):
     """MCP server transport configuration."""
 
-    type: str = Field(description="Transport type: stdio, sse")
+    type: str = Field(description="Transport type: stdio, sse, streamable-http")
     command: str | None = Field(default=None, description="Command to start the server (stdio)")
     args: list[str] | None = Field(default=None, description="Command arguments")
-    url: str | None = Field(default=None, description="Server URL (sse)")
-    env: dict[str, str] | None = Field(default=None, description="Environment variables")
+    url: str | None = Field(default=None, description="Server URL (sse / streamable-http)")
+    env: dict[str, str] | None = Field(
+        default=None, description="Environment variables (stdio) / HTTP headers (streamable-http)"
+    )
     startup_timeout: int = Field(default=30000, description="Startup timeout in ms")
     tool_timeout: int = Field(default=300000, description="Tool call timeout in ms")
 
@@ -148,6 +150,35 @@ class MCPServersConfig(BaseModel):
     """All MCP servers configuration."""
 
     servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
+
+
+class ReconConfig(BaseModel):
+    """Information-gathering configuration: space-mapping API keys + recon knobs.
+
+    Keys are read here OR from environment variables (FOFA_KEY, HUNTER_KEY,
+    QUAKE_KEY, ZOOMEYE_KEY, SHODAN_KEY, ZEROZONE_KEY) — never hard-coded. Put real
+    keys in ~/.vulnclaw/config.yaml (gitignored), not in source.
+    """
+
+    fofa_email: str = Field(default="", description="FOFA account email")
+    fofa_key: str = Field(default="", description="FOFA API key")
+    hunter_key: str = Field(default="", description="Hunter (奇安信鹰图) API key")
+    quake_key: str = Field(default="", description="Quake (360) API token")
+    zoomeye_key: str = Field(default="", description="ZoomEye (钟馗之眼) API key")
+    shodan_key: str = Field(default="", description="Shodan API key")
+    zerozone_key: str = Field(default="", description="零零信安 0.zone API key")
+    http_timeout: float = Field(default=15.0, description="Per-request HTTP timeout (s)")
+    max_concurrency: int = Field(default=20, description="Max concurrent recon requests")
+    space_size: int = Field(default=100, description="Default result size per space-mapping query")
+    dir_wordlist_path: str = Field(
+        default="", description="Optional path to a custom directory-bruteforce wordlist"
+    )
+    dir_max_requests: int = Field(
+        default=1500, description="Hard cap on requests per directory-enumeration call"
+    )
+    js_max_files: int = Field(
+        default=30, description="Max JavaScript files fetched per js_recon call"
+    )
 
 
 class SafetyConfig(BaseModel):
@@ -213,6 +244,9 @@ class SessionConfig(BaseModel):
     solve_max_tool_rounds: int = Field(
         default=6, description="Max tool-calling rounds per intent exploration"
     )
+    solve_max_parallel: int = Field(
+        default=3, description="Max intents explored concurrently per solve batch (1=serial)"
+    )
     show_thinking: bool = Field(
         default=False, description="Show LLM thinking/reasoning output (default: off)"
     )
@@ -270,6 +304,7 @@ class VulnClawConfig(BaseModel):
     mcp: MCPServersConfig = Field(default_factory=MCPServersConfig)
     session: SessionConfig = Field(default_factory=SessionConfig)
     safety: SafetyConfig = Field(default_factory=SafetyConfig)
+    recon: ReconConfig = Field(default_factory=ReconConfig)
 
     model_config = ConfigDict(
         env_prefix="VULNCLAW_",

--- a/vulnclaw/config/settings.py
+++ b/vulnclaw/config/settings.py
@@ -244,6 +244,23 @@ def _overlay_env(config: VulnClawConfig) -> VulnClawConfig:
     if v := os.environ.get("VULNCLAW_SAFETY_PYTHON_EXECUTE_AUDIT_ENABLED"):
         config.safety.python_execute_audit_enabled = v.lower() in ("1", "true", "yes", "on")
 
+    # ── Recon: space-mapping API keys ────────────────────────────────
+    # Accept both the short form (FOFA_KEY) and the prefixed form
+    # (VULNCLAW_RECON_FOFA_KEY); short form wins if both are set.
+    for field, names in {
+        "fofa_email": ("FOFA_EMAIL", "VULNCLAW_RECON_FOFA_EMAIL"),
+        "fofa_key": ("FOFA_KEY", "VULNCLAW_RECON_FOFA_KEY"),
+        "hunter_key": ("HUNTER_KEY", "VULNCLAW_RECON_HUNTER_KEY"),
+        "quake_key": ("QUAKE_KEY", "VULNCLAW_RECON_QUAKE_KEY"),
+        "zoomeye_key": ("ZOOMEYE_KEY", "VULNCLAW_RECON_ZOOMEYE_KEY"),
+        "shodan_key": ("SHODAN_KEY", "VULNCLAW_RECON_SHODAN_KEY"),
+        "zerozone_key": ("ZEROZONE_KEY", "VULNCLAW_RECON_ZEROZONE_KEY"),
+    }.items():
+        for env_name in names:
+            if v := os.environ.get(env_name):
+                setattr(config.recon, field, v)
+                break
+
     return config
 
 

--- a/vulnclaw/mcp/lifecycle.py
+++ b/vulnclaw/mcp/lifecycle.py
@@ -6,6 +6,7 @@ import asyncio
 import subprocess
 import time
 from contextlib import suppress
+from datetime import timedelta
 from typing import Any
 from urllib.parse import urlparse
 
@@ -20,6 +21,16 @@ except ImportError:  # pragma: no cover - optional runtime dependency
     ClientSession = None
     StdioServerParameters = None
     stdio_client = None
+
+try:
+    from mcp.client.streamable_http import streamablehttp_client
+except ImportError:  # pragma: no cover - optional runtime dependency
+    streamablehttp_client = None
+
+# Transport type aliases that map to the MCP Streamable HTTP client.
+HTTP_TRANSPORT_TYPES = frozenset(
+    {"streamable-http", "streamable_http", "streamablehttp", "http"}
+)
 
 
 class MCPLifecycleManager:
@@ -233,6 +244,21 @@ class MCPLifecycleManager:
             self._register_known_tools(name)
             return True
 
+        if transport.type in HTTP_TRANSPORT_TYPES:
+            self.registry.set_server_health(name, HealthStatus.STARTING.value)
+            attached = self._try_attach_http_client(name, config)
+            self.registry.set_server_attach_result(name, attempted=True, succeeded=attached)
+            self.registry.set_server_running(name, running=attached)
+            self.registry.set_server_execution_mode(name, "http" if attached else "placeholder")
+            self.registry.set_server_health(
+                name,
+                HealthStatus.HEALTHY.value if attached else HealthStatus.DEGRADED.value,
+            )
+            # 探测失败时回退到静态已知工具，至少让 LLM 能看到工具名
+            if not attached:
+                self._register_known_tools(name)
+            return True
+
         self.registry.set_server_health(name, "unavailable")
         return False
 
@@ -309,29 +335,143 @@ class MCPLifecycleManager:
 
         return False
 
-    def _probe_stdio_server(
+    def _try_attach_http_client(self, name: str, config: MCPServerConfig) -> bool:
+        """Validate a Streamable HTTP MCP server and mark it for lazy connection.
+
+        Many HTTP MCP servers (Chrome DevTools, etc.) only support **one concurrent
+        session**.  If we probe (connect + initialize + list_tools + disconnect) at
+        startup, the server may not release the session cleanly, causing the real
+        persistent session created on the first tool call to fail with
+        "Already connected to a transport".
+
+        To avoid this, we only validate the URL and do a lightweight HTTP reachability
+        check here.  The real MCP session (with tool discovery) is created lazily by
+        ``_get_or_create_persistent_http_session`` on the first actual tool call.
+        """
+        if ClientSession is None or streamablehttp_client is None:
+            self.registry.set_server_error(
+                name, "MCP Python SDK is not installed", error_type="sdk_unavailable"
+            )
+            return False
+
+        url = config.transport.url or ""
+        if not url:
+            self.registry.set_server_error(
+                name, "streamable-http transport is missing url", error_type="config_error"
+            )
+            return False
+
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            self.registry.set_server_error(
+                name, f"invalid streamable-http url: {url}", error_type="config_error"
+            )
+            return False
+
+        # Lightweight reachability check (no MCP session, no session slot consumed)
+        reachable = self._check_http_reachable(url, self._startup_timeout_seconds(config))
+        if not reachable:
+            self.registry.set_server_error(
+                name, f"streamable-http server unreachable at {url}", error_type="attach_failed"
+            )
+            return False
+
+        self._mcp_clients[name] = {"kind": "http-lazy", "config": config}
+        self._register_known_tools(name)
+        return True
+
+    def _check_http_reachable(self, url: str, timeout_s: float) -> bool:
+        """Quick HTTP GET to verify the server is up (no MCP protocol, no session)."""
+        try:
+            import httpx
+
+            r = httpx.get(url, timeout=min(timeout_s, 10), verify=False)
+            # Any response (even 400/405) means the server is alive
+            return True
+        except Exception:
+            return False
+
+    def _probe_http_server(
         self, config: MCPServerConfig
     ) -> tuple[bool, str, list[dict[str, Any]]]:
-        """Run a one-shot stdio MCP probe to validate the server can initialize."""
+        """One-shot Streamable HTTP probe with a hard timeout (never hangs)."""
+        timeout_s = self._startup_timeout_seconds(config)
+        return self._run_probe(self._async_probe_http_server(config), timeout_s)
+
+    async def _async_probe_http_server(
+        self, config: MCPServerConfig
+    ) -> tuple[bool, str, list[dict[str, Any]]]:
+        url = config.transport.url or ""
+        headers = config.transport.env or None
+        connect_s = self._startup_timeout_seconds(config)
+        read_s = self._tool_timeout_seconds(config)
+        try:
+            async with streamablehttp_client(
+                url, headers=headers, timeout=connect_s, sse_read_timeout=read_s
+            ) as (read_stream, write_stream, _get_session_id):
+                async with ClientSession(
+                    read_stream, write_stream, read_timeout_seconds=timedelta(seconds=read_s)
+                ) as session:
+                    await session.initialize()
+                    tools = await session.list_tools()
+                    tool_defs = self._normalize_mcp_tools(getattr(tools, "tools", []) or [])
+                    return True, f"initialized with {len(tool_defs)} tools", tool_defs
+        except BaseException as exc:
+            # 从 ExceptionGroup 中提取根因（anyio TaskGroup 把真实异常包了一层）
+            detail = str(exc)
+            if hasattr(exc, "exceptions"):
+                subs = list(getattr(exc, "exceptions", []))
+                if subs:
+                    detail = "; ".join(str(s) for s in subs)
+            if "already connected" in detail.lower():
+                detail += " (请重启 MCP 服务或关闭旧客户端连接)"
+            return False, detail, []
+
+    def _run_probe(
+        self, coro: Any, timeout_s: float
+    ) -> tuple[bool, str, list[dict[str, Any]]]:
+        """Run an async probe, handling both 'no loop' and 'loop already running' cases.
+
+        When called from within an active event loop (e.g. VulnClaw's REPL under
+        asyncio.run), ``asyncio.run()`` would fail.  We fall back to creating a
+        *new* event loop on a background thread so the probe can complete without
+        blocking the caller's loop.
+        """
+        import concurrent.futures
+
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             loop = None
 
-        if loop and loop.is_running():
-            return False, "stdio probe skipped because an event loop is already running", []
+        if loop is None or not loop.is_running():
+            try:
+                return asyncio.run(asyncio.wait_for(coro, timeout=timeout_s))
+            except asyncio.TimeoutError:
+                return False, f"probe timed out after {timeout_s:.0f}s", []
+            except Exception as exc:
+                return False, str(exc), []
 
-        timeout_s = self._startup_timeout_seconds(config)
+        # A loop is already running — run the probe on a worker thread with its
+        # own event loop so we don't deadlock the caller.
+        def _in_thread():
+            return asyncio.run(asyncio.wait_for(coro, timeout=timeout_s))
+
         try:
-            return asyncio.run(
-                asyncio.wait_for(self._async_probe_stdio_server(config), timeout=timeout_s)
-            )
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(_in_thread)
+                return future.result(timeout=timeout_s + 5)
         except asyncio.TimeoutError:
-            return False, f"stdio attach timed out after {timeout_s:.0f}s", []
-        except RuntimeError as exc:
+            return False, f"probe timed out after {timeout_s:.0f}s", []
+        except Exception as exc:
             return False, str(exc), []
-        except Exception as exc:  # pragma: no cover - defensive
-            return False, str(exc), []
+
+    def _probe_stdio_server(
+        self, config: MCPServerConfig
+    ) -> tuple[bool, str, list[dict[str, Any]]]:
+        """Run a one-shot stdio MCP probe to validate the server can initialize."""
+        timeout_s = self._startup_timeout_seconds(config)
+        return self._run_probe(self._async_probe_stdio_server(config), timeout_s)
 
     @staticmethod
     def _startup_timeout_seconds(config: MCPServerConfig) -> float:
@@ -339,6 +479,18 @@ class MCPLifecycleManager:
         raw = getattr(config.transport, "startup_timeout", None)
         if not raw or raw <= 0:
             return 30.0
+        return float(raw) / 1000.0
+
+    @staticmethod
+    def _tool_timeout_seconds(config: MCPServerConfig) -> float:
+        """Resolve the per-call tool timeout (config is in ms) to seconds, defaulting to 300s.
+
+        This bounds how long a single tool call waits for the server's (possibly
+        streamed) response, so a silent server can never deadlock the agent.
+        """
+        raw = getattr(config.transport, "tool_timeout", None)
+        if not raw or raw <= 0:
+            return 300.0
         return float(raw) / 1000.0
 
     async def _async_probe_stdio_server(
@@ -353,11 +505,12 @@ class MCPLifecycleManager:
 
         try:
             async with stdio_client(server) as (read_stream, write_stream):
-                session = ClientSession(read_stream, write_stream)
-                await session.initialize()
-                tools = await session.list_tools()
-                tool_defs = self._normalize_mcp_tools(getattr(tools, "tools", []) or [])
-                return True, f"initialized with {len(tool_defs)} tools", tool_defs
+                # async with ClientSession 启动 _receive_loop，否则 initialize() 不会有人读响应而卡死。
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    tools = await session.list_tools()
+                    tool_defs = self._normalize_mcp_tools(getattr(tools, "tools", []) or [])
+                    return True, f"initialized with {len(tool_defs)} tools", tool_defs
         except Exception as exc:
             return False, str(exc), []
 
@@ -444,11 +597,15 @@ class MCPLifecycleManager:
             env=transport.env,
         )
 
+        timeout_s = self._tool_timeout_seconds(config)
         async with stdio_client(server) as (read_stream, write_stream):
-            session = ClientSession(read_stream, write_stream)
-            await session.initialize()
-            result = await session.call_tool(tool_name, arguments=arguments)
-            return result
+            async with ClientSession(
+                read_stream, write_stream, read_timeout_seconds=timedelta(seconds=timeout_s)
+            ) as session:
+                await session.initialize()
+                return await asyncio.wait_for(
+                    session.call_tool(tool_name, arguments=arguments), timeout=timeout_s
+                )
 
     async def _get_or_create_persistent_stdio_session(self, server_name: str) -> Any:
         """Create and cache a persistent stdio-backed MCP session for the current loop."""
@@ -473,10 +630,15 @@ class MCPLifecycleManager:
             args=transport.args or [],
             env=transport.env,
         )
+        timeout_s = self._tool_timeout_seconds(config)
 
         cm = stdio_client(server)
         read_stream, write_stream = await cm.__aenter__()
-        session = ClientSession(read_stream, write_stream)
+        session = ClientSession(
+            read_stream, write_stream, read_timeout_seconds=timedelta(seconds=timeout_s)
+        )
+        # 进入 ClientSession 上下文以启动 _receive_loop；否则后续调用读不到响应而卡死。
+        await session.__aenter__()
         await session.initialize()
 
         self._mcp_clients[server_name] = {
@@ -487,6 +649,120 @@ class MCPLifecycleManager:
             "context_manager": cm,
         }
         return session
+
+    async def _get_or_create_persistent_http_session(self, server_name: str) -> Any:
+        """Create and cache a persistent Streamable HTTP MCP session for the current loop.
+
+        First call establishes the session AND discovers real tools (replacing the
+        static placeholders registered at startup).  Subsequent calls in the same
+        event loop return the cached session.
+
+        If the connect/initialize fails (e.g. "Already connected"), the error is
+        raised to the caller so the tool_call_manager can handle it as a service
+        error — it never crashes the entire solve loop.
+        """
+        if streamablehttp_client is None or ClientSession is None:
+            raise RuntimeError("MCP Python SDK is not installed")
+
+        client_meta = self._mcp_clients.get(server_name)
+        current_loop = asyncio.get_running_loop()
+
+        if isinstance(client_meta, dict) and client_meta.get("kind") == "persistent-http":
+            if client_meta.get("loop") is current_loop and client_meta.get("session") is not None:
+                return client_meta["session"]
+
+        config = None
+        if isinstance(client_meta, dict):
+            config = client_meta.get("config")
+        if config is None:
+            config = self.config.mcp.servers.get(server_name)
+        if config is None:
+            raise RuntimeError(f"missing MCP config for server {server_name}")
+
+        url = config.transport.url or ""
+        if not url:
+            raise RuntimeError(f"streamable-http transport for {server_name} is missing url")
+        headers = config.transport.env or None
+        connect_s = self._startup_timeout_seconds(config)
+        read_s = self._tool_timeout_seconds(config)
+
+        cm = None
+        session = None
+        try:
+            cm = streamablehttp_client(
+                url, headers=headers, timeout=connect_s, sse_read_timeout=read_s
+            )
+            read_stream, write_stream, _get_session_id = await cm.__aenter__()
+            session = ClientSession(
+                read_stream, write_stream, read_timeout_seconds=timedelta(seconds=read_s)
+            )
+            await session.__aenter__()
+            await session.initialize()
+        except BaseException as exc:
+            # Clean up partial state
+            if session is not None:
+                with suppress(Exception):
+                    await session.__aexit__(None, None, None)
+            if cm is not None:
+                with suppress(Exception):
+                    await cm.__aexit__(None, None, None)
+            # Extract root cause from ExceptionGroup
+            detail = str(exc)
+            if hasattr(exc, "exceptions"):
+                subs = list(getattr(exc, "exceptions", []))
+                if subs:
+                    detail = "; ".join(str(s) for s in subs)
+            raise RuntimeError(
+                f"streamable-http session for {server_name} failed: {detail}"
+            ) from None
+
+        # 首次连接时发现真实工具并替换启动时注册的静态占位工具
+        try:
+            tools = await session.list_tools()
+            tool_defs = self._normalize_mcp_tools(getattr(tools, "tools", []) or [])
+            if tool_defs:
+                self._register_runtime_tools(server_name, tool_defs)
+        except Exception:
+            pass
+
+        self._mcp_clients[server_name] = {
+            "kind": "persistent-http",
+            "config": config,
+            "loop": current_loop,
+            "session": session,
+            "context_manager": cm,
+        }
+        self.registry.set_server_running(server_name, running=True)
+        self.registry.set_server_health(server_name, HealthStatus.HEALTHY.value)
+        return session
+
+    async def _get_or_create_session(self, server_name: str) -> Any:
+        """Return a persistent MCP session, dispatching by the server's transport type."""
+        config = self.config.mcp.servers.get(server_name)
+        client_meta = self._mcp_clients.get(server_name)
+        if config is None and isinstance(client_meta, dict):
+            config = client_meta.get("config")
+        transport_type = (
+            config.transport.type if config and config.transport else ""
+        ).lower()
+        if transport_type in HTTP_TRANSPORT_TYPES:
+            return await self._get_or_create_persistent_http_session(server_name)
+        return await self._get_or_create_persistent_stdio_session(server_name)
+
+    def _is_sdk_attachable(self, server_name: str) -> bool:
+        """Whether this server can be driven over a real MCP SDK transport."""
+        config = self.config.mcp.servers.get(server_name)
+        client_meta = self._mcp_clients.get(server_name)
+        if config is None and isinstance(client_meta, dict):
+            config = client_meta.get("config")
+        if config is None or config.transport is None:
+            return False
+        ttype = (config.transport.type or "").lower()
+        if ttype in HTTP_TRANSPORT_TYPES:
+            return streamablehttp_client is not None and ClientSession is not None
+        if ttype == "stdio":
+            return stdio_client is not None and ClientSession is not None
+        return False
 
     def _is_process_alive(self, server_name: str) -> bool:
         """Return True if the server's tracked subprocess (if any) is still running.
@@ -553,14 +829,33 @@ class MCPLifecycleManager:
             and state.health_status == HealthStatus.HEALTHY.value
         )
 
+    @staticmethod
+    def _is_persistent_session(client_meta: Any) -> bool:
+        if not isinstance(client_meta, dict):
+            return False
+        return client_meta.get("kind") in ("persistent-stdio", "persistent-http")
+
+    async def _aclose_session_meta(self, client_meta: Any) -> None:
+        """Exit a persistent session then its transport context manager (order matters)."""
+        if not self._is_persistent_session(client_meta):
+            return
+        session = client_meta.get("session")
+        if session is not None:
+            try:
+                await session.__aexit__(None, None, None)
+            except BaseException:
+                pass
+        cm = client_meta.get("context_manager")
+        if cm is not None:
+            try:
+                await cm.__aexit__(None, None, None)
+            except BaseException:
+                pass
+
     async def _teardown_server(self, server_name: str) -> None:
         """Close any cached session and kill any tracked process for a server."""
         client_meta = self._mcp_clients.pop(server_name, None)
-        if isinstance(client_meta, dict) and client_meta.get("kind") == "persistent-stdio":
-            cm = client_meta.get("context_manager")
-            if cm is not None:
-                with suppress(Exception):
-                    await cm.__aexit__(None, None, None)
+        await self._aclose_session_meta(client_meta)
 
         proc = self._processes.pop(server_name, None)
         if proc is not None:
@@ -653,18 +948,8 @@ class MCPLifecycleManager:
             ],
             "chrome-devtools": [
                 {
-                    "name": "new_page",
-                    "description": "Open a new browser page",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "url": {"type": "string", "description": "URL to navigate to"},
-                        },
-                    },
-                },
-                {
-                    "name": "navigate",
-                    "description": "Navigate to a URL in the current page",
+                    "name": "chrome_navigate",
+                    "description": "Navigate Chrome to a URL. After navigating, use chrome_read_page or chrome_get_web_content to read the page content.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -674,22 +959,111 @@ class MCPLifecycleManager:
                     },
                 },
                 {
-                    "name": "screenshot",
+                    "name": "chrome_read_page",
+                    "description": "Read the current page content (HTML, text, links, forms). Use this AFTER chrome_navigate to get page data.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": {"type": "string", "description": "Output format: text, html, links, forms", "default": "text"},
+                        },
+                    },
+                },
+                {
+                    "name": "chrome_screenshot",
                     "description": "Take a screenshot of the current page",
                     "inputSchema": {"type": "object", "properties": {}},
                 },
                 {
-                    "name": "evaluate_js",
-                    "description": "Evaluate JavaScript in the browser",
+                    "name": "chrome_javascript",
+                    "description": "Execute JavaScript in the browser and return the result",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "expression": {
-                                "type": "string",
-                                "description": "JS expression to evaluate",
-                            },
+                            "code": {"type": "string", "description": "JavaScript code to execute"},
                         },
-                        "required": ["expression"],
+                        "required": ["code"],
+                    },
+                },
+                {
+                    "name": "chrome_get_web_content",
+                    "description": "Get structured web content from the current page (headings, links, images, meta tags)",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string", "description": "URL to get content from (optional, uses current page if omitted)"},
+                        },
+                    },
+                },
+                {
+                    "name": "chrome_console",
+                    "description": "Get browser console messages (errors, warnings, logs)",
+                    "inputSchema": {"type": "object", "properties": {}},
+                },
+                {
+                    "name": "chrome_network_request",
+                    "description": "Send an HTTP request through the browser context (with cookies/session)",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string", "description": "URL"},
+                            "method": {"type": "string", "description": "HTTP method"},
+                            "headers": {"type": "object", "description": "Headers"},
+                            "body": {"type": "string", "description": "Request body"},
+                        },
+                        "required": ["url"],
+                    },
+                },
+                {
+                    "name": "chrome_click_element",
+                    "description": "Click an element on the page by CSS selector or text",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "selector": {"type": "string", "description": "CSS selector or text to click"},
+                        },
+                        "required": ["selector"],
+                    },
+                },
+                {
+                    "name": "chrome_fill_or_select",
+                    "description": "Fill in a form field or select an option",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "selector": {"type": "string", "description": "CSS selector of the input"},
+                            "value": {"type": "string", "description": "Value to fill"},
+                        },
+                        "required": ["selector", "value"],
+                    },
+                },
+                {
+                    "name": "chrome_pentest_http",
+                    "description": "Analyze HTTP security: CORS, CSP, HSTS, cookie flags, security headers",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string", "description": "URL to analyze"},
+                        },
+                    },
+                },
+                {
+                    "name": "chrome_pentest_js_analyze",
+                    "description": "Analyze JavaScript for security issues: eval, innerHTML, postMessage, secrets",
+                    "inputSchema": {"type": "object", "properties": {}},
+                },
+                {
+                    "name": "chrome_pentest_cookies",
+                    "description": "Analyze cookies for security: HttpOnly, Secure, SameSite flags",
+                    "inputSchema": {"type": "object", "properties": {}},
+                },
+                {
+                    "name": "chrome_pentest_headers",
+                    "description": "Check HTTP response security headers",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string", "description": "URL to check"},
+                        },
                     },
                 },
             ],
@@ -765,12 +1139,13 @@ class MCPLifecycleManager:
         """Stop a single MCP server (synchronous; safe to call without a running loop)."""
         self.registry.set_server_health(name, HealthStatus.STOPPING.value)
         client_meta = self._mcp_clients.pop(name, None)
-        if isinstance(client_meta, dict) and client_meta.get("kind") == "persistent-stdio":
-            cm = client_meta.get("context_manager")
+        if self._is_persistent_session(client_meta):
             loop = client_meta.get("loop")
-            if cm is not None and loop is not None and not loop.is_closed():
+            if loop is not None and not loop.is_closed():
                 try:
-                    future = asyncio.run_coroutine_threadsafe(cm.__aexit__(None, None, None), loop)
+                    future = asyncio.run_coroutine_threadsafe(
+                        self._aclose_session_meta(client_meta), loop
+                    )
                     future.result(timeout=5)
                 except Exception:
                     pass
@@ -949,6 +1324,39 @@ class MCPLifecycleManager:
                         suggestion="Start the Burp MCP service and verify the proxy integration is ready.",
                     )
 
+            # 通用路径：任何经 SDK attach 成功的 stdio/streamable-http 服务（如自定义
+            # streamable-mcp-server）都走真实会话调用，而不是回落到 unsupported。
+            if self._is_sdk_attachable(server_name):
+                try:
+                    content, structured = await self._call_attached_server(
+                        server_name, tool_name, arguments
+                    )
+                    self.registry.record_tool_call(server_name, success=True)
+                    self.registry.set_server_health(server_name, "healthy")
+                    return self._tool_result(
+                        ok=True,
+                        server=server_name,
+                        tool=tool_name,
+                        execution_mode=mode,
+                        content=content,
+                        structured_content=structured,
+                    )
+                except Exception as exc:
+                    message = str(exc)
+                    self.registry.record_tool_call(server_name, success=False)
+                    self.registry.set_server_error(
+                        server_name, message, error_type="service_unavailable"
+                    )
+                    return self._tool_result(
+                        ok=False,
+                        server=server_name,
+                        tool=tool_name,
+                        execution_mode=mode,
+                        error_type="service_unavailable",
+                        message=message,
+                        suggestion="Verify the MCP server is reachable and the tool name/args are valid.",
+                    )
+
             message = (
                 f"MCP tool '{tool_name}' is registered in {mode} mode but is not executable yet."
             )
@@ -1021,22 +1429,29 @@ class MCPLifecycleManager:
             return str(value) if value else "[-] 未找到"
         return "[!] 未知 memory 工具"
 
+    async def _call_attached_server(
+        self, server_name: str, tool_name: str, args: dict
+    ) -> tuple[str, dict[str, Any] | None]:
+        """Call a tool on an attached SDK server (stdio or streamable-http).
+
+        The call is bounded by the server's tool_timeout so a silent/streaming
+        server can never deadlock the agent loop.
+        """
+        session = await self._get_or_create_session(server_name)
+        config = self.config.mcp.servers.get(server_name)
+        timeout_s = self._tool_timeout_seconds(config) if config else 300.0
+        result = await asyncio.wait_for(
+            session.call_tool(tool_name, arguments=args), timeout=timeout_s
+        )
+        rendered, structured, is_error = self._render_mcp_call_result(result)
+        if is_error:
+            raise RuntimeError(rendered or f"{server_name} call returned an error")
+        return rendered, structured
+
     async def _call_chrome(self, tool_name: str, args: dict) -> tuple[str, dict[str, Any] | None]:
         """Execute a Chrome DevTools tool call."""
-        session = await self._get_or_create_persistent_stdio_session("chrome-devtools")
-        result = await session.call_tool(tool_name, arguments=args)
-        rendered, _, is_error = self._render_mcp_call_result(result)
-        if is_error:
-            raise RuntimeError(rendered or "chrome-devtools call returned an error")
-        _, structured, _ = self._render_mcp_call_result(result)
-        return rendered, structured
+        return await self._call_attached_server("chrome-devtools", tool_name, args)
 
     async def _call_burp(self, tool_name: str, args: dict) -> tuple[str, dict[str, Any] | None]:
         """Execute a Burp Suite tool call."""
-        session = await self._get_or_create_persistent_stdio_session("burp")
-        result = await session.call_tool(tool_name, arguments=args)
-        rendered, _, is_error = self._render_mcp_call_result(result)
-        if is_error:
-            raise RuntimeError(rendered or "burp call returned an error")
-        _, structured, _ = self._render_mcp_call_result(result)
-        return rendered, structured
+        return await self._call_attached_server("burp", tool_name, args)


### PR DESCRIPTION
## 这次改了啥

之前 solve 引擎一次只能探索一个方向，跑完一个再跑下一个，效率很低。这次改成了多个方向同时跑（asyncio.gather，默认最多 3 个并行），单个方向炸了不影响其他的。

另外之前 agent 没有 JS 信息收集能力，遇到目标只会反复 fetch 同一个页面。现在加了一整套信息收集工具，agent 拿到目标后能自动抓 JS 提接口、跑目录枚举、查空间测绘、做子域名爆破，收集到的接口还会自动过一遍未授权探测。

MCP 这边之前只支持 stdio 传输，Chrome DevTools MCP 这类 HTTP 服务连不上。现在加了 streamable-http 支持，启动时不占 session slot，第一次调工具才建连，自动发现真实工具列表。

## 具体改动

**solve 引擎**
- 多 intent 并行探索，每个 intent 有独立的证据缓冲区和工具调用记录
- reason 阶段加了 checkpoint，图没变化就不重跑（之前每轮都跑，同一个方向能提 6 遍）
- 已放弃的方向做 Jaccard 去重，不会再被重复提出
- conclude 阶段放宽了"有进展"的判定——发现新接口、确认未授权这些都算推进，不再轻易丢弃有价值的发现
- 完成判定加了否定闸门，模型说"未达到完成标准"不会再被误判为已完成

**信息收集工具（新）**
- `js_recon`：抓页面和所有 JS 文件，提 API 路径 / 关联域名 / 硬编码密钥，从 JS 里动态发现实体名并排列组合出隐藏接口（比如只出现了 "/jalis/rest" 和 "User" 就能推断出 /jalis/rest/User/list），收集到的接口自动做未授权探测（GET+POST 双发）
- `unauth_test`：批量未授权验证，能做有 token / 无 token 差分对比，自动跳过 delete/save 等写接口
- `dir_enum`：目录枚举，带 404 基线和全局伪装 200 识别，随机路径返回 200 就自动停
- `space_search`：FOFA / Hunter / Quake / Shodan / ZoomEye / 0.zone 六个引擎统一查询
- `subdomain_enum`：空间测绘被动聚合 + DNS 小字典爆破

**MCP**
- 新增 streamable-http 传输，Chrome MCP 连上后自动拉 33 个真实工具
- 占位工具名改成了 Chrome MCP 的真实名字（chrome_navigate / chrome_read_page 等）
- 连接失败不会 crash 整个测试流程，降级继续跑
- 工具返回 undefined 会标记为失败，不再静默吞掉

**其他**
- blackboard 加了工具调用日志，跨方向可见，agent 能看到"这个接口已经 fetch 过了"不会重复调
- fact/intent 序号在 session 恢复后能正确续接，不会 ID 冲突
- 新增 ReconConfig，空间测绘 key 从 config.yaml 或环境变量读取，不硬编码