### PR TITLE
feat(auth): sign in with ChatGPT subscription + built-in OpenAI↔ChatGPT-backend proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ vulnclaw config set llm.model your-model-name
 
 # 2. 设置 API Key
 vulnclaw config set llm.api_key sk-your-key-here
+#    — 或改用 ChatGPT 订阅登录（无需 API Key）：
+#      vulnclaw login   （浏览器登录；详见 docs/keyless-auth.md，注意 ToS 风险）
 
 # 3. 默认：打开原 CLI / REPL
 vulnclaw
@@ -172,7 +174,8 @@ vulnclaw doctor
 
 LLM 配置:
   Provider: openai
-  API Key: 已设置
+  Auth Mode: static
+  Credentials: configured
   Base URL: https://api.openai.com/v1
   Model: gpt-4o
 
@@ -690,7 +693,9 @@ vulnclaw config set session.show_thinking false # 隐藏推理过程（也可在
 | 配置项                   | 默认值 | 说明                                     |
 | ------------------------ | ------ | ---------------------------------------- |
 | `llm.provider`           | openai | LLM 提供商（8 个内置 + custom）          |
-| `llm.api_key`            | 空     | API Key                                  |
+| `llm.api_key`            | 空     | API Key（auth_mode=static）              |
+| `llm.auth_mode`          | static | `static`（api_key）或 `oauth`（`vulnclaw login`） |
+| `llm.chatgpt_auto_proxy` | false  | 自动启动内置 ChatGPT 后端桥接代理         |
 | `llm.base_url`           | 按 provider | API 基础 URL，可自定义              |
 | `llm.model`              | 按 provider | 模型名称，可自定义                   |
 | `llm.temperature`        | 0.1    | 采样温度                                 |
@@ -715,6 +720,8 @@ vulnclaw config set session.show_thinking false # 隐藏推理过程（也可在
 | ----------------------------- | ---------------------- |
 | `VULNCLAW_LLM_PROVIDER`       | LLM 提供商名称         |
 | `VULNCLAW_LLM_API_KEY`        | API Key                |
+| `VULNCLAW_LLM_AUTH_MODE`      | static / oauth         |
+| `VULNCLAW_LLM_CHATGPT_AUTO_PROXY` | 内置 ChatGPT 代理  |
 | `VULNCLAW_LLM_BASE_URL`       | API 基础 URL           |
 | `VULNCLAW_LLM_MODEL`          | 模型名称               |
 | `VULNCLAW_SESSION_MAX_ROUNDS`| 自主渗透最大轮数       |

--- a/README_EN.md
+++ b/README_EN.md
@@ -90,6 +90,8 @@ vulnclaw config set llm.model your-model-name
 
 # 2. Set API Key
 vulnclaw config set llm.api_key sk-your-key-here
+#    — or sign in with a ChatGPT subscription instead of a key:
+#      vulnclaw login   (browser sign-in; see docs/keyless-auth.md, note the ToS caveat)
 
 # 3. Default: open the original CLI / REPL
 vulnclaw
@@ -116,7 +118,8 @@ Sample output:
 
 LLM Config:
   Provider: openai
-  API Key: set
+  Auth Mode: static
+  Credentials: configured
   Base URL: https://api.openai.com/v1
   Model: gpt-4o
 
@@ -573,7 +576,9 @@ vulnclaw config set session.show_thinking false  # hide thinking process (also i
 | Option                                  | Default        | Description                                      |
 | --------------------------------------- | -------------- | ------------------------------------------------ |
 | `llm.provider`                         | openai         | LLM provider (8 built-in + custom)              |
-| `llm.api_key`                          | empty          | API key                                          |
+| `llm.api_key`                          | empty          | API key (auth_mode=static)                       |
+| `llm.auth_mode`                        | static         | `static` (api_key) or `oauth` (`vulnclaw login`) |
+| `llm.chatgpt_auto_proxy`               | false          | Auto-start built-in ChatGPT-backend bridge proxy |
 | `llm.base_url`                         | per provider   | API base URL, customizable                       |
 | `llm.model`                            | per provider   | Model name, customizable                        |
 | `llm.temperature`                      | 0.1            | Sampling temperature                             |
@@ -594,6 +599,8 @@ vulnclaw config set session.show_thinking false  # hide thinking process (also i
 | ----------------------------------------------- | ---------------------- |
 | `VULNCLAW_LLM_PROVIDER`                       | LLM provider name      |
 | `VULNCLAW_LLM_API_KEY`                        | API key                |
+| `VULNCLAW_LLM_AUTH_MODE`                      | static / oauth         |
+| `VULNCLAW_LLM_CHATGPT_AUTO_PROXY`             | Built-in ChatGPT proxy |
 | `VULNCLAW_LLM_BASE_URL`                       | API base URL           |
 | `VULNCLAW_LLM_MODEL`                          | Model name             |
 | `VULNCLAW_SESSION__MAX_ROUNDS`                | Max autonomous rounds  |

