### PR TITLE
fix(agent): strip port before python_execute scope check

### DIFF
--- a/tests/test_builtin_tools.py
+++ b/tests/test_builtin_tools.py
@@ -195,6 +195,33 @@ class TestBuiltinMcpExecution:
         assert "constraint_violation" in result
         assert "Host example.com" in result
 
+    async def test_execute_python_allows_in_scope_host_with_port(self):
+        import vulnclaw.agent.builtin_tools as builtin_tools
+
+        agent = DummyAgent()
+        agent.session_state.task_constraints.allowed_hosts = ["localhost"]
+        agent.session_state.task_constraints.strict_mode = True
+
+        result = await builtin_tools.execute_python(
+            agent,
+            {"code": "import requests\nrequests.get('http://localhost:3000/home')"},
+        )
+        assert "constraint_violation" not in result
+
+    async def test_execute_python_blocks_out_of_scope_host_with_port(self):
+        import vulnclaw.agent.builtin_tools as builtin_tools
+
+        agent = DummyAgent()
+        agent.session_state.task_constraints.allowed_hosts = ["localhost"]
+        agent.session_state.task_constraints.strict_mode = True
+
+        result = await builtin_tools.execute_python(
+            agent,
+            {"code": "import requests\nrequests.get('http://evil.example:8080/x')"},
+        )
+        assert "constraint_violation" in result
+        assert "Host evil.example" in result
+
     async def test_execute_nmap_blocks_out_of_scope_port(self):
         import vulnclaw.agent.builtin_tools as builtin_tools
 

--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -896,10 +896,15 @@ async def execute_python(agent: Any, args: dict[str, Any]) -> str:
         return "[!] Code is empty; nothing executed"
 
     url_matches = re.findall(r"https?://([a-zA-Z0-9._:-]+)(/[^\s'\"`]*)?", code)
-    for host, path in url_matches:
+    for raw_host, path in url_matches:
+        # Strip the port before the scope check so an in-scope target referenced
+        # with a port (e.g. localhost:3000) is not falsely flagged out of scope.
+        # The fetch tool already compares against urlparse().hostname (no port);
+        # this keeps python_execute consistent with that behavior.
+        host = raw_host.split(":", 1)[0].lower()
         host_violation = enforce_host_path_constraints(
             agent,
-            host=host.lower(),
+            host=host,
             path=(path or "").rstrip("/"),
             target=host,
         )


### PR DESCRIPTION
execute_python extracted the URL host with the port included (e.g. "localhost:3000") via regex, then compared it against allowed_hosts, which holds the bare host ("localhost"). Any in-scope target referenced with a port was therefore falsely rejected with [constraint_violation], silently disabling python_execute for the entire run.

The fetch tool already normalizes via urlparse().hostname (no port). Strip the port in execute_python so host comparison is consistent across tools. Out-of-scope hosts (with or without a port) are still blocked.

Adds regression tests for in-scope and out-of-scope hosts carrying ports.