### PR TITLE
fix: set default OpenAI client user agent

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,6 +221,15 @@ class TestSettingsLoad:
         # Just verify it doesn't crash
         assert config is not None
 
+    def test_openai_default_headers_allow_user_agent_override(self, monkeypatch):
+        from vulnclaw.config.settings import openai_default_headers
+
+        assert openai_default_headers()["User-Agent"] == "Mozilla/5.0"
+
+        monkeypatch.setenv("VULNCLAW_LLM_USER_AGENT", "test-agent")
+
+        assert openai_default_headers()["User-Agent"] == "test-agent"
+
     def test_env_var_override_new_session_fields(self, monkeypatch):
         """二开新增的 session 配置（反思/插件）可通过环境变量注入。"""
         from vulnclaw.config.settings import load_config

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -43,6 +43,7 @@ from vulnclaw.agent.skill_context import get_active_skill_context
 from vulnclaw.agent.system_prompt import build_dynamic_system_prompt
 from vulnclaw.agent.tool_call_manager import safe_parse_tool_args
 from vulnclaw.config.schema import VulnClawConfig
+from vulnclaw.config.settings import make_openai_client
 from vulnclaw.target_state.store import save_target_state
 
 # Optional KB integration — gracefully degrade if KB data is unavailable
@@ -231,9 +232,7 @@ class AgentCore:
         """Lazy-initialize OpenAI client."""
         if self._client is None:
             try:
-                from openai import OpenAI
-
-                self._client = OpenAI(
+                self._client = make_openai_client(
                     api_key=self.config.llm.api_key,
                     base_url=self.config.llm.base_url,
                 )

--- a/vulnclaw/config/settings.py
+++ b/vulnclaw/config/settings.py
@@ -30,12 +30,30 @@ KB_DIR = CONFIG_DIR / "kb"
 SKILLS_DIR = CONFIG_DIR / "skills"
 WEB_TASKS_FILE = CONFIG_DIR / "web_tasks.json"
 PYTHON_EXECUTE_AUDIT_FILE = CONFIG_DIR / "python_execute_audit.jsonl"
+DEFAULT_OPENAI_USER_AGENT = "Mozilla/5.0"
 
 
 def ensure_dirs() -> None:
     """Create VulnClaw config directories if they don't exist."""
     for d in [CONFIG_DIR, SESSIONS_DIR, TARGETS_DIR, KB_DIR, SKILLS_DIR]:
         d.mkdir(parents=True, exist_ok=True)
+
+
+def openai_default_headers() -> dict[str, str]:
+    return {"User-Agent": os.environ.get("VULNCLAW_LLM_USER_AGENT", DEFAULT_OPENAI_USER_AGENT)}
+
+
+def make_openai_client(api_key: str, base_url: str, timeout: float | None = None):
+    from openai import OpenAI
+
+    kwargs: dict[str, Any] = {
+        "api_key": api_key,
+        "base_url": base_url,
+        "default_headers": openai_default_headers(),
+    }
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return OpenAI(**kwargs)
 
 
 # ── Load / Save ────────────────────────────────────────────────────
@@ -347,9 +365,7 @@ def fetch_provider_models(base_url: str, api_key: str, timeout: float = 10.0) ->
     if not base_url or not api_key:
         return []
     try:
-        from openai import OpenAI
-
-        client = OpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
+        client = make_openai_client(api_key=api_key, base_url=base_url, timeout=timeout)
         models_page = client.models.list()
         model_ids = [m.id for m in models_page if m.id]
         return sorted(model_ids)

--- a/vulnclaw/report/generator.py
+++ b/vulnclaw/report/generator.py
@@ -500,16 +500,14 @@ CYCLE_REPORT_TEMPLATE = """\
 def _generate_attack_summary_from_session(session: SessionState) -> str:
     """Generate a readable attack-path summary using VulnClaw's configured LLM."""
     try:
-        from openai import OpenAI
-
         from vulnclaw.agent.think_filter import strip_think_tags
-        from vulnclaw.config.settings import load_config
+        from vulnclaw.config.settings import load_config, make_openai_client
 
         config = load_config()
         if not config.llm.api_key:
             return ""
 
-        client = OpenAI(
+        client = make_openai_client(
             api_key=config.llm.api_key,
             base_url=config.llm.base_url,
         )


### PR DESCRIPTION
OpenAI-compatible gateways may block the SDK default User-Agent. This change routes all OpenAI client creation through one helper, sets a browser-like default User-Agent