--- a/tests/test_chatgpt_proxy.py
+++ b/tests/test_chatgpt_proxy.py
@@ -1,0 +1,232 @@
+"""Tests for the built-in ChatGPT-backend bridge proxy."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from vulnclaw.agent import chatgpt_proxy as cp
+
+
+# ── Pure translation functions ───────────────────────────────────────
+
+
+def test_chat_to_responses_maps_roles_tools_and_params():
+    req = {
+        "model": "gpt-5",
+        "messages": [
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "hi",
+                "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "result"},
+        ],
+        "tools": [{"type": "function", "function": {"name": "f", "description": "d", "parameters": {}}}],
+        "temperature": 0.3,
+        "max_tokens": 128,
+    }
+    r = cp.chat_to_responses(req)
+    assert r["instructions"] == "be terse"
+    assert [i["type"] for i in r["input"]] == [
+        "message",
+        "message",
+        "function_call",
+        "function_call_output",
+    ]
+    assert r["input"][3]["call_id"] == "c1"
+    assert r["tools"][0] == {"type": "function", "name": "f", "description": "d", "parameters": {}}
+    assert r["temperature"] == 0.3
+    assert r["max_output_tokens"] == 128
+    # The ChatGPT backend requires streaming + store=false.
+    assert r["stream"] is True
+    assert r["store"] is False
+
+
+def test_responses_to_chat_content_and_tool_calls():
+    resp = {
+        "id": "resp_1",
+        "output": [
+            {"type": "message", "content": [{"type": "output_text", "text": "hello "}]},
+            {"type": "message", "content": [{"type": "output_text", "text": "world"}]},
+            {"type": "function_call", "call_id": "c9", "name": "do", "arguments": '{"x":1}'},
+        ],
+        "usage": {"input_tokens": 5, "output_tokens": 7, "total_tokens": 12},
+    }
+    chat = cp.responses_to_chat(resp, "gpt-5")
+    msg = chat["choices"][0]["message"]
+    assert msg["content"] == "hello world"
+    assert msg["tool_calls"][0]["id"] == "c9"
+    assert msg["tool_calls"][0]["function"] == {"name": "do", "arguments": '{"x":1}'}
+    assert chat["choices"][0]["finish_reason"] == "tool_calls"
+    assert chat["usage"]["total_tokens"] == 12
+
+
+def test_responses_to_chat_output_text_fallback():
+    chat = cp.responses_to_chat({"output": [], "output_text": "flat"}, "m")
+    assert chat["choices"][0]["message"]["content"] == "flat"
+    assert chat["choices"][0]["finish_reason"] == "stop"
+
+
+def test_aggregate_sse_text_and_tool_call():
+    events = [
+        {"type": "response.created", "response": {"id": "r1"}},
+        {"type": "response.output_text.delta", "delta": "Hel"},
+        {"type": "response.output_text.delta", "delta": "lo"},
+        {
+            "type": "response.output_item.done",
+            "item": {"type": "function_call", "call_id": "c7", "name": "go", "arguments": '{"a":1}'},
+        },
+        {
+            "type": "response.completed",
+            "response": {"id": "r1", "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}},
+        },
+    ]
+    raw = [f"data: {json.dumps(e)}\n".encode() for e in events]
+    resp = cp._aggregate_sse(raw)
+    chat = cp.responses_to_chat(resp, "gpt-5.5")
+    msg = chat["choices"][0]["message"]
+    assert msg["content"] == "Hello"
+    assert msg["tool_calls"][0]["id"] == "c7"
+    assert msg["tool_calls"][0]["function"]["name"] == "go"
+    assert chat["usage"]["total_tokens"] == 5
+
+
+def test_aggregate_sse_surfaces_error():
+    raw = [
+        b'data: {"type": "response.failed", "response": {"error": {"message": "boom"}}}\n'
+    ]
+    with pytest.raises(cp._UpstreamError):
+        cp._aggregate_sse(raw)
+
+
+def test_chat_to_stream_chunks():
+    chat = {
+        "id": "x",
+        "model": "gpt-5",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "hi",
+                    "tool_calls": [
+                        {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+    chunks = cp.chat_to_stream_chunks(chat)
+    assert chunks[0]["choices"][0]["delta"]["content"] == "hi"
+    assert chunks[0]["choices"][0]["delta"]["tool_calls"][0]["index"] == 0
+    assert chunks[1]["choices"][0]["finish_reason"] == "tool_calls"
+
+
+# ── Integration: proxy server ↔ mock ChatGPT backend ─────────────────
+
+
+@pytest.fixture
+def mock_backend(monkeypatch):
+    received: dict = {}
+
+    def _sse(event: dict) -> bytes:
+        return f"event: {event['type']}\ndata: {json.dumps(event)}\n\n".encode()
+
+    class Backend(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 — emulates the streaming Responses backend
+            received["auth"] = self.headers.get("Authorization")
+            received["account"] = self.headers.get("chatgpt-account-id")
+            n = int(self.headers.get("Content-Length", 0))
+            received["body"] = json.loads(self.rfile.read(n).decode())
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(_sse({"type": "response.created", "response": {"id": "resp_x"}}))
+            self.wfile.write(
+                _sse({"type": "response.output_text.delta", "delta": "po"})
+            )
+            self.wfile.write(
+                _sse({"type": "response.output_text.delta", "delta": "ng"})
+            )
+            self.wfile.write(
+                _sse(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_x",
+                            "usage": {
+                                "input_tokens": 1,
+                                "output_tokens": 1,
+                                "total_tokens": 2,
+                            },
+                        },
+                    }
+                )
+            )
+
+        def log_message(self, *a):
+            pass
+
+    srv = HTTPServer(("127.0.0.1", 0), Backend)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    monkeypatch.setenv("VULNCLAW_CHATGPT_BACKEND_URL", f"http://127.0.0.1:{port}/responses")
+    monkeypatch.setattr(cp, "_resolve_credentials", lambda: ("tok-123", "acct-9"))
+    yield received
+    srv.shutdown()
+
+
+def _post(url, payload):
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return r.read().decode()
+
+
+def test_proxy_non_stream(mock_backend):
+    base = cp.ensure_proxy_running()
+    body = _post(
+        base + "/chat/completions",
+        {"model": "gpt-5", "messages": [{"role": "user", "content": "ping"}]},
+    )
+    chat = json.loads(body)
+    assert chat["choices"][0]["message"]["content"] == "pong"
+    assert mock_backend["auth"] == "Bearer tok-123"
+    assert mock_backend["account"] == "acct-9"
+    # request was translated into Responses shape (streaming + store=false)
+    assert mock_backend["body"]["input"][0]["type"] == "message"
+    assert mock_backend["body"]["stream"] is True
+    assert mock_backend["body"]["store"] is False
+
+
+def test_proxy_stream(mock_backend):
+    base = cp.ensure_proxy_running()
+    body = _post(
+        base + "/chat/completions",
+        {"model": "gpt-5", "messages": [{"role": "user", "content": "ping"}], "stream": True},
+    )
+    assert "data: " in body
+    assert "[DONE]" in body
+    first = json.loads(body.split("data: ", 1)[1].split("\n", 1)[0])
+    assert first["choices"][0]["delta"]["content"] == "pong"
+
+
+def test_proxy_models_endpoint(mock_backend):
+    base = cp.ensure_proxy_running()
+    with urllib.request.urlopen(base + "/models", timeout=10) as r:
+        data = json.loads(r.read().decode())
+    assert data["object"] == "list"
+    assert any(m["id"] for m in data["data"])

--- a/tests/test_chatgpt_proxy.py
+++ b/tests/test_chatgpt_proxy.py
@@ -33,6 +33,7 @@ def test_chat_to_responses_maps_roles_tools_and_params():
         "tools": [{"type": "function", "function": {"name": "f", "description": "d", "parameters": {}}}],
         "temperature": 0.3,
         "max_tokens": 128,
+        "reasoning_effort": "high",
     }
     r = cp.chat_to_responses(req)
     assert r["instructions"] == "be terse"
@@ -44,8 +45,12 @@ def test_chat_to_responses_maps_roles_tools_and_params():
     ]
     assert r["input"][3]["call_id"] == "c1"
     assert r["tools"][0] == {"type": "function", "name": "f", "description": "d", "parameters": {}}
-    assert r["temperature"] == 0.3
-    assert r["max_output_tokens"] == 128
+    # The ChatGPT backend rejects sampling/limit params — they must NOT be sent.
+    assert "temperature" not in r
+    assert "max_output_tokens" not in r
+    assert "top_p" not in r
+    # reasoning_effort is mapped onto the accepted `reasoning` object.
+    assert r["reasoning"] == {"effort": "high"}
     # The ChatGPT backend requires streaming + store=false.
     assert r["stream"] is True
     assert r["store"] is False

--- a/tests/test_token_provider.py
+++ b/tests/test_token_provider.py
@@ -1,0 +1,174 @@
+"""Tests for LLM credential resolution (static + OAuth / ChatGPT sign-in)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from vulnclaw.config import token_provider as tp
+from vulnclaw.config.schema import LLMConfig
+
+
+@pytest.fixture
+def _config_dir(tmp_path, monkeypatch):
+    """Isolate the OAuth token store in a temp config dir."""
+    monkeypatch.setenv("VULNCLAW_CONFIG_DIR", str(tmp_path))
+    yield tmp_path
+
+
+# ── static mode ──────────────────────────────────────────────────────
+
+
+def test_static_mode_returns_api_key():
+    llm = LLMConfig(api_key="sk-static")
+    assert tp.resolve_llm_token(llm) == "sk-static"
+    assert tp.has_llm_credentials(llm) is True
+
+
+def test_static_mode_without_key_is_not_credentialed():
+    llm = LLMConfig()
+    assert tp.resolve_llm_token(llm) == ""
+    assert tp.has_llm_credentials(llm) is False
+
+
+def test_unknown_mode_raises():
+    with pytest.raises(tp.TokenResolutionError):
+        tp.resolve_llm_token(LLMConfig(auth_mode="bogus"))
+
+
+# ── oauth store + resolution ─────────────────────────────────────────
+
+
+def test_oauth_has_credentials_reflects_store(_config_dir):
+    llm = LLMConfig(auth_mode="oauth")
+    assert tp.has_llm_credentials(llm) is False
+    tp.save_oauth_tokens({"access_token": "a", "refresh_token": "r"})
+    assert tp.has_llm_credentials(llm) is True
+
+
+def test_oauth_resolve_uses_valid_access_token(_config_dir):
+    tp.save_oauth_tokens({"access_token": "live", "expires_at": time.time() + 3600})
+    assert tp.resolve_llm_token(LLMConfig(auth_mode="oauth")) == "live"
+
+
+def test_oauth_resolve_without_tokens_raises(_config_dir):
+    with pytest.raises(tp.OAuthError):
+        tp.resolve_llm_token(LLMConfig(auth_mode="oauth"))
+
+
+def test_logout_removes_store(_config_dir):
+    tp.save_oauth_tokens({"access_token": "a"})
+    assert tp.logout_oauth() is True
+    assert tp.load_oauth_tokens() == {}
+
+
+def test_decode_jwt_claims_and_account_id():
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    claims = {"https://api.openai.com/auth": {"chatgpt_account_id": "acct-123"}}
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    tok = f"{header}.{payload}.sig"
+    assert tp._extract_account_id(tp._decode_jwt_claims(tok)) == "acct-123"
+    assert tp._decode_jwt_claims("not-a-jwt") == {}
+
+
+# ── Sign in with ChatGPT (Codex OAuth client) ────────────────────────
+
+
+def _make_id_token(account_id: str) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    claims = {"https://api.openai.com/auth": {"chatgpt_account_id": account_id}}
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    return f"{header}.{payload}.sig"
+
+
+def test_chatgpt_login_and_refresh(_config_dir, monkeypatch):
+    refreshes = {"n": 0}
+
+    class Provider(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 — /authorize -> 302 to callback
+            q = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            assert q["client_id"][0] == tp.CHATGPT_CLIENT_ID
+            assert q["code_challenge_method"][0] == "S256"
+            assert q["id_token_add_organizations"][0] == "true"
+            redirect = q["redirect_uri"][0]
+            sep = "&" if "?" in redirect else "?"
+            loc = redirect + sep + urllib.parse.urlencode(
+                {"code": "cgpt-code", "state": q["state"][0]}
+            )
+            self.send_response(302)
+            self.send_header("Location", loc)
+            self.end_headers()
+
+        def do_POST(self):  # noqa: N802 — /token
+            n = int(self.headers.get("Content-Length", 0))
+            form = urllib.parse.parse_qs(self.rfile.read(n).decode())
+            if form["grant_type"][0] == "authorization_code":
+                assert form["client_id"][0] == tp.CHATGPT_CLIENT_ID
+                assert form["code_verifier"][0]
+                body = {
+                    "access_token": "cgpt-1",
+                    "refresh_token": "cgpt-refresh",
+                    "expires_in": 1,
+                    "id_token": _make_id_token("acct-XYZ"),
+                }
+            else:
+                refreshes["n"] += 1
+                assert form["refresh_token"][0] == "cgpt-refresh"
+                body = {"access_token": f"cgpt-{refreshes['n'] + 1}", "expires_in": 3600}
+            data = json.dumps(body).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, *a):
+            pass
+
+    srv = HTTPServer(("127.0.0.1", 0), Provider)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        monkeypatch.setattr(tp, "CHATGPT_AUTHORIZE_URL", f"http://127.0.0.1:{port}/authorize")
+        monkeypatch.setattr(tp, "CHATGPT_TOKEN_URL", f"http://127.0.0.1:{port}/token")
+
+        def fake_open(url):
+            def _go():
+                time.sleep(0.2)
+                try:
+                    urllib.request.urlopen(url, timeout=5)
+                except Exception:
+                    pass
+
+            threading.Thread(target=_go, daemon=True).start()
+            return True
+
+        monkeypatch.setattr(tp.webbrowser, "open", fake_open)
+
+        bundle = tp.perform_chatgpt_login()
+        assert bundle["access_token"] == "cgpt-1"
+        assert bundle["account_id"] == "acct-XYZ"
+        assert bundle["flow"] == "chatgpt"
+
+        # config mirrors what `vulnclaw login` persists (Codex token endpoint).
+        llm = LLMConfig(
+            auth_mode="oauth",
+            oauth_token_url=f"http://127.0.0.1:{port}/token",
+            oauth_client_id=tp.CHATGPT_CLIENT_ID,
+        )
+        assert tp.has_llm_credentials(llm) is True
+        time.sleep(1.1)  # force expiry → silent refresh
+        tok = tp.resolve_llm_token(llm)
+        assert tok.startswith("cgpt-")
+        assert refreshes["n"] >= 1
+        # account id survives the refresh
+        assert tp.load_oauth_tokens().get("account_id") == "acct-XYZ"
+    finally:
+        srv.shutdown()

