### PR TITLE
Fix solve engine frontier recovery

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -44,6 +44,28 @@ def test_extract_json_handles_fences_and_noise():
     assert solver._extract_json("not json at all") is None
 
 
+def test_reason_prompt_requires_frontier_recovery_without_open_intents():
+    board = Blackboard(origin="http://t", goal="capture flag")
+    seed = board.add_fact("login form")
+    dead = board.add_intent("try generic login bypass", [seed.id])
+    board.abandon_intent(dead.id, note="no useful response")
+
+    prompt = solver._reason_prompt(board, max_intents=3)
+
+    assert "Frontier recovery rule" in prompt
+    assert 'Do not return {"complete": false} without new intents' in prompt
+
+
+def test_reason_prompt_does_not_force_recovery_with_open_intents():
+    board = Blackboard(origin="http://t", goal="capture flag")
+    seed = board.add_fact("login form")
+    board.add_intent("try generic login bypass", [seed.id])
+
+    prompt = solver._reason_prompt(board, max_intents=3)
+
+    assert "Frontier recovery rule" not in prompt
+
+
 async def test_solve_completes_when_reason_signals_goal(monkeypatch):
     calls = {"reason": 0}
 
@@ -255,10 +277,14 @@ async def test_solve_stops_when_frontier_exhausted(monkeypatch):
     async def fake_reason_noop(agent, board, max_intents):
         return {}  # never proposes intents
 
+    async def fake_recovery_noop(agent, board, max_intents, streak):
+        return {}  # recovery also cannot find a path
+
     async def fake_explore(agent, board, intent, *, max_tool_rounds, evidence_buffer, stream_sink=None):
         return True, "unused"
 
     monkeypatch.setattr(solver, "reason_step", fake_reason_noop)
+    monkeypatch.setattr(solver, "frontier_recovery_step", fake_recovery_noop)
     monkeypatch.setattr(solver, "explore_step", fake_explore)
 
     result = await solver.solve(_fake_agent(), origin="t", goal="g", max_steps=10)
@@ -267,6 +293,66 @@ async def test_solve_stops_when_frontier_exhausted(monkeypatch):
     assert result.reason == "探索前沿耗尽"
     # only the seeded origin fact
     assert result.facts == 1
+
+
+async def test_solve_recovers_empty_frontier_with_new_intent(monkeypatch):
+    async def fake_reason(agent, board, max_intents):
+        if not board.intents:
+            return {
+                "intents": [
+                    {"from": [], "description": "inspect login page"},
+                    {"from": [], "description": "try generic sqli bypass"},
+                    {"from": [], "description": "enumerate common files"},
+                ]
+            }
+        return {"complete": False}
+
+    async def fake_recovery(agent, board, max_intents, streak):
+        return {
+            "complete": False,
+            "intents": [
+                {
+                    "from": ["f002"],
+                    "description": "try header and cookie based auth bypass",
+                }
+            ],
+        }
+
+    async def fake_explore(
+        agent,
+        board,
+        intent,
+        *,
+        max_tool_rounds,
+        evidence_buffer,
+        stream_sink=None,
+        skip_context_write=False,
+    ):
+        if "header and cookie" in intent.description:
+            evidence_buffer.append("HTTP 200\nflag{recovered}")
+            return True, "header/cookie bypass returned flag{recovered}"
+        if "login page" in intent.description:
+            return True, "login form and CORS headers confirmed"
+        return False, "no useful result"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "frontier_recovery_step", fake_recovery)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[str] = []
+    result = await solver.solve(
+        _fake_agent(),
+        origin="http://t",
+        goal="capture flag",
+        max_steps=10,
+        max_parallel=3,
+        on_event=lambda kind, payload: events.append(kind),
+    )
+
+    assert result.completed is True
+    assert "frontier_recovery" in events
+    assert any("header and cookie" in intent.description for intent in result.board.intents)
+    assert "flag{recovered}" in result.board.complete_reason
 
 
 async def test_solve_abandons_unproductive_intent(monkeypatch):

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -355,6 +355,53 @@ async def test_solve_recovers_empty_frontier_with_new_intent(monkeypatch):
     assert "flag{recovered}" in result.board.complete_reason
 
 
