### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,62 @@
+# Git / CI
+.git
+.github
+.gitignore
+
+# Python caches & build artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+build/
+dist/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.tox/
+.nox/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Frontend deps / build (rebuilt inside the image)
+frontend/node_modules/
+frontend/dist/
+frontend/.vite/
+frontend/.npm-cache/
+frontend/*.tsbuildinfo
+
+# VulnClaw runtime state (lives in the /data volume)
+.vulnclaw/
+sessions/
+reports/
+pocs/
+
+# Local-only / secrets
+.env
+.env.*
+!.env.example
+.claude/
+CLAUDE.md
+docs/
+.test-tmp/
+
+# Editor / OS noise
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Tests & assets not needed at runtime
+tests/
+assets/
+*.log
+*.tmp
+*.bak

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# VulnClaw container configuration.
+# Copy to `.env` and fill in your LLM credentials:  cp .env.example .env
+
+# ── LLM provider ──────────────────────────────────────────────────────
+# IMPORTANT: when configuring via environment variables, set BASE_URL and
+# MODEL explicitly to match the provider your API key belongs to. The
+# PROVIDER value below is only a label here — unlike the interactive
+# `vulnclaw config` command, it does NOT auto-fill base_url/model. If you
+# set a non-OpenAI key but leave BASE_URL unset, requests go to OpenAI's
+# endpoint and you'll get "invalid api key".
+
+# Required: API key for your provider.
+VULNCLAW_LLM_API_KEY=sk-your-key-here
+
+# Provider label (openai, deepseek, zhipu, minimax, moonshot, qwen, ...).
+VULNCLAW_LLM_PROVIDER=openai
+
+# API base URL — MUST match your key's provider. Examples:
+#   OpenAI    https://api.openai.com/v1
+#   DeepSeek  https://api.deepseek.com
+#   Zhipu     https://open.bigmodel.cn/api/paas/v4
+#   Moonshot  https://api.moonshot.cn/v1
+#   Qwen      https://dashscope.aliyuncs.com/compatible-mode/v1
+VULNCLAW_LLM_BASE_URL=https://api.openai.com/v1
+
+# Model name — MUST match the provider above (e.g. gpt-4o, deepseek-chat,
+# glm-4.7, kimi-k2.6, qwen3-max).
+VULNCLAW_LLM_MODEL=gpt-4o
+
+# Optional: token / sampling tuning.
+#VULNCLAW_LLM_MAX_TOKENS=4096
+#VULNCLAW_LLM_MAX_CONTEXT_TOKENS=128000
+#VULNCLAW_LLM_TEMPERATURE=0.2
+
+# ── Storage ───────────────────────────────────────────────────────────
+# Where config, sessions, targets and reports live inside the container.
+# Already defaulted to /data (the mounted volume) in the image; override
+# only if you change the volume mount point.
+#VULNCLAW_CONFIG_DIR=/data

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,115 @@
+# Running VulnClaw in Docker
+
+The image bundles the Python CLI, the built React Web UI, and the runtimes
+(`npx` + `uvx`) needed by the default MCP servers (`memory`, `fetch`). All
+mutable state (config, sessions, targets, reports) is kept in a `/data` volume.
+
+## Quick start (docker compose)
+
+```bash
+cp .env.example .env          # add your VULNCLAW_LLM_API_KEY
+docker compose up --build      # builds the image and starts the Web UI
+```
+
+Then open <http://127.0.0.1:7788>.
+
+State persists in the `vulnclaw-data` named volume across restarts.
+
+## Quick start (plain docker)
+
+```bash
+# Build
+docker build -t vulnclaw:latest .
+
+# Run the Web UI (persisting state in a named volume)
+docker run --rm -it \
+  -p 127.0.0.1:7788:7788 \
+  -e VULNCLAW_LLM_API_KEY=sk-your-key-here \
+  -v vulnclaw-data:/data \
+  vulnclaw:latest
+```
+
+## Running CLI commands instead of the Web UI
+
+The entrypoint is the `vulnclaw` binary, so you can override the command:
+
+```bash
+# One-off scan (replace TARGET)
+docker run --rm -it \
+  -e VULNCLAW_LLM_API_KEY=sk-your-key-here \
+  -v vulnclaw-data:/data \
+  vulnclaw:latest scan TARGET
+
+# Interactive REPL / TUI
+docker run --rm -it \
+  -e VULNCLAW_LLM_API_KEY=sk-your-key-here \
+  -v vulnclaw-data:/data \
+  vulnclaw:latest repl
+
+# Show help / available subcommands
+docker run --rm vulnclaw:latest --help
+```
+
+With compose:
+
+```bash
+docker compose run --rm vulnclaw scan TARGET
+```
+
+## Configuration
+
+Configuration is supplied via environment variables (see `.env.example`) and/or
+the persisted `config.yaml` written into the `/data` volume. Environment
+variables override the config file at startup.
+
+## Scanning a target from inside the container
+
+`localhost` / `127.0.0.1` inside the container refers to the **container
+itself**, not your host or another container — so scanning `localhost:PORT`
+will never reach a service running elsewhere. Use a routable address instead:
+
+- **Target on your host** (e.g. a `pnpm dev` / `npm run dev` server): add a
+  host-gateway alias and target `host.docker.internal`:
+
+  ```yaml
+  services:
+    vulnclaw:
+      extra_hosts:
+        - "host.docker.internal:host-gateway"
+  ```
+
+  Then scan `host.docker.internal:3000`. Note many dev servers bind to
+  loopback only (`127.0.0.1` / `[::1]`); start them on `0.0.0.0`
+  (e.g. `--host 0.0.0.0`) or the container still won't reach them.
+
+- **Target in another container**: put both on the same Docker network and
+  scan it by **container/service name** (e.g. `targetapp:8080`):
+
+  ```yaml
+  services:
+    vulnclaw:
+      networks: [default, targetnet]
+  networks:
+    targetnet:
+      external: true
+      name: <the-target-project's-network>   # `docker network ls`
+  ```
+
+Verify reachability before scanning:
+
+```bash
+docker compose exec vulnclaw \
+  python -c "import socket; socket.create_connection(('TARGET', PORT), 3); print('reachable')"
+```
+
+## Notes
+
+- The container binds the Web UI to `0.0.0.0` internally (required for the
+  published port to be reachable); the host-side `127.0.0.1:7788` mapping keeps
+  it private to your machine. Change the mapping to expose it elsewhere — only
+  do so on networks you trust, as the UI has no authentication.
+- The `chrome-devtools` MCP server is disabled by default; enabling it requires
+  a Chrome/Chromium browser which is not installed in this image to keep it
+  lean.
+- The optional knowledge-base feature (`kb`, ChromaDB) is not installed by
+  default. Add `kb` to the `pip install` extras in the Dockerfile if you need it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build the React Web UI ───────────────────────────────────
+FROM node:20-bookworm-slim AS frontend
+WORKDIR /frontend
+
+# Install deps first for better layer caching
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+# Build the SPA into /frontend/dist
+COPY frontend/ ./
+RUN npm run build
+
+
+# ── Stage 2: Python runtime ───────────────────────────────────────────
+FROM python:3.12-slim-bookworm AS runtime
+
+# Runtime tooling:
+#   - nodejs/npm  → provides `npx` for npx-based MCP servers (e.g. memory)
+#   - uv          → provides `uvx` for uvx-based MCP servers (e.g. fetch)
+#   - git/curl    → commonly needed by MCP servers fetched on demand
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        nodejs \
+        npm \
+        git \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv/uvx for Python-based MCP servers (kept in a stable location on PATH)
+RUN pip install --no-cache-dir uv
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    # Persist config, sessions, targets, reports here (mount a volume)
+    VULNCLAW_CONFIG_DIR=/data
+
+WORKDIR /app
+
+# Install Python deps first (better caching): copy only project metadata
+COPY pyproject.toml README.md LICENSE ./
+COPY vulnclaw ./vulnclaw
+
+# Editable install so vulnclaw resolves to /app and finds frontend/dist.
+# `web` extra pulls in fastapi + uvicorn for the Web UI.
+RUN pip install -e ".[web]"
+
+# Bring in the built frontend so the full React UI is served (not the
+# bundled single-file fallback). resolve_web_index() looks for this path.
+COPY --from=frontend /frontend/dist ./frontend/dist
+
+# Run as an unprivileged user; /data holds all mutable state.
+RUN useradd --create-home --uid 1000 vulnclaw \
+    && mkdir -p /data \
+    && chown -R vulnclaw:vulnclaw /app /data
+USER vulnclaw
+
+VOLUME ["/data"]
+EXPOSE 7788
+
+# Default: launch the Web UI bound to all interfaces inside the container.
+# (Binding to 0.0.0.0 is required for the published port to be reachable;
+#  the host-side port mapping controls real exposure.)
+ENTRYPOINT ["vulnclaw"]
+CMD ["web", "--host", "0.0.0.0", "--port", "7788", "--allow-remote"]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ cd VulnClaw
 pip install -e .
 ```
 
+### Docker 运行（可选）
+
+镜像已内置 Web UI 以及默认 MCP 服务所需的运行时（`npx` / `uvx`），所有状态（配置、会话、目标、报告）持久化到 `/data` 数据卷。
+
+```bash
+cp .env.example .env          # 填入 VULNCLAW_LLM_API_KEY 等
+docker compose up --build      # 构建镜像并启动 Web UI
+# 打开 http://127.0.0.1:7788
+```
+
+也可用纯 docker 运行某条 CLI 命令：
+
+```bash
+docker run --rm -it \
+  -e VULNCLAW_LLM_API_KEY=sk-your-key-here \
+  -v vulnclaw-data:/data \
+  vulnclaw:latest scan <target>
+```
+
+> ⚠️ 容器内的 `localhost` 指向容器自身。扫描宿主机服务请使用 `host.docker.internal`，扫描其它容器请共享网络并用容器名访问。详见 [DOCKER.md](DOCKER.md)。
+
 ### 四步启动
 
 ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -78,6 +78,31 @@ cd VulnClaw
 pip install -e .
 ```
 
+### Run with Docker (optional)
+
+The image bundles the Web UI plus the runtimes (`npx` / `uvx`) needed by the
+default MCP servers. All state (config, sessions, targets, reports) persists in
+a `/data` volume.
+
+```bash
+cp .env.example .env          # add VULNCLAW_LLM_API_KEY etc.
+docker compose up --build      # build the image and start the Web UI
+# open http://127.0.0.1:7788
+```
+
+Or run a one-off CLI command with plain docker:
+
+```bash
+docker run --rm -it \
+  -e VULNCLAW_LLM_API_KEY=sk-your-key-here \
+  -v vulnclaw-data:/data \
+  vulnclaw:latest scan <target>
+```
+
+> ⚠️ `localhost` inside the container refers to the container itself. To scan a
+> service on your host use `host.docker.internal`; to scan another container,
+> share a network and use its container name. See [DOCKER.md](DOCKER.md).
+
 ### Four-Step Launch
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  vulnclaw:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: vulnclaw:latest
+    container_name: vulnclaw
+    # LLM credentials and overrides come from .env (see .env.example).
+    # Marked optional so `docker compose up` still works before you create
+    # one — you can also pass VULNCLAW_LLM_* via the shell environment.
+    env_file:
+      - path: .env
+        required: false
+    ports:
+      # host:container — change the host side to expose elsewhere.
+      - "127.0.0.1:7788:7788"
+    volumes:
+      # Persist config, sessions, targets and reports across restarts.
+      - vulnclaw-data:/data
+    restart: unless-stopped
+
+volumes:
+  vulnclaw-data:


### PR DESCRIPTION
hey! :D

so i wanted to be able to run VulnClaw inside a container instead of setting up python + node + all the mcp runtimes on my own machine every time  figured this would make it a lot easier for people to just spin it up and go, so i put together a little docker setup for it.

here's basically what i did:

- **Dockerfile**  multi-stage build. first stage uses node to build the react web ui, second stage is the python runtime that installs the package (editable, so it actually finds the built `frontend/dist`) with the `web` extra. i also baked in `npx` + `uvx` so the default mcp servers (memory, fetch) work out of the box. runs as a non-root user and keeps all the state (config, sessions, targets, reports) in a `/data` volume so nothing gets lost between restarts.
- **docker-compose.yml**  one command to build + run. the `.env` is optional so `docker compose up` still works before you make one, port is pinned to `127.0.0.1:7788` so it stays private, and there's a named volume for persistence.
- **.dockerignore**  keeps the build context small and makes sure no secrets/.env sneak into the image.
- **.env.example**  documented the `VULNCLAW_LLM_*` vars. one thing that tripped me up: when you configure via env, the provider name alone doesn't auto-fill base_url/model like the interactive `config` command does, so i called that out (otherwise you get a confusing \"invalid api key\" when your key hits the wrong endpoint).
- **DOCKER.md**  usage for both compose and plain docker, plus a section on scanning targets from inside the container (the whole \"localhost inside the container is the container itself\" thing  caught me out so i wrote it down).
- **README.md / README_EN.md**  added a short docker quick-start to both.

what i actually tested: the image builds, the container boots, `/api/health` returns ok, the real react ui gets served (not the fallback), and npx/uvx/node are all on PATH. being honest though

happy to change anything if you'd rather it be structured differently! thanks for the cool project :D