--- a/vulnclaw/agent/chatgpt_proxy.py
+++ b/vulnclaw/agent/chatgpt_proxy.py
@@ -1,0 +1,485 @@
+"""Built-in OpenAI-compatible proxy for the ChatGPT backend (Responses API).
+
+When a user signs in with their ChatGPT subscription (``vulnclaw login --chatgpt``),
+the resulting token only works against OpenAI's ChatGPT backend (the Responses
+API at ``chatgpt.com/backend-api/codex``), **not** the public
+``/v1/chat/completions`` endpoint that VulnClaw speaks.
+
+This module runs a tiny local HTTP server that:
+
+* accepts standard OpenAI ``/v1/chat/completions`` (and ``/v1/models``) requests
+  from VulnClaw's OpenAI client,
+* translates them into Responses-API requests,
+* forwards them to the ChatGPT backend with the stored (auto-refreshed) bearer
+  token + ``chatgpt-account-id`` header,
+* translates the answer back into chat-completions shape (including tool calls).
+
+It is started automatically (in-process, background thread) by
+``AgentCore._get_client`` when ``llm.chatgpt_auto_proxy`` is enabled — so users
+do not have to install or launch any external proxy.
+
+⚠️ The ChatGPT backend protocol is undocumented and may change. The endpoint and
+headers are overridable via env vars (``VULNCLAW_CHATGPT_BACKEND_URL`` etc.) so
+breakage can be fixed without code changes. This is a best-effort bridge.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+# ── Upstream (ChatGPT backend) configuration — all overridable via env ───
+DEFAULT_BACKEND_URL = "https://chatgpt.com/backend-api/codex/responses"
+DEFAULT_MODELS_URL = "https://chatgpt.com/backend-api/codex/models"
+DEFAULT_CLIENT_VERSION = "1.0.0"
+
+
+def _backend_url() -> str:
+    return os.environ.get("VULNCLAW_CHATGPT_BACKEND_URL", DEFAULT_BACKEND_URL)
+
+
+def _models_url() -> str:
+    return os.environ.get("VULNCLAW_CHATGPT_MODELS_URL", DEFAULT_MODELS_URL)
+
+
+def _client_version() -> str:
+    return os.environ.get("VULNCLAW_CHATGPT_CLIENT_VERSION", DEFAULT_CLIENT_VERSION)
+
+
+def _extra_headers() -> dict[str, str]:
+    """Headers Codex sends to the backend. Overridable via env."""
+    headers = {
+        "OpenAI-Beta": os.environ.get("VULNCLAW_CHATGPT_OPENAI_BETA", "responses=experimental"),
+        "originator": os.environ.get("VULNCLAW_CHATGPT_ORIGINATOR", "codex_cli_rs"),
+        "User-Agent": os.environ.get("VULNCLAW_CHATGPT_USER_AGENT", "vulnclaw-codex-proxy"),
+    }
+    return headers
+
+
+# ═════════════════════════════════════════════════════════════════════
+# Translation: OpenAI chat.completions  <->  Responses API
+# (pure functions — unit-testable without any network)
+# ═════════════════════════════════════════════════════════════════════
+
+
+def chat_to_responses(payload: dict[str, Any]) -> dict[str, Any]:
+    """Translate an OpenAI chat.completions request into a Responses request."""
+    messages = payload.get("messages") or []
+    instructions_parts: list[str] = []
+    input_items: list[dict[str, Any]] = []
+
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+
+        if role == "system":
+            if content:
+                instructions_parts.append(content if isinstance(content, str) else str(content))
+            continue
+
+        if role == "tool":
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.get("tool_call_id", ""),
+                    "output": content if isinstance(content, str) else json.dumps(content),
+                }
+            )
+            continue
+
+        if role == "assistant":
+            if content:
+                input_items.append(
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": content}],
+                    }
+                )
+            for tc in msg.get("tool_calls") or []:
+                fn = tc.get("function", {})
+                input_items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tc.get("id", ""),
+                        "name": fn.get("name", ""),
+                        "arguments": fn.get("arguments", "") or "{}",
+                    }
+                )
+            continue
+
+        # user (and any other) role → input_text
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            text = "".join(
+                part.get("text", "") for part in content if isinstance(part, dict)
+            )
+        else:
+            text = str(content) if content is not None else ""
+        input_items.append(
+            {
+                "type": "message",
+                "role": role or "user",
+                "content": [{"type": "input_text", "text": text}],
+            }
+        )
+
+    responses: dict[str, Any] = {
+        "model": payload.get("model"),
+        "input": input_items,
+        # The ChatGPT backend REQUIRES streaming and store=false.
+        "stream": True,
+        "store": False,
+    }
+    if instructions_parts:
+        responses["instructions"] = "\n\n".join(instructions_parts)
+
+    # Tools: chat.completions nests under .function; Responses flattens them.
+    tools = payload.get("tools")
+    if tools:
+        conv_tools = []
+        for t in tools:
+            if t.get("type") == "function" and "function" in t:
+                fn = t["function"]
+                conv_tools.append(
+                    {
+                        "type": "function",
+                        "name": fn.get("name"),
+                        "description": fn.get("description", ""),
+                        "parameters": fn.get("parameters", {}),
+                    }
+                )
+            else:
+                conv_tools.append(t)
+        responses["tools"] = conv_tools
+
+    if payload.get("temperature") is not None:
+        responses["temperature"] = payload["temperature"]
+    if payload.get("max_tokens") is not None:
+        responses["max_output_tokens"] = payload["max_tokens"]
+    if payload.get("max_completion_tokens") is not None:
+        responses["max_output_tokens"] = payload["max_completion_tokens"]
+    return responses
+
+
+def responses_to_chat(resp: dict[str, Any], model: str) -> dict[str, Any]:
+    """Translate a Responses-API answer into a chat.completions answer."""
+    content_text = ""
+    tool_calls: list[dict[str, Any]] = []
+
+    for item in resp.get("output") or []:
+        itype = item.get("type")
+        if itype == "message":
+            for c in item.get("content") or []:
+                if c.get("type") in ("output_text", "text"):
+                    content_text += c.get("text", "")
+        elif itype in ("function_call", "tool_call"):
+            tool_calls.append(
+                {
+                    "id": item.get("call_id") or item.get("id") or f"call_{uuid.uuid4().hex[:8]}",
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name", ""),
+                        "arguments": item.get("arguments", "") or "{}",
+                    },
+                }
+            )
+        elif itype == "reasoning":
+            # Optional: surface reasoning summary if present (kept out of content).
+            continue
+
+    # Fallback: some responses expose a flattened output_text field.
+    if not content_text and isinstance(resp.get("output_text"), str):
+        content_text = resp["output_text"]
+
+    message: dict[str, Any] = {"role": "assistant", "content": content_text or None}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    usage = resp.get("usage") or {}
+    return {
+        "id": resp.get("id") or f"chatcmpl-{uuid.uuid4().hex}",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": usage.get("input_tokens", 0),
+            "completion_tokens": usage.get("output_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+        },
+    }
+
+
+def chat_to_stream_chunks(chat: dict[str, Any]) -> list[dict[str, Any]]:
+    """Split a chat.completions answer into SSE chunk dicts (single content chunk).
+
+    We buffer upstream then synthesize a minimal stream: one chunk carrying the
+    full content + any tool_calls, then a finish chunk. VulnClaw's streaming
+    parser accumulates these correctly.
+    """
+    choice = chat["choices"][0]
+    msg = choice["message"]
+    model = chat.get("model", "")
+    base = {"id": chat["id"], "object": "chat.completion.chunk", "model": model}
+
+    delta: dict[str, Any] = {"role": "assistant"}
+    if msg.get("content"):
+        delta["content"] = msg["content"]
+    if msg.get("tool_calls"):
+        delta["tool_calls"] = [
+            {
+                "index": i,
+                "id": tc["id"],
+                "type": "function",
+                "function": tc["function"],
+            }
+            for i, tc in enumerate(msg["tool_calls"])
+        ]
+
+    return [
+        {**base, "choices": [{"index": 0, "delta": delta, "finish_reason": None}]},
+        {
+            **base,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": choice["finish_reason"]}],
+        },
+    ]
+
+
+# ═════════════════════════════════════════════════════════════════════
+# Upstream call
+# ═════════════════════════════════════════════════════════════════════
+
+
+class _UpstreamError(Exception):
+    def __init__(self, status: int, body: str):
+        self.status = status
+        self.body = body
+        super().__init__(f"upstream {status}: {body[:200]}")
+
+
+def _backend_headers(token: str, account_id: str) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "session_id": str(uuid.uuid4()),
+        **_extra_headers(),
+    }
+    if account_id:
+        headers["chatgpt-account-id"] = account_id
+    return headers
+
+
+def _aggregate_sse(resp_stream: Any) -> dict[str, Any]:
+    """Consume the backend's Responses SSE stream into a single responses dict.
+
+    The ChatGPT backend only streams. We accumulate text deltas and completed
+    function-call items, then hand a synthesized {"output": [...]} object to
+    ``responses_to_chat`` so the rest of the pipeline is unchanged.
+    """
+    content = ""
+    tool_calls: list[dict[str, Any]] = []
+    usage: dict[str, Any] = {}
+    resp_id = ""
+    error_detail = ""
+
+    for raw in resp_stream:
+        line = raw.decode("utf-8", "replace").strip()
+        if not line.startswith("data:"):
+            continue
+        data_str = line[len("data:"):].strip()
+        if not data_str or data_str == "[DONE]":
+            continue
+        try:
+            ev = json.loads(data_str)
+        except json.JSONDecodeError:
+            continue
+        etype = ev.get("type", "")
+
+        if etype == "response.output_text.delta":
+            content += ev.get("delta", "")
+        elif etype == "response.output_item.done":
+            item = ev.get("item", {})
+            if item.get("type") == "function_call":
+                tool_calls.append(
+                    {
+                        "type": "function_call",
+                        "call_id": item.get("call_id") or item.get("id") or "",
+                        "name": item.get("name", ""),
+                        "arguments": item.get("arguments", "") or "{}",
+                    }
+                )
+        elif etype in ("response.completed", "response.incomplete"):
+            r = ev.get("response", {})
+            resp_id = r.get("id", resp_id)
+            usage = r.get("usage", usage) or usage
+        elif etype in ("response.failed", "error", "response.error"):
+            r = ev.get("response", {}) or ev
+            err = r.get("error") or ev.get("error") or {}
+            error_detail = err.get("message") if isinstance(err, dict) else str(err)
+
+    if error_detail:
+        raise _UpstreamError(502, f"backend stream error: {error_detail}")
+
+    output: list[dict[str, Any]] = []
+    if content:
+        output.append(
+            {"type": "message", "content": [{"type": "output_text", "text": content}]}
+        )
+    output.extend(tool_calls)
+    return {"id": resp_id, "output": output, "usage": usage}
+
+
+def _call_backend(responses_payload: dict[str, Any], token: str, account_id: str) -> dict[str, Any]:
+    """Stream the request to the ChatGPT backend and aggregate the SSE answer."""
+    data = json.dumps(responses_payload).encode("utf-8")
+    req = urllib.request.Request(
+        _backend_url(), data=data, headers=_backend_headers(token, account_id), method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:  # noqa: S310
+            return _aggregate_sse(resp)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace") if hasattr(exc, "read") else str(exc)
+        raise _UpstreamError(exc.code, detail) from exc
+    except urllib.error.URLError as exc:
+        raise _UpstreamError(502, f"cannot reach ChatGPT backend: {exc}") from exc
+
+
+def list_backend_models(token: str, account_id: str) -> list[str]:
+    """Return the model slugs the ChatGPT backend allows for this account."""
+    url = f"{_models_url()}?client_version={urllib.parse.quote(_client_version())}"
+    headers = _backend_headers(token, account_id)
+    headers["Accept"] = "application/json"
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, json.JSONDecodeError):
+        return []
+    return [m.get("slug", "") for m in data.get("models", []) if m.get("slug")]
+
+
+# ═════════════════════════════════════════════════════════════════════
+# Local OpenAI-compatible HTTP server
+# ═════════════════════════════════════════════════════════════════════
+
+
+def _resolve_credentials() -> tuple[str, str]:
+    """Fetch a fresh ChatGPT token (auto-refreshing) + account id from the store."""
+    from vulnclaw.config.settings import load_config
+    from vulnclaw.config.token_provider import load_oauth_tokens, resolve_llm_token
+
+    token = resolve_llm_token(load_config().llm)
+    account_id = str(load_oauth_tokens().get("account_id") or "")
+    return token, account_id
+
+
+class _ProxyHandler(BaseHTTPRequestHandler):
+    def _send_json(self, obj: dict[str, Any], status: int = 200) -> None:
+        data = json.dumps(obj).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_error_json(self, status: int, message: str) -> None:
+        self._send_json(
+            {"error": {"message": message, "type": "vulnclaw_chatgpt_proxy"}}, status=status
+        )
+
+    def do_GET(self):  # noqa: N802
+        if self.path.rstrip("/").endswith("/models"):
+            slugs: list[str] = []
+            try:
+                token, account_id = _resolve_credentials()
+                slugs = list_backend_models(token, account_id)
+            except Exception:  # noqa: BLE001 - models listing is best-effort
+                slugs = []
+            if not slugs:
+                slugs = ["gpt-5.5"]
+            self._send_json(
+                {
+                    "object": "list",
+                    "data": [
+                        {"id": s, "object": "model", "owned_by": "openai"} for s in slugs
+                    ],
+                }
+            )
+        else:
+            self._send_error_json(404, f"not found: {self.path}")
+
+    def do_POST(self):  # noqa: N802
+        if not self.path.rstrip("/").endswith("/chat/completions"):
+            self._send_error_json(404, f"not found: {self.path}")
+            return
+        try:
+            n = int(self.headers.get("Content-Length", 0))
+            payload = json.loads(self.rfile.read(n).decode("utf-8"))
+        except (ValueError, json.JSONDecodeError) as exc:
+            self._send_error_json(400, f"bad request body: {exc}")
+            return
+
+        want_stream = bool(payload.get("stream"))
+        model = payload.get("model", "")
+
+        try:
+            token, account_id = _resolve_credentials()
+            responses_payload = chat_to_responses(payload)
+            upstream = _call_backend(responses_payload, token, account_id)
+            chat = responses_to_chat(upstream, model)
+        except _UpstreamError as exc:
+            self._send_error_json(exc.status, exc.body)
+            return
+        except Exception as exc:  # noqa: BLE001 - surface anything as an API error
+            self._send_error_json(500, f"proxy error: {exc}")
+            return
+
+        if not want_stream:
+            self._send_json(chat)
+            return
+
+        # Synthesize an SSE stream from the buffered answer.
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        for chunk in chat_to_stream_chunks(chat):
+            self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+        self.wfile.write(b"data: [DONE]\n\n")
+
+    def log_message(self, *args):  # silence default logging
+        pass
+
+
+_PROXY_LOCK = threading.Lock()
+_PROXY_BASE_URL: str | None = None
+
+
+def ensure_proxy_running() -> str:
+    """Start the in-process proxy (once) and return its OpenAI base_url."""
+    global _PROXY_BASE_URL
+    with _PROXY_LOCK:
+        if _PROXY_BASE_URL is not None:
+            return _PROXY_BASE_URL
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _ProxyHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        _PROXY_BASE_URL = f"http://127.0.0.1:{port}/v1"
+        return _PROXY_BASE_URL

--- a/vulnclaw/agent/chatgpt_proxy.py
+++ b/vulnclaw/agent/chatgpt_proxy.py
@@ -161,12 +161,14 @@ def chat_to_responses(payload: dict[str, Any]) -> dict[str, Any]:
                 conv_tools.append(t)
         responses["tools"] = conv_tools
 
-    if payload.get("temperature") is not None:
-        responses["temperature"] = payload["temperature"]
-    if payload.get("max_tokens") is not None:
-        responses["max_output_tokens"] = payload["max_tokens"]
-    if payload.get("max_completion_tokens") is not None:
-        responses["max_output_tokens"] = payload["max_completion_tokens"]
+    # The ChatGPT backend rejects sampling / limit params with HTTP 400
+    # ("Unsupported parameter: temperature / top_p / max_output_tokens"), so we
+    # do NOT forward them. It does accept a `reasoning` object — map the chat
+    # `reasoning_effort` onto it.
+    if isinstance(payload.get("reasoning"), dict):
+        responses["reasoning"] = payload["reasoning"]
+    elif payload.get("reasoning_effort"):
+        responses["reasoning"] = {"effort": payload["reasoning_effort"]}
     return responses
 
 

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -229,15 +229,50 @@ class AgentCore:
             pass
 
     def _get_client(self):
-        """Lazy-initialize OpenAI client."""
+        """Lazy-initialize OpenAI client with dynamic credential resolution.
+
+        Supports static API keys as well as keyless / short-lived bearer tokens
+        (env / file / command / WIF). The token is re-resolved on every call so
+        rotated or just-minted access tokens are picked up without rebuilding the
+        client; ``client.api_key`` becomes the ``Authorization: Bearer`` value.
+        """
+        from vulnclaw.config.token_provider import load_oauth_tokens, resolve_llm_token
+
+        llm = self.config.llm
+
+        # ── ChatGPT subscription: auto-start the built-in bridge proxy ──
+        # The subscription token only works against the ChatGPT backend, so we
+        # transparently route VulnClaw's chat.completions through an in-process
+        # proxy instead of requiring the user to run one.
+        if (
+            getattr(llm, "chatgpt_auto_proxy", False)
+            and str(getattr(llm, "auth_mode", "") or "").lower() == "oauth"
+            and str(load_oauth_tokens().get("flow") or "") == "chatgpt"
+        ):
+            from vulnclaw.agent.chatgpt_proxy import ensure_proxy_running
+
+            proxy_base = ensure_proxy_running()
+            if self._client is None:
+                try:
+                    self._client = make_openai_client(
+                        api_key="local-proxy", base_url=proxy_base
+                    )
+                except ImportError:
+                    raise RuntimeError("请安装 openai 包: pip install openai")
+            return self._client
+
+        token = resolve_llm_token(llm)
         if self._client is None:
             try:
                 self._client = make_openai_client(
-                    api_key=self.config.llm.api_key,
-                    base_url=self.config.llm.base_url,
+                    api_key=token or "placeholder",
+                    base_url=llm.base_url,
                 )
             except ImportError:
                 raise RuntimeError("请安装 openai 包: pip install openai")
+        elif token:
+            # Refresh the bearer token in place for rotating / short-lived creds.
+            self._client.api_key = token
         return self._client
 
     @staticmethod

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -56,6 +56,7 @@ from vulnclaw.config.settings import (
     save_config,
     set_config_value,
 )
+from vulnclaw.config.token_provider import has_llm_credentials
 from vulnclaw.i18n import _
 from vulnclaw.orchestrator import run_agent_task
 from vulnclaw.repl_runner import run_repl_call
@@ -253,7 +254,7 @@ def _run_repl() -> None:
     _print_banner()
 
     config = load_config()
-    if not config.llm.api_key:
+    if not has_llm_credentials(config.llm):
         console.print(_("cli.no_api_key"))
         console.print(_("cli.choose_provider"))
         console.print(_("cli.set_env_var"))
@@ -902,8 +903,8 @@ def run(
 ) -> None:
     """Run a full authorized pentest workflow."""
     config = load_config()
-    if not config.llm.api_key:
-        err_console.print("[!] Configure an LLM API key first.")
+    if not has_llm_credentials(config.llm):
+        err_console.print("[!] Configure LLM credentials first (api_key or auth_mode).")
         raise typer.Exit(1)
 
     console.print(f"[*] Target: [bold]{target}[/] | Scope: [bold]{scope}[/]")
@@ -998,8 +999,8 @@ def solve(
     from the target toward the goal and stops on success or when no path remains.
     """
     config = load_config()