+async def test_solve_adds_fallback_intents_when_recovery_is_empty(monkeypatch):
+    async def fake_reason(agent, board, max_intents):
+        if not board.intents:
+            return {"intents": [{"from": [], "description": "dead login path"}]}
+        return {"complete": False}
+
+    async def fake_recovery_noop(agent, board, max_intents, streak):
+        return {"complete": False}
+
+    async def fake_explore(
+        agent,
+        board,
+        intent,
+        *,
+        max_tool_rounds,
+        evidence_buffer,
+        stream_sink=None,
+        skip_context_write=False,
+    ):
+        if "header/cookie auth bypass" in intent.description:
+            evidence_buffer.append("HTTP 200\nflag{fallback}")
+            return True, "header/cookie auth bypass returned flag{fallback}"
+        return False, "no useful result"
+
+    monkeypatch.setattr(solver, "reason_step", fake_reason)
+    monkeypatch.setattr(solver, "frontier_recovery_step", fake_recovery_noop)
+    monkeypatch.setattr(solver, "explore_step", fake_explore)
+
+    events: list[tuple[str, dict]] = []
+    result = await solver.solve(
+        _fake_agent(),
+        origin="http://t",
+        goal="capture flag",
+        max_steps=10,
+        max_parallel=3,
+        on_event=lambda kind, payload: events.append((kind, payload)),
+    )
+
+    assert result.completed is True
+    assert any(
+        kind == "frontier_recovery" and payload.get("reason") == "fallback_intents"
+        for kind, payload in events
+    )
+    assert any("header/cookie auth bypass" in intent.description for intent in result.board.intents)
+    assert "flag{fallback}" in result.board.complete_reason
+
+
 async def test_solve_abandons_unproductive_intent(monkeypatch):
     state = {"reason": 0}
 

--- a/vulnclaw/agent/solver.py
+++ b/vulnclaw/agent/solver.py
@@ -23,6 +23,8 @@ from vulnclaw.agent.blackboard import Blackboard, BoardIntent, IntentStatus
 from vulnclaw.agent.llm_client import build_chat_completion_kwargs, call_llm_auto
 from vulnclaw.agent.think_filter import strip_think_tags
 
