### PR TITLE
fix: chrome-devtools MCP auto-discover real tool names on session init

### DIFF
--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -440,6 +440,7 @@ def _run_repl() -> None:
                 try:
 
                     async def _run_persistent():
+                        await mcp_manager._preinit_chrome_devtools()
                         sink = TerminalStreamSink(console, config.session.show_thinking)
                         return await agent.persistent_pentest(
                             user_input=persistent_prompt,
@@ -538,6 +539,7 @@ def _run_repl() -> None:
                     # 默认走目标驱动 solve 引擎；engine=rounds 时回退到旧固定轮数循环
                     if getattr(config.session, "engine", "solve") == "solve":
                         async def _run_auto():
+                            await mcp_manager._preinit_chrome_devtools()
                             sink = TerminalStreamSink(console, config.session.show_thinking)
 
                             async def call():
@@ -631,6 +633,7 @@ def _run_repl() -> None:
                 else:
                     # Single-turn chat
                     async def _run_agent():
+                        await mcp_manager._preinit_chrome_devtools()
                         sink = TerminalStreamSink(console, config.session.show_thinking)
                         async def call():
                             return await agent.chat(user_input, target=current_target, stream_sink=sink)

--- a/vulnclaw/mcp/lifecycle.py
+++ b/vulnclaw/mcp/lifecycle.py
@@ -253,7 +253,21 @@ class MCPLifecycleManager:
                         started += 1
                 except Exception as e:
                     self.registry.set_server_error(name, str(e), error_type="startup_error")
+        # 如果事件循环在跑，后台预初始化 chrome-devtools session（在主协程入口也会跑）
+        try:
+            loop = asyncio.get_running_loop()
+            if "chrome-devtools" in self.config.mcp.servers and self.config.mcp.servers["chrome-devtools"].enabled:
+                loop.create_task(self._preinit_chrome_devtools())
+        except RuntimeError:
+            pass
         return started
+
+    async def _preinit_chrome_devtools(self) -> None:
+        """预初始化 chrome-devtools: 提前建 session + 发现工具."""
+        try:
+            await self._get_or_create_persistent_stdio_session("chrome-devtools")
+        except BaseException:
+            pass
 
     def _start_server(self, name: str, config: MCPServerConfig) -> bool:
         """Start a single MCP server.
@@ -753,6 +767,21 @@ class MCPLifecycleManager:
             with suppress(Exception):
                 await cm.__aexit__(None, None, None)
             raise
+
+        # 发现并注册真实工具名，替换 KNOWN_TOOLS 硬编码的假名
+        try:
+            result = await asyncio.wait_for(session.list_tools(), timeout=10)
+            tool_defs = self._normalize_mcp_tools(getattr(result, "tools", []) or [])
+            if tool_defs:
+                self._register_runtime_tools(server_name, tool_defs)
+        except BaseException:
+            pass
+
+        # 关闭旧 context_manager，避免 GC 回收时 cancel scope 跨 task 冲突
+        old_cm = client_meta.get("context_manager") if isinstance(client_meta, dict) else None
+        if old_cm is not None and old_cm is not cm:
+            with suppress(Exception):
+                await old_cm.__aexit__(None, None, None)
 
         self._mcp_clients[server_name] = {
             "kind": "persistent-stdio",


### PR DESCRIPTION
**问题**

当 chrome-devtools 通过 npx 配置时完全不可用。启动时的 probe 正确跳过了包管理器命令，但兜底的 KNOWN_TOOLS 占位工具名（chrome_navigate、chrome_read_page 等）与 chrome-devtools-mcp 实际暴露的工具名（navigate_page、take_snapshot 等）不一致。LLM 每次工具调用都返回 MCP error -32602: Tool chrome_navigate not found。

另外，直接覆写 _mcp_clients 中的 context_manager 而不关闭旧的，会导致 Python GC 回收残留的 stdio_client 异步生成器时触发 anyio cancel scope 崩溃。
**改动**

vulnclaw/mcp/lifecycle.py（+31 行）：

1. 在 _get_or_create_persistent_stdio_session 的 session.initialize() 之后调用 session.list_tools()，通过 _register_runtime_tools() 注册真实工具名。替换掉硬编码的占位符，不需要手动维护映射表。
2. 覆写旧的 context_manager 之前显式关闭它。防止 Python GC 回收残留的 stdio_client 生成器时触发 anyio cancel scope 错误。
3. 新增 _preinit_chrome_devtools() 方法，并在 start_enabled_servers 末尾通过 create_task 懒加载 Chrome session，让工具在第一轮 LLM 调用前就绪。

vulnclaw/cli/main.py（+3 行）：

4. 在 _run_persistent、_run_auto、_run_agent 三处入口开头调用 _preinit_chrome_devtools()，确保事件循环可用时初始化 session（因为 start_enabled_servers 可能在事件循环启动前执行）。

**测试**

对 DVWA 登录页面的手动验证确认：
- list_tools() 正常返回 29 个真实工具名
- session 缓存在多次工具调用间正常工作
- new_page、select_page、list_pages 调用全部成功
- 正常操作下无 cancel scope 错误