-    if not config.llm.api_key:
-        err_console.print("[!] Configure an LLM API key first.")
+    if not has_llm_credentials(config.llm):
+        err_console.print("[!] Configure LLM credentials first (api_key or auth_mode).")
         raise typer.Exit(1)
 
     resolved_goal = goal or "找到 flag / 拿到 shell / 确认并验证高价值漏洞"
@@ -1088,8 +1089,8 @@ def persistent(
     from vulnclaw.agent.core import PersistentCycleResult
 
     config = load_config()
-    if not config.llm.api_key:
-        err_console.print("[!] Configure an LLM API key first.")
+    if not has_llm_credentials(config.llm):
+        err_console.print("[!] Configure LLM credentials first (api_key or auth_mode).")
         raise typer.Exit(1)
 
     # Resolve parameters (CLI override -> config defaults)
@@ -1515,10 +1516,11 @@ def config_provider(
     console.print(f"    Base URL: [dim]{config.llm.base_url}[/]")
     console.print(f"    Model:    [dim]{config.llm.model}[/]")
 
-    if not config.llm.api_key:
+    if not has_llm_credentials(config.llm):
         console.print()
         console.print(
-            "[yellow]Set an API key first: [bold]vulnclaw config set llm.api_key <your-key>[/][/]"
+            "[yellow]Set credentials first: [bold]vulnclaw config set llm.api_key <your-key>[/] "
+            "or configure keyless auth (llm.auth_mode = env/file/command/wif)[/]"
         )
 
 
@@ -1545,6 +1547,101 @@ def init() -> None:
     console.print(_("cli.init.step_api_key"))
     console.print(_("cli.init.step_cli"))
     console.print(_("cli.init.step_tui"))
+
+
+# 鈹€鈹€ Login / Logout commands 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+
+
+@app.command()
+def login(
+    proxy_url: Optional[str] = typer.Option(
+        None,
+        "--proxy-url",
+        help="External OpenAI-compatible proxy base_url (disables the built-in one)",
+    ),
+    no_browser: bool = typer.Option(
+        False, "--no-browser", help="Print the URL instead of opening a browser"
+    ),
+    set_default: bool = typer.Option(
+        True, "--set-default/--no-set-default", help="Set llm.auth_mode=oauth on success"
+    ),
+) -> None:
+    """Sign in with your ChatGPT subscription (Codex "Sign in with ChatGPT").
+
+    Opens the ChatGPT consent page in your browser, stores the resulting
+    refreshable token, and enables the built-in proxy that bridges
+    chat.completions to the ChatGPT backend — so VulnClaw just works afterwards.
+
+    ⚠️ This reuses OpenAI's first-party Codex OAuth client. Using a ChatGPT
+    subscription through a non-official client may violate OpenAI's Terms of
+    Service and can get your account restricted. You proceed at your own risk.
+    """
+    from vulnclaw.config.token_provider import (
+        CHATGPT_CLIENT_ID,
+        CHATGPT_TOKEN_URL,
+        OAuthError,
+        perform_chatgpt_login,
+    )
+
+    llm = load_config().llm
+
+    err_console.print(
+        "[yellow][!] Sign in with ChatGPT reuses OpenAI's first-party Codex OAuth "
+        "client. Using a ChatGPT subscription through a non-official client may "
+        "violate OpenAI's Terms of Service and can get your account restricted. "
+        "You are proceeding at your own risk.[/]"
+    )
+    try:
+        bundle = perform_chatgpt_login(open_browser=not no_browser)
+    except OAuthError as exc:
+        err_console.print(f"[!] ChatGPT sign-in failed: {exc}")
+        raise typer.Exit(1)
+
+    # Wire config so resolve/refresh works against the Codex token endpoint.
+    set_config_value("llm.oauth_token_url", CHATGPT_TOKEN_URL)
+    set_config_value("llm.oauth_client_id", CHATGPT_CLIENT_ID)
+    if set_default:
+        set_config_value("llm.auth_mode", "oauth")
+    # The ChatGPT backend serves its own model family — gpt-4o won't work.
+    if (llm.model or "").lower() in ("", "gpt-4o", "gpt-5", "gpt-5-codex"):
+        set_config_value("llm.model", "gpt-5.5")
+
+    if proxy_url:
+        # User supplied an external proxy: use it, disable the built-in one.
+        set_config_value("llm.base_url", proxy_url.rstrip("/"))
+        set_config_value("llm.chatgpt_auto_proxy", "false")
+    else:
+        # Default: built-in proxy auto-starts on demand — zero setup.
+        set_config_value("llm.chatgpt_auto_proxy", "true")
+
+    tok = bundle.get("access_token", "")
+    masked = (tok[:6] + "…" + tok[-4:]) if len(tok) > 12 else "(received)"
+    console.print("[green]Signed in with ChatGPT.[/]")
+    console.print(f"  Access token: [dim]{masked}[/]  (refreshes automatically)")
+    if bundle.get("account_id"):
+        console.print(f"  Account id: [dim]{bundle['account_id']}[/]")
+    console.print()
+    if proxy_url:
+        console.print(f"  base_url set to external proxy: [dim]{proxy_url.rstrip('/')}[/]")
+    else:
+        console.print(
+            "  [green]Built-in ChatGPT proxy enabled — it starts automatically.[/]\n"
+            "  [dim]No external proxy needed. The bridge to OpenAI's ChatGPT backend "
+            "is experimental; if a call fails, the error shows the backend response "
+            "so you can adjust llm.model or the VULNCLAW_CHATGPT_* env vars.[/]"
+        )
+    console.print("  Run [bold]vulnclaw[/] to start.")
+
+
+@app.command()
+def logout() -> None:
+    """Remove stored OAuth tokens (browser sign-in)."""
+    from vulnclaw.config.token_provider import logout_oauth
+
+    if logout_oauth():
+        console.print("[green]Signed out — stored OAuth tokens removed.[/]")
+    else:
+        console.print("[yellow]No stored OAuth tokens to remove.[/]")
 
 
 # 鈹€鈹€ Doctor command 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
@@ -1600,10 +1697,13 @@ def doctor() -> None:
     config = load_config()
     console.print()
     console.print("[bold]LLM Config[/]:")
-    has_key = bool(config.llm.api_key)
+    has_key = has_llm_credentials(config.llm)
+    auth_mode = (config.llm.auth_mode or "static").lower()
     console.print(f"  Provider: [bold cyan]{config.llm.provider}[/]")
+    console.print(f"  Auth Mode: [bold]{auth_mode}[/]")
+    cred_label = "configured" if has_key else "not set"
     console.print(
-        f"  API Key: [{'green' if has_key else 'red'}]{'configured' if has_key else 'not set'}[/]"
+        f"  Credentials: [{'green' if has_key else 'red'}]{cred_label}[/]"
     )
     console.print(f"  Base URL: [dim]{config.llm.base_url}[/]")
     console.print(f"  Model: [dim]{config.llm.model}[/]")
@@ -1642,7 +1742,8 @@ def doctor() -> None:
         console.print("[green]Environment ready. Run [bold]vulnclaw[/] to start.[/]")
     else:
         console.print(
-            "[yellow]Set an API key first: [bold]vulnclaw config set llm.api_key <key>[/][/]"
+            "[yellow]Set credentials first: [bold]vulnclaw config set llm.api_key <key>[/] "
+            "or keyless auth (llm.auth_mode = env/file/command/wif)[/]"
         )
 
 

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -106,7 +106,28 @@ class LLMConfig(BaseModel):
         default="openai",
         description="LLM provider name (openai/minimax/deepseek/zhipu/moonshot/qwen/siliconflow/doubao/baichuan/stepfun/sensetime/yi/custom)",
     )
-    api_key: str = Field(default="", description="API key for the chosen provider")
+    api_key: str = Field(default="", description="Static API key for the chosen provider (auth_mode=static)")
+    auth_mode: str = Field(
+        default="static",
+        description="Credential mode: static (api_key) or oauth (browser sign-in via `vulnclaw login`).",
+    )
+    # ── OAuth (auth_mode=oauth) ─────────────────────────────────────────
+    # Tokens are obtained by `vulnclaw login` and refreshed silently. These two
+    # endpoints are set automatically by the login flow.
+    oauth_token_url: str = Field(
+        default="", description="OAuth token endpoint (code/refresh exchange)"
+    )
+    oauth_client_id: str = Field(
+        default="", description="OAuth client_id used for token exchange/refresh"
+    )
+    chatgpt_auto_proxy: bool = Field(
+        default=False,
+        description=(
+            "When signed in with a ChatGPT subscription, auto-start a built-in "
+            "local proxy that bridges chat.completions to the ChatGPT backend "
+            "(no external proxy needed)."
+        ),
+    )
     base_url: str = Field(
         default="https://api.openai.com/v1",
         description="OpenAI-compatible API base URL (auto-filled by provider)",

--- a/vulnclaw/config/settings.py
+++ b/vulnclaw/config/settings.py
@@ -205,6 +205,12 @@ def _overlay_env(config: VulnClawConfig) -> VulnClawConfig:
         with suppress(ValueError):
             config.llm.temperature = float(v)
 
+    # ── LLM auth mode (static / oauth) ──────────────────────────────────
+    if v := os.environ.get("VULNCLAW_LLM_AUTH_MODE"):
+        config.llm.auth_mode = v
+    if v := os.environ.get("VULNCLAW_LLM_CHATGPT_AUTO_PROXY"):
+        config.llm.chatgpt_auto_proxy = v.lower() in ("1", "true", "yes", "on")
+
     # ── Session ──────────────────────────────────────────────────────
     if v := os.environ.get("VULNCLAW_SESSION_OUTPUT_DIR"):
         config.session.output_dir = Path(v)

--- a/vulnclaw/config/token_provider.py
+++ b/vulnclaw/config/token_provider.py
@@ -1,0 +1,378 @@
+"""LLM credential resolution.
+
+VulnClaw uses a static API key (``llm.api_key``) for the OpenAI-compatible client
+by default. In addition it supports a browser sign-in via OAuth so the agent can
+run on a ChatGPT subscription instead of a static key.
+
+Supported ``llm.auth_mode`` values:
+
+* ``static`` — (default) use ``llm.api_key`` verbatim.
+* ``oauth``  — use tokens obtained by ``vulnclaw login`` (OAuth 2.0 Authorization
+               Code + PKCE). The "Sign in with ChatGPT" flow stores a refreshable
+               access token; at call time it is used and silently refreshed via
+               the refresh token when it expires (no browser, no static key).
+
+The resolved string is handed to the OpenAI client as ``api_key`` — the SDK sends
+it as ``Authorization: Bearer <token>`` either way, so a static key and an OAuth
+access token are wire-compatible.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from contextlib import suppress
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+# Skew subtracted from a token's lifetime so we refresh slightly early.
+_EXPIRY_SKEW_SECONDS = 60.0
+
+
+class TokenResolutionError(RuntimeError):
+    """Raised when a credential cannot be obtained."""
+
+
+class OAuthError(TokenResolutionError):
+    """Raised when the OAuth sign-in / refresh flow fails."""
+
+
+def _get(llm: Any, name: str, default: Any = "") -> Any:
+    return getattr(llm, name, default)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# OAuth token store
+# ─────────────────────────────────────────────────────────────────────
+
+_OAUTH_LOCK = threading.Lock()
+_CALLBACK_TIMEOUT_SECONDS = 300
+
+
+def _oauth_store_path() -> Path:
+    """Where the OAuth token bundle is persisted (per VulnClaw config dir)."""
+    config_dir = Path(os.environ.get("VULNCLAW_CONFIG_DIR", str(Path.home() / ".vulnclaw")))
+    return config_dir / "oauth_tokens.json"
+
+
+def load_oauth_tokens() -> dict[str, Any]:
+    path = _oauth_store_path()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save_oauth_tokens(bundle: dict[str, Any]) -> None:
+    path = _oauth_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(bundle, f, indent=2)
+    # Best-effort tighten permissions on POSIX (no-op on Windows).
+    with suppress(OSError):
+        os.chmod(path, 0o600)
+
+
+def logout_oauth() -> bool:
+    """Delete the stored OAuth token bundle. Returns True if a file was removed."""
+    try:
+        _oauth_store_path().unlink()
+        return True
+    except OSError:
+        return False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# OAuth 2.0 Authorization Code + PKCE primitives
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Return (code_verifier, code_challenge) for PKCE S256."""
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    expected_path = "/callback"
+    result: dict[str, str] = {}
+    done = threading.Event()
+
+    def do_GET(self):  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path != type(self).expected_path:
+            self.send_response(404)
+            self.end_headers()
+            return
+        params = urllib.parse.parse_qs(parsed.query)
+        type(self).result = {k: v[0] for k, v in params.items()}
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        ok = "code" in type(self).result and "error" not in type(self).result
+        msg = (
+            "VulnClaw 登录成功，可以关闭此页面。 / Sign-in complete, you may close this tab."
+            if ok
+            else f"登录失败 / Sign-in failed: {type(self).result.get('error', 'unknown')}"
+        )
+        self.wfile.write(
+            f"<html><body style='font-family:sans-serif'><h3>{msg}</h3></body></html>".encode()
+        )
+        type(self).done.set()
+
+    def log_message(self, *args):  # silence access logging
+        pass
+
+
+def _oauth_token_request(token_url: str, form: dict[str, str]) -> dict[str, Any]:
+    data = urllib.parse.urlencode(form).encode("utf-8")
+    req = urllib.request.Request(
+        token_url,
+        data=data,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:300] if hasattr(exc, "read") else str(exc)
+        raise OAuthError(f"OAuth token 请求失败 HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise OAuthError(f"OAuth token 端点无法访问: {exc}") from exc
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise OAuthError(f"OAuth token 端点返回非 JSON: {body[:200]!r}") from exc
+    if "access_token" not in payload:
+        raise OAuthError(f"OAuth 响应缺少 access_token: {body[:200]!r}")
+    return payload
+
+
+def _bundle_from_payload(payload: dict[str, Any], fallback_refresh: str = "") -> dict[str, Any]:
+    expires_in = payload.get("expires_in")
+    expires_at = (
+        time.time() + float(expires_in)
+        if isinstance(expires_in, (int, float)) and expires_in > 0
+        else 0.0
+    )
+    return {
+        "access_token": str(payload["access_token"]),
+        "refresh_token": str(payload.get("refresh_token") or fallback_refresh or ""),
+        "token_type": str(payload.get("token_type") or "Bearer"),
+        "expires_at": expires_at,
+        "scope": str(payload.get("scope") or ""),
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────
+# "Sign in with ChatGPT" (reuses the official Codex CLI OAuth client)
+# ─────────────────────────────────────────────────────────────────────
+# WARNING: This authenticates against OpenAI's first-party Codex OAuth client.
+# Using a ChatGPT subscription programmatically through a non-official client may
+# violate OpenAI's Terms of Service and can get the account restricted. The user
+# opts into this explicitly. The client_id below is public (the Codex CLI is open
+# source); no secret is involved.
+CHATGPT_ISSUER = "https://auth.openai.com"
+CHATGPT_AUTHORIZE_URL = CHATGPT_ISSUER + "/oauth/authorize"
+CHATGPT_TOKEN_URL = CHATGPT_ISSUER + "/oauth/token"
+CHATGPT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CHATGPT_REDIRECT_PORT = 1455
+CHATGPT_REDIRECT_PATH = "/auth/callback"
+CHATGPT_SCOPE = "openid profile email offline_access"
+
+
+def _decode_jwt_claims(token: str) -> dict[str, Any]:
+    """Best-effort decode of a JWT payload (no signature verification)."""
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)  # pad
+        return json.loads(base64.urlsafe_b64decode(payload_b64).decode("utf-8"))
+    except (IndexError, ValueError, json.JSONDecodeError):
+        return {}
+
+
+def _extract_account_id(claims: dict[str, Any]) -> str:
+    """Pull the ChatGPT account id from id_token claims, if present."""
+    auth = claims.get("https://api.openai.com/auth")
+    if isinstance(auth, dict):
+        for key in ("chatgpt_account_id", "account_id", "organization_id"):
+            if auth.get(key):
+                return str(auth[key])
+    return ""
+
+
+def perform_chatgpt_login(*, open_browser: bool = True) -> dict[str, Any]:
+    """Run the Codex "Sign in with ChatGPT" OAuth flow and persist tokens.
+
+    Obtains a refreshable ChatGPT access token tied to the user's subscription.
+    The token works against the ChatGPT backend (Responses API); VulnClaw's
+    built-in proxy bridges chat.completions to it.
+    """
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+
+    _CallbackHandler.expected_path = CHATGPT_REDIRECT_PATH
+    _CallbackHandler.result = {}
+    _CallbackHandler.done = threading.Event()
+    try:
+        server = HTTPServer(("127.0.0.1", CHATGPT_REDIRECT_PORT), _CallbackHandler)
+    except OSError as exc:
+        raise OAuthError(
+            f"无法绑定本地端口 {CHATGPT_REDIRECT_PORT}（Codex 重定向要求固定端口）: {exc}"
+        ) from exc
+    redirect_uri = f"http://localhost:{CHATGPT_REDIRECT_PORT}{CHATGPT_REDIRECT_PATH}"
+
+    auth_params = {
+        "response_type": "code",
+        "client_id": CHATGPT_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "scope": CHATGPT_SCOPE,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+    }
+    full_authorize_url = CHATGPT_AUTHORIZE_URL + "?" + urllib.parse.urlencode(auth_params)
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        opened = False
+        if open_browser:
+            with suppress(Exception):
+                opened = webbrowser.open(full_authorize_url)
+        if not opened:
+            print(f"[i] 在浏览器中打开以登录 ChatGPT / Open to sign in:\n{full_authorize_url}")
+        else:
+            print("[i] 已打开 ChatGPT 登录页，等待授权... / Browser opened, waiting for consent...")
+        if not _CallbackHandler.done.wait(timeout=_CALLBACK_TIMEOUT_SECONDS):
+            raise OAuthError("等待授权回调超时 / Timed out waiting for the OAuth callback")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    result = _CallbackHandler.result
+    if "error" in result:
+        raise OAuthError(f"授权被拒绝 / Authorization error: {result.get('error')}")
+    if result.get("state") != state:
+        raise OAuthError("OAuth state 不匹配（可能的 CSRF），已中止 / state mismatch, aborted")
+    code = result.get("code")
+    if not code:
+        raise OAuthError("回调未返回授权码 / No authorization code in callback")
+
+    payload = _oauth_token_request(
+        CHATGPT_TOKEN_URL,
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": CHATGPT_CLIENT_ID,
+            "code_verifier": verifier,
+        },
+    )
+    bundle = _bundle_from_payload(payload)
+    id_token = str(payload.get("id_token") or "")
+    if id_token:
+        bundle["account_id"] = _extract_account_id(_decode_jwt_claims(id_token))
+    bundle["flow"] = "chatgpt"
+    save_oauth_tokens(bundle)
+    return bundle
+
+
+# ─────────────────────────────────────────────────────────────────────
+# OAuth token refresh + resolution
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _refresh_oauth(llm: Any, refresh_token: str) -> dict[str, Any]:
+    token_url = str(_get(llm, "oauth_token_url") or "").strip()
+    client_id = str(_get(llm, "oauth_client_id") or "").strip()
+    if not (token_url and client_id):
+        raise OAuthError("OAuth 刷新需要 llm.oauth_token_url 和 llm.oauth_client_id")
+    payload = _oauth_token_request(
+        token_url,
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+        },
+    )
+    bundle = _bundle_from_payload(payload, fallback_refresh=refresh_token)
+    # Preserve flow-specific metadata across refreshes (e.g. ChatGPT account id).
+    prior = load_oauth_tokens()
+    for key in ("account_id", "flow"):
+        if prior.get(key) and not bundle.get(key):
+            bundle[key] = prior[key]
+    save_oauth_tokens(bundle)
+    return bundle
+
+
+def _resolve_oauth_token(llm: Any) -> str:
+    """Return a valid OAuth access token, refreshing silently if needed."""
+    with _OAUTH_LOCK:
+        bundle = load_oauth_tokens()
+        access = str(bundle.get("access_token") or "")
+        expires_at = float(bundle.get("expires_at") or 0.0)
+        refresh = str(bundle.get("refresh_token") or "")
+
+        valid = access and (expires_at == 0.0 or time.time() < expires_at - _EXPIRY_SKEW_SECONDS)
+        if valid:
+            return access
+        if refresh:
+            return str(_refresh_oauth(llm, refresh)["access_token"])
+        if access:
+            # No refresh token and (possibly) expired — return what we have and
+            # let the API surface a 401 rather than failing pre-emptively.
+            return access
+        raise OAuthError(
+            "尚未登录或令牌已失效，请运行 `vulnclaw login` / Not signed in — run `vulnclaw login`"
+        )
+
+
+def resolve_llm_token(llm: Any) -> str:
+    """Return the effective bearer token / API key for the configured auth mode.
+
+    ``static`` returns ``llm.api_key`` (possibly empty, preserving legacy
+    behaviour); ``oauth`` returns a valid access token, refreshing if needed.
+    """
+    mode = str(_get(llm, "auth_mode") or "static").strip().lower()
+    if mode in ("", "static"):
+        return str(_get(llm, "api_key") or "")
+    if mode == "oauth":
+        return _resolve_oauth_token(llm)
+    raise TokenResolutionError(f"未知的 llm.auth_mode={mode!r}（支持: static/oauth）")
+
+
+def has_llm_credentials(llm: Any) -> bool:
+    """Whether usable credentials are configured, without minting a token.
+
+    ``static`` requires a non-empty ``api_key``; ``oauth`` requires stored
+    tokens. This is a cheap pre-flight check — it does NOT validate that the
+    credential actually works.
+    """
+    mode = str(_get(llm, "auth_mode") or "static").strip().lower()
+    if mode in ("", "static"):
+        return bool(_get(llm, "api_key"))
+    if mode == "oauth":
+        bundle = load_oauth_tokens()
+        return bool(bundle.get("access_token") or bundle.get("refresh_token"))
+    return False

--- a/vulnclaw/config/token_provider.py
+++ b/vulnclaw/config/token_provider.py
@@ -138,25 +138,46 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         pass
 
 
-def _oauth_token_request(token_url: str, form: dict[str, str]) -> dict[str, Any]:
+def _oauth_token_request(token_url: str, form: dict[str, str], *, attempts: int = 4) -> dict[str, Any]:
+    """POST a token request, retrying transient network/TLS/5xx failures.
+
+    The OAuth endpoints can be reached over flaky TLS (e.g. intermittent
+    ``SSL: UNEXPECTED_EOF_WHILE_READING``). 4xx responses (other than 429) are
+    permanent and fail fast; network errors and 5xx/429 are retried with backoff.
+    The authorization code is single-use but valid for minutes, so a few quick
+    retries within one login call are safe.
+    """
     data = urllib.parse.urlencode(form).encode("utf-8")
-    req = urllib.request.Request(
-        token_url,
-        data=data,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-        },
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
-            body = resp.read().decode("utf-8")
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", "replace")[:300] if hasattr(exc, "read") else str(exc)
-        raise OAuthError(f"OAuth token 请求失败 HTTP {exc.code}: {detail}") from exc
-    except urllib.error.URLError as exc:
-        raise OAuthError(f"OAuth token 端点无法访问: {exc}") from exc
+    body: str | None = None
+    last_exc: Exception | None = None
+    for i in range(attempts):
+        req = urllib.request.Request(
+            token_url,
+            data=data,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+                body = resp.read().decode("utf-8")
+            break
+        except urllib.error.HTTPError as exc:
+            if exc.code != 429 and 400 <= exc.code < 500:
+                detail = exc.read().decode("utf-8", "replace")[:300] if hasattr(exc, "read") else str(exc)
+                raise OAuthError(f"OAuth token 请求失败 HTTP {exc.code}: {detail}") from exc
+            last_exc = exc  # 5xx / 429 → retry
+        except urllib.error.URLError as exc:
+            last_exc = exc  # network / TLS → retry
+        if i < attempts - 1:
+            time.sleep(1.5 * (i + 1))
+
+    if body is None:
+        raise OAuthError(
+            f"OAuth token 端点无法访问（重试 {attempts} 次后失败 / failed after {attempts} retries）: {last_exc}"
+        )
     try:
         payload = json.loads(body)
     except json.JSONDecodeError as exc:

--- a/vulnclaw/report/generator.py
+++ b/vulnclaw/report/generator.py
@@ -502,13 +502,23 @@ def _generate_attack_summary_from_session(session: SessionState) -> str:
     try:
         from vulnclaw.agent.think_filter import strip_think_tags
         from vulnclaw.config.settings import load_config, make_openai_client
+        from vulnclaw.config.token_provider import (
+            TokenResolutionError,
+            has_llm_credentials,
+            resolve_llm_token,
+        )
 
         config = load_config()
-        if not config.llm.api_key:
+        if not has_llm_credentials(config.llm):
+            return ""
+
+        try:
+            token = resolve_llm_token(config.llm)
+        except TokenResolutionError:
             return ""
 
         client = make_openai_client(
-            api_key=config.llm.api_key,
+            api_key=token,
             base_url=config.llm.base_url,
         )
 


### PR DESCRIPTION
Adds an OAuth "Sign in with ChatGPT" flow so VulnClaw can run on a user's
ChatGPT subscription instead of a static API key, plus a built-in local proxy
that bridges the OpenAI `chat.completions` API VulnClaw speaks to the ChatGPT
backend (Responses API). After `vulnclaw login`, everything works with zero
extra setup no external proxy to install.
