### PR TITLE
fix(web): prevent path traversal in asset serving and report output_path

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -164,8 +164,10 @@ class TestWebServices:
         import vulnclaw.web.services.report_service as report_service
         from vulnclaw.agent.context import SessionState, VulnerabilityFinding
 
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setattr(store_mod, "TARGETS_DIR", tmp_path / "targets")
-        monkeypatch.setattr(report_service, "SESSIONS_DIR", tmp_path / "sessions")
+        monkeypatch.setattr(report_service, "SESSIONS_DIR", sessions_dir)
 
         state = SessionState(target="https://example.com")
         finding = VulnerabilityFinding(
@@ -178,7 +180,7 @@ class TestWebServices:
         state.add_finding(finding)
         store_mod.save_target_state("https://example.com", state, command="scan")
 
-        out = tmp_path / "report.md"
+        out = sessions_dir / "report.md"
         path = report_service.generate_target_report("https://example.com", str(out))
         assert Path(path).exists()
 

--- a/vulnclaw/web/app.py
+++ b/vulnclaw/web/app.py
@@ -62,13 +62,11 @@ def resolve_web_asset(path: str) -> Path:
     if not normalized:
         return resolve_web_index()
 
-    dist_path = FRONTEND_DIST_DIR / normalized
-    if dist_path.exists() and dist_path.is_file():
-        return dist_path
-
-    static_path = STATIC_DIR / normalized
-    if static_path.exists() and static_path.is_file():
-        return static_path
+    for base_dir in (FRONTEND_DIST_DIR, STATIC_DIR):
+        candidate = (base_dir / normalized).resolve()
+        base_resolved = base_dir.resolve()
+        if base_resolved in candidate.parents and candidate.is_file():
+            return candidate
 
     return resolve_web_index()
 

--- a/vulnclaw/web/services/report_service.py
+++ b/vulnclaw/web/services/report_service.py
@@ -57,9 +57,12 @@ def generate_target_report(
         output_path=str(_default_report_path(target, normalized_format)),
     )
     if output_path:
-        destination = Path(output_path)
+        destination = Path(output_path).resolve()
+        sessions_root = SESSIONS_DIR.resolve()
+        if sessions_root not in destination.parents and destination != sessions_root:
+            raise PermissionError(f"output_path is outside sessions dir: {destination}")
         destination.write_text(Path(path).read_text(encoding="utf-8"), encoding="utf-8")
-        return str(destination.resolve())
+        return str(destination)
     return str(Path(path).resolve())
 
 


### PR DESCRIPTION
## Summary

Two path traversal vulnerabilities were found in the web UI backend that allow arbitrary file reads and writes on the local machine.

- **Arbitrary file read** (`vulnclaw/web/app.py`): `resolve_web_asset()` joined caller-supplied URL paths with the dist/static base directories without checking for `..` components. Any local process (or browser tab) could read arbitrary files via `GET /../../../../../../home/user/.ssh/id_rsa`.
- **Arbitrary file write** (`vulnclaw/web/services/report_service.py`): `generate_target_report()` wrote reports to any caller-supplied `output_path` with no bounds check, allowing overwrite of arbitrary files (`.bashrc`, `.ssh/authorized_keys`, config, etc.).

Both fixes apply the same `resolve()` + containment check already used by `resolve_report_path()` in the same codebase. The affected test was updated to write within the sessions directory as the guard now requires.

## Test plan

- [ ] `tests/test_web.py::TestWebServices::test_web_report_service_generates_target_report` — passes with `output_path` inside sessions dir
- [ ] Verify `GET /../../../../../../etc/passwd` returns the index page (falls through containment check) rather than file contents
- [ ] Verify `POST /api/reports/target` with `output_path` outside sessions dir returns a 500/PermissionError rather than writing the file