+FRONTIER_RECOVERY_LIMIT = 2
+
 # 探索阶段判定「已推进/已确认结论」的信号（宽泛匹配，避免漏判有进展的 intent）
 _ADVANCE_MARKERS = [
     "确认",
@@ -276,10 +278,21 @@ def _reason_prompt(board: Blackboard, max_intents: int) -> str:
             concluded_block += f"  - {i.id} → {i.result_fact}: {i.description}\n"
         concluded_block += "\n"
 
+    frontier_block = ""
+    if not open_list and not board.completed:
+        frontier_block = (
+            "Frontier recovery rule: there are currently no OPEN intents and the goal is "
+            "not complete. Do not return {\"complete\": false} without new intents in this "
+            "state. Propose fresh, non-overlapping directions that pivot to a different "
+            "attack surface, parameter shape, HTTP method/header/cookie angle, source leak, "
+            "or runtime behavior. Avoid repeating abandoned intents, but do not stop just "
+            "because earlier broad directions failed.\n\n"
+        )
+
     return (
         "你是该领域的资深渗透专家。下面是当前任务的「黑板图」快照：facts 是已确认的客观事实，"
         "intents 是探索方向。图从 facts 出发、通过 intent 探索得到新的 fact，逐步逼近 goal。\n\n"
-        f"{open_block}{abandoned_block}{concluded_block}"
+        f"{open_block}{abandoned_block}{concluded_block}{frontier_block}"
         "请判断两件事：① 现有 facts 是否已满足 goal；② 若未满足，是否应提出新的探索方向。\n\n"
         "只返回一个 JSON 对象，不要输出别的内容：\n"
         '- 若 goal 已达成： {"complete": true, "reason": "说明为何已达成", "evidence": ["f002"]}'
@@ -395,8 +408,48 @@ def _is_duplicate_intent(board: Blackboard, new_desc: str) -> bool:
     return False
 
 
+def _add_decision_intents(board: Blackboard, decision: dict) -> int:
+    added = 0
+    for item in decision.get("intents") or []:
+        desc = (item or {}).get("description", "").strip() if isinstance(item, dict) else ""
+        if not desc:
+            continue
+        if _is_duplicate_intent(board, desc):
+            continue
+        board.add_intent(desc, (item or {}).get("from"))
+        added += 1
+    return added
+
+
+def _frontier_recovery_prompt(board: Blackboard, max_intents: int, streak: int) -> str:
+    return (
+        _reason_prompt(board, max_intents)
+        + "\n\n## Frontier recovery override\n"
+        + f"This is recovery attempt {streak}/{FRONTIER_RECOVERY_LIMIT}. "
+        + "The solve graph has no OPEN intents, but the goal is not complete. "
+        + "Return JSON with at least one new intent unless the existing facts prove the "
+        + "goal is impossible under the authorized scope. The new intents must be concrete "
+        + "next actions and must pivot away from abandoned directions.\n"
+        + 'Valid recovery response: {"complete": false, "intents": [{"from": ["f001"], '
+        + '"description": "try a different concrete path"}]}\n'
+    )
+
+
 async def reason_step(agent: Any, board: Blackboard, max_intents: int) -> dict:
     raw = await _structured_call(agent, _reason_prompt(board, max_intents), max_tokens=1200)
+    parsed = _extract_json(raw)
+    return parsed or {}
+
+
+async def frontier_recovery_step(
+    agent: Any,
+    board: Blackboard,
+    max_intents: int,
+    streak: int,
+) -> dict:
+    raw = await _structured_call(
+        agent, _frontier_recovery_prompt(board, max_intents, streak), max_tokens=1200
+    )
     parsed = _extract_json(raw)
     return parsed or {}
 
@@ -572,6 +625,31 @@ async def solve(
                 sum(1 for i in board.intents if i.status == IntentStatus.ABANDONED),
             )
 
+        async def _try_frontier_recovery() -> bool:
+            nonlocal empty_reason_streak, consecutive_errors
+            if empty_reason_streak >= FRONTIER_RECOVERY_LIMIT:
+                return False
+
+            empty_reason_streak += 1
+            emit(
+                "frontier_recovery",
+                {"streak": empty_reason_streak, "reason": "no_open_intents"},
+            )
+            try:
+                recovery_decision = await frontier_recovery_step(
+                    agent, board, max_intents, empty_reason_streak
+                )
+            except Exception as exc:
+                consecutive_errors += 1
+                emit("error", {"phase": "frontier_recovery", "error": str(exc)})
+                return False
+
+            emit("reason", {"decision": recovery_decision, "step": steps, "recovery": True})
+            if _add_decision_intents(board, recovery_decision):
+                empty_reason_streak = 0
+                return True
+            return False
+
         while steps < max_steps and not board.completed:
             cur_checkpoint = _graph_checkpoint()
             open_intents = board.open_intents()
@@ -630,29 +708,27 @@ async def solve(
                     continue
                 complete_reject_streak = 0
 
-                for item in decision.get("intents") or []:
-                    desc = (item or {}).get("description", "").strip() if isinstance(item, dict) else ""
-                    if not desc:
-                        continue
-                    if _is_duplicate_intent(board, desc):
-                        continue
-                    board.add_intent(desc, (item or {}).get("from"))
+                _add_decision_intents(board, decision)
 
                 open_intents = board.open_intents()
                 if not open_intents:
-                    empty_reason_streak += 1
-                    if empty_reason_streak >= 3:
+                    await _try_frontier_recovery()
+                    open_intents = board.open_intents()
+                    if empty_reason_streak >= FRONTIER_RECOVERY_LIMIT and not open_intents:
                         break
-                    continue
+                    if not open_intents:
+                        continue
                 empty_reason_streak = 0
 
             # ── 选取 intent batch 去探索 ──────────────────────────────
             open_intents = board.open_intents()
             if not open_intents:
-                empty_reason_streak += 1
-                if empty_reason_streak >= 3:
+                await _try_frontier_recovery()
+                open_intents = board.open_intents()
+                if empty_reason_streak >= FRONTIER_RECOVERY_LIMIT and not open_intents:
                     break
-                continue
+                if not open_intents:
+                    continue
             empty_reason_streak = 0
 
             batch = open_intents[:max_parallel]

--- a/vulnclaw/agent/solver.py
+++ b/vulnclaw/agent/solver.py
@@ -435,6 +435,40 @@ def _frontier_recovery_prompt(board: Blackboard, max_intents: int, streak: int) 
     )
 
 
+def _add_fallback_recovery_intents(board: Blackboard, max_intents: int) -> int:
+    if not board.intents:
+        return 0
+
+    from_facts = board.fact_ids()[-3:]
+    candidates = [
+        (
+            "Pivot to header/cookie auth bypass: test Authorization, x-auth-token, "
+            "Cookies, Aaa, X-Forwarded-* and method override headers against login "
+            "and likely protected pages."
+        ),
+        (
+            "Pivot to request-shape login bypass: compare form vs JSON bodies, "
+            "duplicate username/password parameters, array parameters, empty values, "
+            "and GET/POST/PUT method differences while preserving session cookies."
+        ),
+        (
+            "Pivot to source and backup leakage under catch-all routing: classify "
+            "candidate source/backup paths by status, content-type, body length, "
+            "hash and headers rather than status code alone."
+        ),
+    ]
+
+    added = 0
+    for desc in candidates:
+        if _is_duplicate_intent(board, desc):
+            continue
+        board.add_intent(desc, from_facts)
+        added += 1
+        if added >= max(1, min(max_intents, len(candidates))):
+            break
+    return added
+
+
 async def reason_step(agent: Any, board: Blackboard, max_intents: int) -> dict:
     raw = await _structured_call(agent, _reason_prompt(board, max_intents), max_tokens=1200)
     parsed = _extract_json(raw)
@@ -646,6 +680,19 @@ async def solve(
 
             emit("reason", {"decision": recovery_decision, "step": steps, "recovery": True})
             if _add_decision_intents(board, recovery_decision):
+                empty_reason_streak = 0
+                return True
+
+            fallback_added = _add_fallback_recovery_intents(board, max_intents)
+            if fallback_added:
+                emit(
+                    "frontier_recovery",
+                    {
+                        "streak": empty_reason_streak,
+                        "reason": "fallback_intents",
+                        "added": fallback_added,
+                    },
+                )
                 empty_reason_streak = 0
                 return True
             return False

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -196,6 +196,11 @@ def _make_solve_event_printer(target_console):
                 )
             else:
                 target_console.print("[dim]◆ Reason: 暂不新增方向[/dim]")
+        elif kind == "frontier_recovery":
+            target_console.print(
+                f"[yellow]Frontier recovery:[/yellow] "
+                f"no open intents, retry {payload.get('streak', '?')}"
+            )
         elif kind == "completed":
             target_console.print("[green]✓ Reason: 目标达成[/green]")
         elif kind == "explore_start":

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -197,10 +197,16 @@ def _make_solve_event_printer(target_console):
             else:
                 target_console.print("[dim]◆ Reason: 暂不新增方向[/dim]")
         elif kind == "frontier_recovery":
-            target_console.print(
-                f"[yellow]Frontier recovery:[/yellow] "
-                f"no open intents, retry {payload.get('streak', '?')}"
-            )
+            if payload.get("reason") == "fallback_intents":
+                target_console.print(
+                    f"[yellow]Frontier recovery:[/yellow] "
+                    f"added {payload.get('added', 0)} fallback intents"
+                )
+            else:
+                target_console.print(
+                    f"[yellow]Frontier recovery:[/yellow] "
+                    f"no open intents, retry {payload.get('streak', '?')}"
+                )
         elif kind == "completed":
             target_console.print("[green]✓ Reason: 目标达成[/green]")
         elif kind == "explore_start":


### PR DESCRIPTION
## Summary
- add a bounded frontier recovery step when the solve graph has no open intents but the goal is not complete
- tighten the reason prompt so empty-frontier states cannot silently return `{complete: false}` without new intents
- add deterministic fallback recovery intents when the LLM recovery pass still returns no new directions
- surface `frontier_recovery` events in the CLI and cover both LLM-driven and fallback recovery paths in solver tests

## Real-target smoke test
Ran against `https://ad25ab12-512d-4c98-9c2e-8ddaee40e670.challenge.ctf.show/` with `--max-steps 6 --max-tool-rounds 2 --no-resume`.

Observed behavior:
- initial intents exhausted
- recovery triggered: `Frontier recovery: no open intents, retry 1`
- DeepSeek still returned no new directions
- fallback engaged: `Frontier recovery: added 3 fallback intents`
- solver continued exploring new header/cookie, request-shape, and source-leak pivots instead of stopping at the empty frontier

## Tests
- `python -m pytest tests/test_cli.py tests/test_solver.py -q`
- `python -m ruff check vulnclaw/agent/solver.py vulnclaw/cli/main.py tests/test_solver.py`

## Local note
A full local test run currently has one unrelated timeout in `tests/test_chatgpt_proxy.py::test_proxy_models_endpoint`; the solver and CLI suites are green.