### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ vulnclaw tui --target 192.168.1.100 --mode continuous
 
 ```bash
 # 安装 Web 依赖
-pip install vulnclaw[web]
+pip install 'vulnclaw[web]'
 
 # 启动 Web UI（默认 127.0.0.1:7788）
 vulnclaw web

--- a/README_EN.md
+++ b/README_EN.md
@@ -418,7 +418,7 @@ Operate the full pentest workflow through a browser — ideal for users who pref
 
 ```bash
 # Install Web dependencies
-pip install vulnclaw[web]
+pip install 'vulnclaw[web]'
 
 # Launch Web UI (default: 127.0.0.1:7788)
 vulnclaw web


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.md`
- `README_EN.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`