### PR TITLE
Fix three triaged bugs: scope-prompt drift, missing run report, dead fetch cookie jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+.PHONY: help install install-frontend test lint build build-python build-frontend release-preflight release-preflight-build dev-web
+
+PYTHON ?= python
+PIP ?= $(PYTHON) -m pip
+NPM ?= npm
+
+help:
+	@printf '%s\n' \
+		'VulnClaw development targets:' \
+		'  make install          Install Python dev extras and frontend dependencies' \
+		'  make test             Run the backend pytest suite' \
+		'  make lint             Run Ruff checks' \
+		'  make build            Build Python distributions and the frontend' \
+		'  make release-preflight Run release validation script' \
+		'  make release-preflight-build Run release validation with dist checks' \
+		'  make dev-web          Start the frontend Vite dev server'
+
+install:
+	$(PIP) install -e ".[dev,web,pdf]"
+	$(NPM) --prefix frontend install
+
+install-frontend:
+	$(NPM) --prefix frontend install
+
+test:
+	$(PYTHON) -m pytest
+
+lint:
+	$(PYTHON) -m ruff check .
+
+build: build-python build-frontend
+
+build-python:
+	$(PYTHON) -m build
+
+build-frontend:
+	$(NPM) --prefix frontend run build
+
+release-preflight:
+	$(PYTHON) scripts/release_preflight.py
+
+release-preflight-build:
+	$(PYTHON) scripts/release_preflight.py --build
+
+dev-web:
+	$(NPM) --prefix frontend run dev

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,109 @@
+VulnClaw
+========
+
+VulnClaw is a derivative work built on Vulnbot and incorporating code ported
+from two other MIT-licensed projects:
+
+  Vulnbot  — Copyright (c) 2026 UncleC
+              https://github.com/Unclecheng-li/Vulnbot
+
+  VulnBot   — Copyright (c) 2026 UncleC (fork), JMAN730
+              https://github.com/JMAN730/VulnBot
+
+  HackBot   — Copyright (c) 2026 HackBot Team (Yashab Alam)
+              https://github.com/yashab-cyber/hackbot
+
+VulnClaw uses Vulnbot as its base (agent core, MCP toolchain, skills,
+CLI/TUI/web surfaces). It additionally ports selected modules from VulnBot —
+itself a Vulnbot fork — including adaptive network scanning, bounded parallel
+agent fan-out, PDF report export, provider-preset model listing, the CLI
+manual, multi-key LLM failover, and web/path-traversal hardening. VulnBot in
+turn ported its threat-intelligence modules (CVE lookup, OSINT recon, network
+topology, compliance/MITRE ATT&CK mapping, findings scoring, remediation
+advice) from HackBot; those modules are included in VulnClaw transitively via
+the VulnBot port.
+
+All three upstream projects are distributed under the MIT License. The full
+text of each upstream license is reproduced below. This NOTICE file must be
+retained in all copies or substantial portions of the combined work.
+
+
+--------------------------------------------------------------------------------
+Vulnbot — MIT License
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2026 UncleC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+VulnBot — MIT License
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2026 UncleC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+HackBot — MIT License
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2026 HackBot Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -796,6 +796,10 @@ vulnclaw config set session.show_thinking false # 隐藏推理过程（也可在
 
 ## 安全声明
 
+**公开 Alpha 阶段**：VulnClaw 是面向已授权安全测试、CTF、实验环境与可控研究场景的公开
+Alpha 软件，不应作为生产环境的安全控制手段或授权机制。使用前请阅读
+[SECURITY.md](SECURITY.md)。
+
 VulnClaw 仅用于**已授权的安全测试**。使用本工具前，请确保：
 
 1. 你已获得目标系统的**明确授权**

--- a/README_EN.md
+++ b/README_EN.md
@@ -642,6 +642,12 @@ Config file location: `~/.vulnclaw/config.yaml`.
 
 ## Security Notice
 
+**Public alpha:** VulnClaw is public alpha software for authorized security
+testing, CTFs, labs, and controlled research. It is not a production security
+control or a replacement for human authorization, scoping, review, or
+reporting. See [SECURITY.md](SECURITY.md) before using or reporting security
+issues.
+
 VulnClaw is intended **solely for authorized security testing**. Before using this tool, ensure:
 
 1. You have **explicit authorization** for the target system

--- a/frontend/src/api/web.ts
+++ b/frontend/src/api/web.ts
@@ -3,6 +3,9 @@ import type {
   ConstraintAuditView,
   ConfigUpdateRequest,
   MCPDiagnosticsView,
+  ProviderModelsRequest,
+  ProviderModelsResponse,
+  ProvidersView,
   ReportListItem,
   ReportContentView,
   TargetPreviewView,
@@ -103,6 +106,17 @@ export function getConstraintAudit(): Promise<ConstraintAuditView> {
 
 export function updateConfig(payload: ConfigUpdateRequest): Promise<ConfigView> {
   return requestJson<ConfigView>("/api/config", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function getProviders(): Promise<ProvidersView> {
+  return requestJson<ProvidersView>("/api/providers");
+}
+
+export function fetchProviderModels(payload: ProviderModelsRequest): Promise<ProviderModelsResponse> {
+  return requestJson<ProviderModelsResponse>("/api/provider-models", {
     method: "POST",
     body: JSON.stringify(payload),
   });

--- a/frontend/src/hooks/queries.ts
+++ b/frontend/src/hooks/queries.ts
@@ -1,11 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
-import { getConfig, getConstraintAudit, getMcpDiagnostics, getReportContent, getReports, getTarget, getTargetDiff, getTargetPreview, getTargetSnapshots, getTargets, getTasks } from "../api/web";
+import { getConfig, getConstraintAudit, getMcpDiagnostics, getProviders, getReportContent, getReports, getTarget, getTargetDiff, getTargetPreview, getTargetSnapshots, getTargets, getTasks } from "../api/web";
 
 export function useConfigQuery() {
   return useQuery({
     queryKey: ["config"],
     queryFn: getConfig,
     staleTime: 30_000,
+  });
+}
+
+export function useProvidersQuery() {
+  return useQuery({
+    queryKey: ["providers"],
+    queryFn: getProviders,
+    staleTime: 300_000,
   });
 }
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -495,6 +495,12 @@
   "settings.model_hint": "Use the model name configured for your backend.",
   "settings.base_url": "Base URL",
   "settings.base_url_hint": "Leave blank to use the backend default.",
+  "settings.custom_endpoint": "Custom endpoint…",
+  "settings.custom_model": "Custom model…",
+  "settings.refresh_models": "Refresh models",
+  "settings.loading_models": "Loading…",
+  "settings.models_loaded": "Loaded {count} models",
+  "settings.no_models": "No models returned. Save your API key, then refresh.",
 
   "settings.max_rounds": "Max rounds",
   "settings.rounds_per_cycle": "Rounds per cycle",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -495,6 +495,12 @@
   "settings.model_hint": "使用后端配置的模型名称。",
   "settings.base_url": "Base URL",
   "settings.base_url_hint": "留空使用后端默认值。",
+  "settings.custom_endpoint": "自定义端点…",
+  "settings.custom_model": "自定义模型…",
+  "settings.refresh_models": "刷新模型列表",
+  "settings.loading_models": "加载中…",
+  "settings.models_loaded": "已加载 {count} 个模型",
+  "settings.no_models": "未返回任何模型。请先保存 API 密钥，然后刷新。",
 
   "settings.max_rounds": "最大轮数",
   "settings.rounds_per_cycle": "每周期轮数",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
-import { updateConfig } from "../api/web";
+import { fetchProviderModels, updateConfig } from "../api/web";
 import { SectionCard } from "../components/SectionCard";
-import { useConfigQuery, useMcpDiagnosticsQuery } from "../hooks/queries";
+import { useConfigQuery, useMcpDiagnosticsQuery, useProvidersQuery } from "../hooks/queries";
 import { useT, type TFunction } from "../i18n";
 import { formatActionLabel, formatActionList, formatMcpExecutionMode, formatMcpHealth } from "../utils/taskLabels";
 import { loadUiPreferences, saveUiPreferences, type UiPreferences } from "../utils/preferences";
@@ -51,10 +51,14 @@ export function SettingsPage({ initialSection = "basic", onOpenAdvanced }: Setti
   const PYTHON_MODES = useMemo(() => buildPythonModes(t), [t]);
   const configQuery = useConfigQuery();
   const mcpQuery = useMcpDiagnosticsQuery();
+  const providersQuery = useProvidersQuery();
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
   const [provider, setProvider] = useState("openai");
   const [model, setModel] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+  const [models, setModels] = useState<string[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelsHint, setModelsHint] = useState<string | null>(null);
   const [outputDir, setOutputDir] = useState("");
   const [maxRounds, setMaxRounds] = useState(15);
   const [persistentRounds, setPersistentRounds] = useState(100);
@@ -118,6 +122,47 @@ export function SettingsPage({ initialSection = "basic", onOpenAdvanced }: Setti
     : activeSection === "boundary"
       ? t("settings.save_boundary")
       : t("settings.save_settings");
+
+  const providers = providersQuery.data?.providers ?? [];
+  const presetBaseUrls = providers.filter((preset) => preset.base_url);
+  const isPresetBaseUrl = presetBaseUrls.some((preset) => preset.base_url === baseUrl);
+  const currentPreset = providers.find((preset) => preset.id === provider);
+  const modelOptions = Array.from(
+    new Set([...models, model, currentPreset?.default_model ?? ""].filter(Boolean)),
+  );
+  const isKnownModel = modelOptions.includes(model);
+
+  function onProviderChange(id: string) {
+    setProvider(id);
+    const preset = providers.find((item) => item.id === id);
+    if (preset && id !== "custom") {
+      setBaseUrl(preset.base_url);
+      setModel(preset.default_model);
+    }
+    setModels([]);
+    setModelsHint(null);
+  }
+
+  async function handleRefreshModels() {
+    setModelsLoading(true);
+    setModelsHint(null);
+    try {
+      const res = await fetchProviderModels({ provider, base_url: baseUrl });
+      setModels(res.models);
+      if (res.models.length && !model) {
+        setModel(res.models[0]);
+      }
+      setModelsHint(
+        res.models.length
+          ? t("settings.models_loaded", { count: String(res.models.length) })
+          : res.detail || t("settings.no_models"),
+      );
+    } catch (err) {
+      setModelsHint(err instanceof Error ? err.message : t("settings.no_models"));
+    } finally {
+      setModelsLoading(false);
+    }
+  }
 
   function saveLocalPreferences() {
     saveUiPreferences({
@@ -247,19 +292,68 @@ export function SettingsPage({ initialSection = "basic", onOpenAdvanced }: Setti
             <div className="form-grid">
               <label className="field">
                 <span>{t("settings.provider")}</span>
-                <input value={provider} onChange={(event) => setProvider(event.target.value)} />
+                <select value={provider} onChange={(event) => onProviderChange(event.target.value)}>
+                  {providers.length === 0 && <option value={provider}>{provider}</option>}
+                  {providers.map((preset) => (
+                    <option key={preset.id} value={preset.id}>{preset.label}</option>
+                  ))}
+                </select>
                 <small>{t("settings.provider_hint")}</small>
               </label>
               <label className="field">
-                <span>{t("settings.model_field")}</span>
-                <input value={model} onChange={(event) => setModel(event.target.value)} />
-                <small>{t("settings.model_hint")}</small>
-              </label>
-              <label className="field field-wide">
                 <span>{t("settings.base_url")}</span>
-                <input value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} />
+                <select
+                  value={isPresetBaseUrl ? baseUrl : "__custom__"}
+                  onChange={(event) => {
+                    setBaseUrl(event.target.value === "__custom__" ? "" : event.target.value);
+                    setModels([]);
+                    setModelsHint(null);
+                  }}
+                >
+                  {presetBaseUrls.map((preset) => (
+                    <option key={preset.id} value={preset.base_url}>{preset.label}</option>
+                  ))}
+                  <option value="__custom__">{t("settings.custom_endpoint")}</option>
+                </select>
+                {!isPresetBaseUrl && (
+                  <input
+                    value={baseUrl}
+                    onChange={(event) => setBaseUrl(event.target.value)}
+                    placeholder="https://host/v1"
+                  />
+                )}
                 <small>{t("settings.base_url_hint")}</small>
               </label>
+              <div className="field field-wide">
+                <span>{t("settings.model_field")}</span>
+                <div className="settings-model-row">
+                  <select
+                    value={isKnownModel ? model : "__custom__"}
+                    onChange={(event) => setModel(event.target.value === "__custom__" ? "" : event.target.value)}
+                  >
+                    {modelOptions.map((option) => (
+                      <option key={option} value={option}>{option}</option>
+                    ))}
+                    <option value="__custom__">{t("settings.custom_model")}</option>
+                  </select>
+                  <button
+                    type="button"
+                    className="secondary-btn"
+                    onClick={handleRefreshModels}
+                    disabled={modelsLoading}
+                  >
+                    {modelsLoading ? t("settings.loading_models") : t("settings.refresh_models")}
+                  </button>
+                </div>
+                {!isKnownModel && (
+                  <input
+                    value={model}
+                    onChange={(event) => setModel(event.target.value)}
+                    placeholder="model-name"
+                  />
+                )}
+                <small>{modelsHint ?? t("settings.model_hint")}</small>
+              </div>
             </div>
           )}
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -556,6 +556,17 @@ code {
   min-height: 120px;
 }
 
+.settings-model-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-model-row select {
+  flex: 1;
+  min-width: 0;
+}
+
 .diagnostics-grid {
   display: grid;
   gap: 12px;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -31,6 +31,29 @@ export interface ConfigUpdateRequest {
   python_execute_audit_enabled?: boolean;
 }
 
+export interface ProviderPresetView {
+  id: string;
+  label: string;
+  base_url: string;
+  default_model: string;
+}
+
+export interface ProvidersView {
+  providers: ProviderPresetView[];
+}
+
+export interface ProviderModelsRequest {
+  provider?: string;
+  base_url?: string;
+}
+
+export interface ProviderModelsResponse {
+  base_url: string;
+  models: string[];
+  has_api_key: boolean;
+  detail: string;
+}
+
 export interface TargetView {
   target: string;
   schema_version: number;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ web = [
 kb = [
     "chromadb>=0.4.0",
 ]
+pdf = [
+    # Optional: render reports to PDF via report.pdf_exporter.
+    "reportlab>=4.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/Unclecheng-li/VulnClaw"

--- a/tests/intel/test_agent_seam.py
+++ b/tests/intel/test_agent_seam.py
@@ -1,0 +1,25 @@
+import pytest
+
+from vulnclaw.agent import builtin_tools as bt
+
+
+def test_builder_includes_intel_schemas():
+    schemas = bt.build_openai_tools(mcp_manager=None)
+    names = {s["function"]["name"] for s in schemas}
+    assert "cve_lookup" in names
+
+
+@pytest.mark.asyncio
+async def test_execute_routes_intel_tool(monkeypatch):
+    from vulnclaw.intel import tools as intel_tools
+
+    async def fake(agent, args):
+        return "OK:" + args["query"]
+
+    monkeypatch.setitem(intel_tools._HANDLERS, "cve_lookup", fake)
+    out = await bt.execute_mcp_tool(agent=_FakeAgent(), tool_name="cve_lookup", args={"query": "x"})
+    assert out == "OK:x"
+
+
+class _FakeAgent:
+    session_state = None

--- a/tests/intel/test_attack.py
+++ b/tests/intel/test_attack.py
@@ -1,0 +1,81 @@
+import json
+
+import pytest
+
+from vulnclaw.intel.attack import AttackMapper, attack_map_tool
+
+SQLI = {"title": "SQL Injection", "severity": "High", "description": "sql injection union select"}
+
+
+def test_mapper_maps_findings_to_techniques():
+    rep = AttackMapper().map_findings([SQLI], target="example.com")
+    assert rep.mappings
+    assert rep.target == "example.com"
+    # each mapping references a technique id like T1xxx
+    assert all(m.technique.id.startswith("T") for m in rep.mappings)
+
+
+def test_tool_techniques_lookup():
+    techs = AttackMapper.get_tool_techniques("nmap_scan")
+    # may be empty if tool not mapped, but must be a list
+    assert isinstance(techs, list)
+
+
+def test_navigator_layer_is_valid_json():
+    rep = AttackMapper().map_findings([SQLI], target="example.com")
+    layer = json.loads(AttackMapper().generate_navigator_json(rep))
+    assert layer["name"].startswith("VulnClaw")
+    assert "techniques" in layer
+    assert layer.get("domain") or layer.get("versions")
+
+
+def test_format_report_markdown():
+    rep = AttackMapper().map_findings([SQLI], target="example.com")
+    out = AttackMapper.format_report(rep)
+    assert "MITRE ATT&CK" in out
+
+
+def test_list_tactics_and_techniques():
+    assert len(AttackMapper.list_tactics()) > 0
+    assert len(AttackMapper.list_techniques()) > 0
+
+
+@pytest.mark.asyncio
+async def test_tool_markdown_default():
+    out = await attack_map_tool(agent=None, args={"findings": [SQLI], "target": "x"})
+    assert "MITRE ATT&CK" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_navigator_format():
+    out = await attack_map_tool(agent=None, args={"findings": [SQLI], "format": "navigator"})
+    layer = json.loads(out)
+    assert "techniques" in layer
+
+
+@pytest.mark.asyncio
+async def test_tool_no_input():
+    out = await attack_map_tool(agent=None, args={})
+    assert out.startswith("[attack_map]")
+
+
+@pytest.mark.asyncio
+async def test_tool_no_matches():
+    out = await attack_map_tool(agent=None, args={"findings": [{"title": "xyz", "severity": "Info"}]})
+    assert out.startswith("[attack_map]")
+
+
+@pytest.mark.asyncio
+async def test_tool_session_fallback():
+    class _F:
+        def model_dump(self):
+            return SQLI
+
+    class _S:
+        findings = [_F()]
+
+    class _A:
+        session_state = _S()
+
+    out = await attack_map_tool(agent=_A(), args={})
+    assert "MITRE ATT&CK" in out

--- a/tests/intel/test_compliance.py
+++ b/tests/intel/test_compliance.py
@@ -1,0 +1,106 @@
+import pytest
+
+from vulnclaw.intel.compliance import (
+    compliance_map_tool,
+    format_report,
+    list_frameworks,
+    map_findings,
+    normalize_frameworks,
+)
+
+SQLI = {
+    "title": "SQL Injection in login",
+    "severity": "Critical",
+    "description": "union select extracts data",
+    "evidence": "' OR 1=1 --",
+}
+WEAK_TLS = {
+    "title": "Weak TLS ciphers",
+    "severity": "Medium",
+    "description": "expired cert, weak encryption",
+}
+
+
+def test_normalize_frameworks_aliases_and_default():
+    assert normalize_frameworks(None) == ["pci", "nist", "owasp", "iso"]
+    assert normalize_frameworks(["OWASP Top 10"]) == ["owasp"]
+    assert set(normalize_frameworks(["pci-dss", "ISO 27001"])) == {"pci", "iso"}
+
+
+def test_list_frameworks_counts():
+    fws = {f["key"]: f["controls"] for f in list_frameworks()}
+    assert fws["owasp"] == 10
+    assert fws["pci"] > 0 and fws["nist"] > 0 and fws["iso"] > 0
+
+
+def test_map_sqli_hits_injection_controls():
+    report = map_findings([SQLI])
+    ids = {(m.control.framework, m.control.control_id) for m in report.mappings}
+    assert any(cid == "A03:2021" for _, cid in ids)
+    assert any(cid == "6.2.4" for _, cid in ids)
+    # Critical severity -> fail status
+    assert all(m.status == "fail" for m in report.mappings if m.control.control_id == "A03:2021")
+
+
+def test_framework_filter_limits_output():
+    report = map_findings([SQLI], frameworks=["owasp"])
+    assert report.mappings
+    assert all(m.control.framework.startswith("OWASP") for m in report.mappings)
+
+
+def test_dedup_same_control_same_finding_once():
+    report = map_findings([SQLI])
+    keys = [f"{m.control.framework}:{m.control.control_id}:{m.finding_title}" for m in report.mappings]
+    assert len(keys) == len(set(keys))
+
+
+def test_medium_severity_uses_default_status():
+    # network/firewall rule has default "warn"; weak TLS rule default "fail".
+    report = map_findings([WEAK_TLS], frameworks=["pci"])
+    tls = [m for m in report.mappings if m.control.control_id == "4.2.1"]
+    assert tls and tls[0].status == "fail"  # crypto rule default fail, medium keeps default
+
+
+def test_format_report_structure():
+    out = format_report(map_findings([SQLI], target="example.com"))
+    assert "# Compliance Mapping Report" in out
+    assert "example.com" in out
+    assert "## Executive Summary" in out
+    assert "## Gap Analysis" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_with_explicit_findings():
+    out = await compliance_map_tool(agent=None, args={"findings": [SQLI], "target": "t"})
+    assert "Compliance Mapping Report" in out
+    assert "A03:2021" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_no_findings_message():
+    out = await compliance_map_tool(agent=None, args={})
+    assert out.startswith("[compliance_map]") and "No findings" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_pulls_from_session_state():
+    class _Finding:
+        def model_dump(self):
+            return SQLI
+
+    class _Session:
+        findings = [_Finding()]
+
+    class _Agent:
+        session_state = _Session()
+
+    out = await compliance_map_tool(agent=_Agent(), args={})
+    assert "A03:2021" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_no_matching_mappings():
+    out = await compliance_map_tool(
+        agent=None, args={"findings": [{"title": "nothing relevant", "severity": "Info"}]}
+    )
+    assert "No control mappings" in out

--- a/tests/intel/test_constraints.py
+++ b/tests/intel/test_constraints.py
@@ -1,0 +1,22 @@
+from vulnclaw.agent.constraint_policy import infer_tool_action
+from vulnclaw.intel.tools import READ_ONLY_INTEL_TOOLS, RECON_INTEL_TOOLS
+
+
+def test_read_only_intel_tools_are_recon():
+    # Read-only intel tools must be classified as passive recon, never as an
+    # active scan/exploit action (the default fallback is "scan").
+    for tool in READ_ONLY_INTEL_TOOLS:
+        assert infer_tool_action(tool, {"query": "x"}) == "recon"
+
+
+def test_recon_intel_tools_are_recon():
+    for tool in RECON_INTEL_TOOLS:
+        assert infer_tool_action(tool, {"domain": "example.com"}) == "recon"
+
+
+def test_cve_lookup_specifically_is_recon():
+    assert infer_tool_action("cve_lookup", {"query": "openssl"}) == "recon"
+
+
+def test_osint_recon_specifically_is_recon():
+    assert infer_tool_action("osint_recon", {"domain": "example.com"}) == "recon"

--- a/tests/intel/test_cve.py
+++ b/tests/intel/test_cve.py
@@ -1,0 +1,146 @@
+import httpx
+import pytest
+
+from vulnclaw.intel import cve
+from vulnclaw.intel.cve import (
+    CVEEntry,
+    cve_lookup_tool,
+    format_cve_report,
+    lookup_cve_id,
+    search_cve,
+)
+
+# Minimal NVD 2.0 response shaped like the real API.
+NVD_SAMPLE = {
+    "vulnerabilities": [
+        {
+            "cve": {
+                "id": "CVE-2021-44228",
+                "descriptions": [
+                    {"lang": "en", "value": "Apache Log4j2 JNDI features allow RCE."}
+                ],
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "cvssData": {
+                                "baseScore": 10.0,
+                                "vectorString": "CVSS:3.1/AV:N/AC:L",
+                                "baseSeverity": "CRITICAL",
+                            },
+                            "baseSeverity": "CRITICAL",
+                        }
+                    ]
+                },
+                "published": "2021-12-10T00:00:00.000",
+                "lastModified": "2023-04-03T00:00:00.000",
+                "references": [{"url": "https://logging.apache.org/log4j/"}],
+                "weaknesses": [{"description": [{"value": "CWE-502"}]}],
+                "configurations": [
+                    {"nodes": [{"cpeMatch": [{"criteria": "cpe:2.3:a:apache:log4j:2.0"}]}]}
+                ],
+            }
+        }
+    ]
+}
+
+GITHUB_SAMPLE = {
+    "items": [
+        {
+            "full_name": "owner/log4shell-poc",
+            "html_url": "https://github.com/owner/log4shell-poc",
+            "description": "PoC",
+            "stargazers_count": 1234,
+            "language": "Java",
+        }
+    ]
+}
+
+
+def _mock_client() -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "services.nvd.nist.gov" in url:
+            return httpx.Response(200, json=NVD_SAMPLE)
+        if "api.github.com" in url:
+            return httpx.Response(200, json=GITHUB_SAMPLE)
+        return httpx.Response(404, json={})
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_parse_nvd_item_extracts_fields():
+    entry = cve._parse_nvd_item(NVD_SAMPLE["vulnerabilities"][0])
+    assert entry.cve_id == "CVE-2021-44228"
+    assert entry.cvss_score == 10.0
+    assert entry.severity_label == "Critical"
+    assert "CWE-502" in entry.weaknesses
+    assert entry.references and entry.cpe_matches
+
+
+@pytest.mark.asyncio
+async def test_search_cve_returns_sorted_entries():
+    async with _mock_client() as client:
+        results = await search_cve(
+            "log4j", max_results=5, client=client, rate_limit=False
+        )
+    assert len(results) == 1
+    assert isinstance(results[0], CVEEntry)
+    assert results[0].cve_id == "CVE-2021-44228"
+
+
+@pytest.mark.asyncio
+async def test_lookup_cve_id_attaches_exploits():
+    async with _mock_client() as client:
+        entry = await lookup_cve_id(
+            "CVE-2021-44228", client=client, rate_limit=False, with_exploits=True
+        )
+    assert entry is not None
+    assert entry.exploits and entry.exploits[0]["source"] == "GitHub"
+
+
+@pytest.mark.asyncio
+async def test_lookup_cve_id_rejects_malformed_id():
+    async with _mock_client() as client:
+        entry = await lookup_cve_id("not-a-cve", client=client, rate_limit=False)
+    assert entry is None
+
+
+def test_format_cve_report_renders_table_and_detail():
+    entry = cve._parse_nvd_item(NVD_SAMPLE["vulnerabilities"][0])
+    out = format_cve_report([entry], title="CVE search: log4j")
+    assert "CVE search: log4j" in out
+    assert "CVE-2021-44228" in out
+    assert "| CVE ID | CVSS | Severity |" in out
+
+
+def test_format_cve_report_empty():
+    assert "No CVEs found" in format_cve_report([], title="x")
+
+
+@pytest.mark.asyncio
+async def test_tool_empty_query_is_structured_error():
+    out = await cve_lookup_tool(agent=None, args={"query": "  "})
+    assert out.startswith("[cve_lookup]") and "query" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_routes_cve_id_vs_keyword(monkeypatch):
+    calls = {}
+
+    async def fake_lookup(cve_id, **kw):
+        calls["id"] = cve_id
+        return cve._parse_nvd_item(NVD_SAMPLE["vulnerabilities"][0])
+
+    async def fake_search(keyword, **kw):
+        calls["kw"] = keyword
+        return [cve._parse_nvd_item(NVD_SAMPLE["vulnerabilities"][0])]
+
+    monkeypatch.setattr(cve, "lookup_cve_id", fake_lookup)
+    monkeypatch.setattr(cve, "search_cve", fake_search)
+
+    out_id = await cve_lookup_tool(agent=None, args={"query": "CVE-2021-44228"})
+    out_kw = await cve_lookup_tool(agent=None, args={"query": "log4j"})
+
+    assert calls.get("id") == "CVE-2021-44228"
+    assert calls.get("kw") == "log4j"
+    assert "CVE-2021-44228" in out_id and "CVE-2021-44228" in out_kw

--- a/tests/intel/test_findings.py
+++ b/tests/intel/test_findings.py
@@ -1,0 +1,133 @@
+import pytest
+
+from vulnclaw.intel.findings import (
+    SEVERITY_WEIGHTS,
+    annotate_compliance,
+    diff_assessments,
+    finding_risk,
+    findings_diff_tool,
+    findings_report_tool,
+    format_diff,
+    format_risk_report,
+    score_findings,
+)
+
+SQLI = {"title": "SQL Injection in login", "severity": "Critical", "description": "union select"}
+XSS = {"title": "Reflected XSS in search", "severity": "Medium", "description": "xss payload"}
+INFO = {"title": "Server banner", "severity": "Info"}
+REJECTED = {"title": "False positive", "severity": "High", "lifecycle_status": "rejected"}
+
+
+def test_finding_risk_uses_severity_weight():
+    assert finding_risk(SQLI) == SEVERITY_WEIGHTS["critical"]
+    assert finding_risk(INFO) == SEVERITY_WEIGHTS["info"]
+
+
+def test_finding_risk_prefers_cvss():
+    assert finding_risk({"severity": "Low", "cvss_score": 9.1}) == 9.1
+    assert finding_risk({"severity": "High", "cvss_score": 0}) == SEVERITY_WEIGHTS["high"]
+
+
+def test_score_findings_counts_and_total():
+    score = score_findings([SQLI, XSS, INFO, REJECTED])  # rejected excluded by default
+    assert score.open_count == 3
+    assert score.counts["Critical"] == 1
+    assert score.counts["Medium"] == 1
+    assert score.counts["Info"] == 1
+    assert score.counts["High"] == 0  # rejected High not counted
+    assert score.total == round(10.0 + 5.0 + 0.5, 1)
+    assert score.band == "Critical"
+
+
+def test_score_findings_open_only_false_includes_rejected():
+    score = score_findings([SQLI, REJECTED], open_only=False)
+    assert score.open_count == 2
+    assert score.counts["High"] == 1
+
+
+def test_annotate_compliance_attaches_controls():
+    annotated = annotate_compliance(SQLI)
+    assert "compliance" in annotated
+    ids = {c["control_id"] for c in annotated["compliance"]}
+    assert "A03:2021" in ids
+    # original not mutated
+    assert "compliance" not in SQLI
+
+
+def test_diff_new_fixed_persistent():
+    old = {"findings": [SQLI, XSS], "target": "example.com"}
+    # XSS persists (same title), SQLI fixed, a new RCE appears
+    new = {
+        "findings": [
+            {"title": "Reflected XSS in search", "severity": "Medium"},
+            {"title": "RCE via upload", "severity": "Critical"},
+        ],
+        "target": "example.com",
+    }
+    report = diff_assessments(old, new)
+    assert report.target == "example.com"
+    assert {e.title for e in report.new} == {"RCE via upload"}
+    assert {e.title for e in report.fixed} == {"SQL Injection in login"}
+    assert {e.title for e in report.persistent} == {"Reflected XSS in search"}
+
+
+def test_diff_detects_severity_regression():
+    old = [{"title": "Weak TLS", "severity": "Low"}]
+    new = [{"title": "Weak TLS", "severity": "High"}]
+    report = diff_assessments(old, new)
+    assert len(report.persistent) == 1
+    assert report.persistent[0].old_severity == "Low"
+    assert len(report.regressions) == 1
+
+
+def test_diff_accepts_raw_lists():
+    report = diff_assessments([], [SQLI])
+    assert len(report.new) == 1
+
+
+def test_format_risk_report_with_compliance():
+    findings = [SQLI, XSS]
+    out = format_risk_report(findings, score_findings(findings), with_compliance=True)
+    assert "# Findings Risk Summary" in out
+    assert "Top Risks" in out
+    assert "Compliance Control Coverage" in out
+
+
+def test_format_diff_sections():
+    report = diff_assessments([XSS], [SQLI])
+    out = format_diff(report)
+    assert "Assessment Diff" in out
+    assert "+1 new" in out
+    assert "-1 fixed" in out
+
+
+@pytest.mark.asyncio
+async def test_report_tool_session_fallback():
+    class _F:
+        def model_dump(self):
+            return SQLI
+
+    class _S:
+        findings = [_F()]
+
+    class _A:
+        session_state = _S()
+
+    out = await findings_report_tool(agent=_A(), args={})
+    assert "Findings Risk Summary" in out
+    assert "SQL Injection" in out
+
+
+@pytest.mark.asyncio
+async def test_report_tool_no_findings():
+    out = await findings_report_tool(agent=None, args={})
+    assert out.startswith("[findings_report]")
+
+
+@pytest.mark.asyncio
+async def test_diff_tool_explicit_arrays():
+    out = await findings_diff_tool(
+        agent=None, args={"baseline": [XSS], "current": [SQLI], "target": "t"}
+    )
+    assert "Assessment Diff: t" in out
+    assert "+1 new" in out

--- a/tests/intel/test_osint.py
+++ b/tests/intel/test_osint.py
@@ -1,0 +1,219 @@
+import socket
+
+import httpx
+import pytest
+
+from vulnclaw.intel import osint
+from vulnclaw.intel.osint import (
+    DNSRecord,
+    OSINTReport,
+    SubdomainResult,
+    WHOISResult,
+    clean_domain,
+    crtsh_subdomains,
+    enumerate_subdomains,
+    fingerprint_tech,
+    format_report,
+    get_dns_records,
+    is_valid_subdomain,
+    normalize_url,
+    osint_recon_tool,
+    rdap_whois,
+)
+
+CRTSH_SAMPLE = [
+    {"name_value": "www.example.com\nadmin.example.com"},
+    {"name_value": "*.example.com"},
+    {"name_value": "mail.example.com"},
+]
+
+RDAP_SAMPLE = {
+    "entities": [
+        {
+            "roles": ["registrar"],
+            "vcardArray": ["vcard", [["version", {}, "text", "4.0"], ["fn", {}, "text", "Example Registrar Inc"]]],
+        }
+    ],
+    "events": [
+        {"eventAction": "registration", "eventDate": "1995-08-14T04:00:00Z"},
+        {"eventAction": "expiration", "eventDate": "2026-08-13T04:00:00Z"},
+    ],
+    "nameservers": [{"ldhName": "a.iana-servers.net"}, {"ldhName": "b.iana-servers.net"}],
+    "status": ["client delete prohibited"],
+}
+
+TECH_HTML = (
+    "<html><head>"
+    '<meta name="generator" content="WordPress 6.4">'
+    '<script src="/wp-includes/js/jquery.js"></script>'
+    "</head><body>wp-content theme</body></html>"
+)
+
+
+# ── pure helpers ─────────────────────────────────────────────────────────────
+
+
+def test_clean_domain_strips_scheme_path_port_www():
+    assert clean_domain("https://www.Example.com:443/path?x=1") == "example.com"
+
+
+def test_normalize_url_adds_scheme():
+    assert normalize_url("example.com") == "https://example.com"
+    assert normalize_url("http://x.io") == "http://x.io"
+
+
+def test_is_valid_subdomain():
+    assert is_valid_subdomain("a.example.com")
+    assert not is_valid_subdomain("bad_underscore.example.com")
+    assert not is_valid_subdomain("")
+
+
+# ── HTTP features via MockTransport ──────────────────────────────────────────
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_crtsh_subdomains_parses_ct_log():
+    def handler(req):
+        assert "crt.sh" in str(req.url)
+        return httpx.Response(200, json=CRTSH_SAMPLE)
+
+    async with _client(handler) as c:
+        subs = await crtsh_subdomains("example.com", client=c)
+    assert subs == {"www.example.com", "admin.example.com", "mail.example.com", "example.com"}
+
+
+@pytest.mark.asyncio
+async def test_enumerate_subdomains_no_resolve():
+    def handler(req):
+        return httpx.Response(200, json=CRTSH_SAMPLE)
+
+    async with _client(handler) as c:
+        results = await enumerate_subdomains("example.com", resolve=False, client=c)
+    names = [r.subdomain for r in results]
+    assert names == sorted(names)
+    assert "www.example.com" in names
+    assert all(isinstance(r, SubdomainResult) for r in results)
+
+
+@pytest.mark.asyncio
+async def test_rdap_whois_parses_fields():
+    def handler(req):
+        assert "rdap.org" in str(req.url)
+        return httpx.Response(200, json=RDAP_SAMPLE)
+
+    async with _client(handler) as c:
+        w = await rdap_whois("example.com", client=c)
+    assert isinstance(w, WHOISResult)
+    assert w.registrar == "Example Registrar Inc"
+    assert w.creation_date == "1995-08-14"
+    assert w.expiration_date == "2026-08-13"
+    assert "a.iana-servers.net" in w.name_servers
+
+
+@pytest.mark.asyncio
+async def test_rdap_whois_returns_none_on_404():
+    async with _client(lambda req: httpx.Response(404, json={})) as c:
+        assert await rdap_whois("nope.example", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_tech_detects_stack():
+    def handler(req):
+        return httpx.Response(
+            200,
+            headers={
+                "Server": "nginx/1.18.0",
+                "X-Powered-By": "PHP/8.1",
+                "Set-Cookie": "PHPSESSID=abc123; Path=/",
+            },
+            text=TECH_HTML,
+        )
+
+    async with _client(handler) as c:
+        result = await fingerprint_tech("example.com", client=c, check_ssl=False)
+
+    names = {t["name"] for t in result.technologies}
+    assert "Nginx" in names
+    assert "PHP" in names  # from header and/or cookie
+    assert "WordPress" in names  # from html "wp-content"
+    assert result.server.startswith("nginx")
+    assert "PHPSESSID" in result.cookies
+    assert any("jquery" in s for s in result.scripts)
+    assert "WordPress 6.4" in result.frameworks
+
+
+# ── DNS fallback ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_dns_records_socket_fallback(monkeypatch):
+    monkeypatch.setattr(osint, "_dnspython_records", lambda d, t: None)
+
+    def fake_getaddrinfo(host, port):
+        return [(socket.AF_INET, None, None, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    records = await get_dns_records("example.com")
+    assert any(r.record_type == "A" and r.value == "93.184.216.34" for r in records)
+
+
+# ── formatting ───────────────────────────────────────────────────────────────
+
+
+def test_format_report_sections():
+    report = OSINTReport(
+        domain="example.com",
+        subdomains=[SubdomainResult(subdomain="www.example.com", ip="1.2.3.4", source="crt.sh")],
+        dns_records=[DNSRecord(record_type="A", value="1.2.3.4", ttl=300)],
+        whois=WHOISResult(domain="example.com", registrar="Example Registrar Inc"),
+        emails=["info@example.com"],
+    )
+    out = format_report(report)
+    assert "# OSINT Report: example.com" in out
+    assert "## Subdomains" in out
+    assert "## DNS Records" in out
+    assert "Example Registrar Inc" in out
+    assert "info@example.com" in out
+
+
+# ── tool ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tool_rejects_invalid_domain():
+    out = await osint_recon_tool(agent=None, args={"domain": "not a domain"})
+    assert out.startswith("[osint_recon]") and "domain" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_orchestrates_without_network(monkeypatch):
+    async def fake_subs(domain, **kw):
+        return [SubdomainResult(subdomain="www.example.com", ip="1.2.3.4", source="crt.sh")]
+
+    async def fake_dns(domain, **kw):
+        return [DNSRecord(record_type="A", value="1.2.3.4", ttl=300)]
+
+    async def fake_whois(domain, **kw):
+        return WHOISResult(domain="example.com", registrar="Example Registrar Inc")
+
+    async def fake_tech(domain, **kw):
+        return osint.TechStackResult(url="https://example.com", server="nginx")
+
+    async def fake_emails(domain, **kw):
+        return ["info@example.com"]
+
+    monkeypatch.setattr(osint, "enumerate_subdomains", fake_subs)
+    monkeypatch.setattr(osint, "get_dns_records", fake_dns)
+    monkeypatch.setattr(osint, "whois_lookup", fake_whois)
+    monkeypatch.setattr(osint, "fingerprint_tech", fake_tech)
+    monkeypatch.setattr(osint, "common_emails", fake_emails)
+
+    out = await osint_recon_tool(agent=None, args={"domain": "example.com"})
+    assert "# OSINT Report: example.com" in out
+    assert "www.example.com" in out
+    assert "Example Registrar Inc" in out
+    assert "info@example.com" in out

--- a/tests/intel/test_remediation.py
+++ b/tests/intel/test_remediation.py
@@ -1,0 +1,73 @@
+import pytest
+
+from vulnclaw.intel.remediation import (
+    RemediationEngine,
+    RemediationType,
+    remediation_advice_tool,
+)
+
+SQLI = {"title": "SQL Injection in login", "severity": "Critical", "description": "union select"}
+
+
+def test_engine_has_rules():
+    assert RemediationEngine.get_rule_count() >= 15
+
+
+def test_remediate_sqli_returns_steps():
+    eng = RemediationEngine()
+    rem = eng.remediate_finding(SQLI)
+    assert rem.steps
+    assert rem.source != "generic"  # matched a real rule
+    assert "param" in rem.summary.lower() or "sql" in rem.summary.lower()
+    # has at least one code or config step
+    assert any(s.type in (RemediationType.CODE, RemediationType.CONFIG, RemediationType.COMMAND) for s in rem.steps)
+
+
+def test_generic_fallback_for_unknown():
+    eng = RemediationEngine()
+    rem = eng.remediate_finding({"title": "totally unknown weirdness", "severity": "Low"})
+    assert rem.source == "generic"
+    assert rem.steps  # generic still offers guidance
+
+
+def test_summary_markdown():
+    eng = RemediationEngine()
+    rems = eng.remediate_findings([SQLI])
+    md = RemediationEngine.get_summary_markdown(rems)
+    assert "Remediation Report" in md
+    assert "Priority Summary" in md
+
+
+@pytest.mark.asyncio
+async def test_tool_with_query():
+    out = await remediation_advice_tool(agent=None, args={"query": "cross-site scripting", "severity": "High"})
+    assert "Remediation Report" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_with_findings():
+    out = await remediation_advice_tool(agent=None, args={"findings": [SQLI]})
+    assert "Remediation Report" in out
+    assert "##" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_no_input():
+    out = await remediation_advice_tool(agent=None, args={})
+    assert out.startswith("[remediation_advice]")
+
+
+@pytest.mark.asyncio
+async def test_tool_session_fallback():
+    class _F:
+        def model_dump(self):
+            return SQLI
+
+    class _S:
+        findings = [_F()]
+
+    class _A:
+        session_state = _S()
+
+    out = await remediation_advice_tool(agent=_A(), args={})
+    assert "Remediation Report" in out

--- a/tests/intel/test_tool_plumbing.py
+++ b/tests/intel/test_tool_plumbing.py
@@ -1,0 +1,30 @@
+import pytest
+
+from vulnclaw.intel import tools as intel_tools
+from vulnclaw.intel.tools import INTEL_TOOL_NAMES, dispatch_intel_tool, intel_tool_schemas
+
+
+def test_schemas_expose_cve_lookup():
+    names = {s["function"]["name"] for s in intel_tool_schemas()}
+    assert "cve_lookup" in names
+
+
+def test_intel_tool_names_match_schemas():
+    schema_names = {s["function"]["name"] for s in intel_tool_schemas()}
+    assert schema_names == set(INTEL_TOOL_NAMES)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_tool_returns_structured_error():
+    out = await dispatch_intel_tool(agent=None, tool_name="nope", args={})
+    assert "[intel_error]" in out
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_to_registered_handler(monkeypatch):
+    async def fake(agent, args):
+        return "ROUTED:" + args["query"]
+
+    monkeypatch.setitem(intel_tools._HANDLERS, "cve_lookup", fake)
+    out = await dispatch_intel_tool(agent=None, tool_name="cve_lookup", args={"query": "x"})
+    assert out == "ROUTED:x"

--- a/tests/intel/test_topology.py
+++ b/tests/intel/test_topology.py
@@ -1,0 +1,148 @@
+import json
+
+import pytest
+
+from vulnclaw.intel import topology
+from vulnclaw.intel.topology import (
+    auto_parse,
+    format_markdown,
+    parse_masscan_output,
+    parse_nmap_text,
+    parse_nmap_xml,
+    render_ascii,
+    topology_build_tool,
+)
+
+MASSCAN = """Discovered open port 80/tcp on 192.168.1.10
+Discovered open port 443/tcp on 192.168.1.10
+Discovered open port 22/tcp on 192.168.1.20
+"""
+
+NMAP_TEXT = """Starting Nmap 7.94
+Nmap scan report for web.example.com (192.168.1.10)
+Host is up (0.012s latency).
+PORT     STATE SERVICE  VERSION
+80/tcp   open  http     nginx 1.18.0
+443/tcp  open  ssl/http nginx 1.18.0
+OS details: Linux 5.4
+MAC Address: AA:BB:CC:DD:EE:FF
+"""
+
+NMAP_XML = """<?xml version="1.0"?>
+<nmaprun scanner="nmap" args="nmap -oX - 10.0.0.5" startstr="Mon">
+  <host>
+    <status state="up"/>
+    <address addr="10.0.0.5" addrtype="ipv4"/>
+    <hostnames><hostname name="db.internal"/></hostnames>
+    <ports>
+      <port protocol="tcp" portid="3306">
+        <state state="open"/>
+        <service name="mysql" product="MySQL" version="8.0.32"/>
+      </port>
+      <port protocol="tcp" portid="22">
+        <state state="closed"/>
+        <service name="ssh"/>
+      </port>
+    </ports>
+    <os><osmatch name="Linux 5.x"/></os>
+  </host>
+</nmaprun>
+"""
+
+
+def test_get_subnet():
+    assert topology._get_subnet("192.168.1.10") == "192.168.1.0/24"
+    assert topology._get_subnet("not-an-ip") == ""
+
+
+def test_parse_masscan():
+    topo = parse_masscan_output(MASSCAN)
+    hosts = [n for n in topo.nodes if n.node_type == "host"]
+    assert {h.ip for h in hosts} == {"192.168.1.10", "192.168.1.20"}
+    h10 = next(h for h in hosts if h.ip == "192.168.1.10")
+    assert len(h10.ports) == 2
+    # subnet node + scanner->subnet edge exist
+    assert any(n.node_type == "subnet" for n in topo.nodes)
+
+
+def test_parse_nmap_text():
+    topo = parse_nmap_text(NMAP_TEXT)
+    hosts = [n for n in topo.nodes if n.node_type == "host"]
+    assert len(hosts) == 1
+    h = hosts[0]
+    assert h.ip == "192.168.1.10"
+    assert h.hostname == "web.example.com"
+    assert h.os == "Linux 5.4"
+    assert h.mac == "AA:BB:CC:DD:EE:FF"
+    assert {p["port"] for p in h.ports} == {80, 443}
+
+
+def test_parse_nmap_xml():
+    topo = parse_nmap_xml(NMAP_XML)
+    hosts = [n for n in topo.nodes if n.node_type == "host"]
+    assert len(hosts) == 1
+    h = hosts[0]
+    assert h.ip == "10.0.0.5"
+    assert h.hostname == "db.internal"
+    assert h.os == "Linux 5.x"
+    # only the open port (3306) is kept, closed 22 dropped
+    assert [p["port"] for p in h.ports] == [3306]
+    assert h.ports[0]["product"] == "MySQL"
+
+
+def test_parse_nmap_xml_malformed_falls_back_to_text():
+    # Looks like XML but is broken -> falls back to text parsing (no hosts here).
+    topo = parse_nmap_xml("<?xml broken <<<")
+    assert [n for n in topo.nodes if n.node_type == "host"] == []
+
+
+def test_auto_parse_detects_formats():
+    assert any(
+        n.node_type == "host" for n in auto_parse(NMAP_XML).nodes
+    )
+    assert any(n.node_type == "host" for n in auto_parse(MASSCAN).nodes)
+    assert any(n.node_type == "host" for n in auto_parse(NMAP_TEXT).nodes)
+
+
+def test_format_markdown_and_ascii():
+    topo = parse_nmap_text(NMAP_TEXT)
+    md = format_markdown(topo)
+    assert "## Network Topology" in md
+    assert "192.168.1.10" in md
+    assert "nginx" in md
+    ascii_out = render_ascii(topo)
+    assert "NETWORK TOPOLOGY MAP" in ascii_out
+    assert "192.168.1.10" in ascii_out
+
+
+def test_to_dict_stats():
+    stats = parse_nmap_text(NMAP_TEXT).to_dict()["stats"]
+    assert stats["total_hosts"] == 1
+    assert stats["total_services"] == 2
+    assert stats["subnets"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_empty_input_error():
+    out = await topology_build_tool(agent=None, args={"scan_output": "  "})
+    assert out.startswith("[topology_build]")
+
+
+@pytest.mark.asyncio
+async def test_tool_markdown_default():
+    out = await topology_build_tool(agent=None, args={"scan_output": MASSCAN})
+    assert "## Network Topology" in out
+    assert "192.168.1.10" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_json_format_is_valid():
+    out = await topology_build_tool(agent=None, args={"scan_output": NMAP_XML, "format": "json"})
+    data = json.loads(out)
+    assert "nodes" in data and "edges" in data and data["stats"]["total_hosts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_no_hosts_message():
+    out = await topology_build_tool(agent=None, args={"scan_output": "nothing useful here"})
+    assert "No hosts parsed" in out

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -768,6 +768,15 @@ class TestAgentCore:
         assert context is not None
         assert "逆向" in context or "reverse" in context.lower()
 
+    def test_skill_context_explicit_slash_skill_selector(self):
+        agent = self._make_agent()
+        context = agent._get_active_skill_context(
+            user_input="Use VulnClaw skill secknowledge-skill. test this target"
+        )
+        assert context is not None
+        assert "SRC" in context
+        assert "GAARM" in context
+
     def test_build_openai_tools_includes_skill_ref(self):
         """Tools should include load_skill_reference."""
         agent = self._make_agent()

--- a/tests/test_agent_context_protocol.py
+++ b/tests/test_agent_context_protocol.py
@@ -1,0 +1,29 @@
+"""The production agent must satisfy the AgentContext seam its helpers rely on.
+
+Helper modules annotate their handle as ``agent: AgentContext``. This test is
+the drift guard for that contract: whenever a helper starts reaching for a new
+member — or ``AgentCore`` drops one — the surface and the real object part ways,
+and this fails.
+
+Only the real ``AgentCore`` is required to conform. Focused test doubles
+elsewhere in the suite are intentionally partial and are *not* checked here;
+requiring them to implement the whole surface would defeat the point of a
+narrow double.
+"""
+
+from __future__ import annotations
+
+from vulnclaw.agent.agent_context import AgentContext
+from vulnclaw.agent.core import AgentCore
+from vulnclaw.config.schema import VulnClawConfig
+
+
+def test_agent_core_satisfies_agent_context() -> None:
+    agent = AgentCore(VulnClawConfig())
+    assert isinstance(agent, AgentContext)
+
+
+def test_agent_context_is_not_vacuous() -> None:
+    # A bare object lacks the surface, so the protocol is a real constraint —
+    # guards against the check silently degrading to "everything conforms".
+    assert not isinstance(object(), AgentContext)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -320,6 +320,66 @@ class TestCLI:
         assert result.exit_code == 0
         assert called == [("run", "https://example.com")]
 
+    def test_run_generates_report_after_completion(self, runner, monkeypatch):
+        import vulnclaw.cli.main as cli_main
+        from vulnclaw.cli.main import app
+        from vulnclaw.config.schema import VulnClawConfig
+
+        config = VulnClawConfig()
+        config.llm.api_key = "test-key"
+        monkeypatch.setattr(cli_main, "load_config", lambda: config)
+
+        async def fake_orchestrated(*, command, target, resume, snapshot, runner):
+            return type("RunResult", (), {"summary": {"findings_count": 2}})()
+
+        monkeypatch.setattr(cli_main, "_run_cli_orchestrated_task", fake_orchestrated)
+
+        report_calls = []
+
+        def fake_generate_report(target, **kwargs):
+            report_calls.append((target, kwargs))
+            return "/tmp/vulnclaw-output/report.md"
+
+        monkeypatch.setattr(cli_main, "_generate_report_for_target", fake_generate_report)
+
+        result = runner.invoke(app, ["run", "https://example.com"])
+
+        assert result.exit_code == 0
+        assert report_calls == [("https://example.com", {"output_path": None})]
+        assert "report.md" in result.output
+
+    def test_run_passes_output_flag_to_report_generation(self, runner, monkeypatch):
+        import vulnclaw.cli.main as cli_main
+        from vulnclaw.cli.main import app
+        from vulnclaw.config.schema import VulnClawConfig
+
+        config = VulnClawConfig()
+        config.llm.api_key = "test-key"
+        monkeypatch.setattr(cli_main, "load_config", lambda: config)
+
+        async def fake_orchestrated(*, command, target, resume, snapshot, runner):
+            return type("RunResult", (), {"summary": {"findings_count": 0}})()
+
+        monkeypatch.setattr(cli_main, "_run_cli_orchestrated_task", fake_orchestrated)
+
+        report_calls = []
+
+        def fake_generate_report(target, **kwargs):
+            report_calls.append((target, kwargs))
+            return "/custom/path/report.md"
+
+        monkeypatch.setattr(cli_main, "_generate_report_for_target", fake_generate_report)
+
+        result = runner.invoke(
+            app, ["run", "https://example.com", "--output", "/custom/path/report.md"]
+        )
+
+        assert result.exit_code == 0
+        assert report_calls == [
+            ("https://example.com", {"output_path": "/custom/path/report.md"})
+        ]
+        assert "/custom/path/report.md" in result.output
+
     def test_run_cli_constraints_are_appended_to_prompt(self, runner, monkeypatch):
         import vulnclaw.cli.main as cli_main
         from vulnclaw.cli.main import app

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -963,6 +963,34 @@ class TestClassicReplSlashPalette:
         assert "reporting" in names
         assert all(name.startswith("re") for name in names)
 
+    def test_skill_description_localizes_by_language(self):
+        import vulnclaw.cli.tui as tui_mod
+        from vulnclaw.i18n import init_i18n
+
+        skill = {"name": "recon", "description": "信息收集流程 — 被动+主动侦察"}
+        try:
+            init_i18n(lang="en")
+            english = tui_mod.skill_display_description(skill)
+            init_i18n(lang="zh")
+            chinese = tui_mod.skill_display_description(skill)
+        finally:
+            init_i18n()  # restore auto-detected default
+
+        # English catalog override applies; zh falls back to the frontmatter.
+        assert english == "Reconnaissance workflow — passive and active recon"
+        assert chinese == "信息收集流程 — 被动+主动侦察"
+
+    def test_skill_description_falls_back_when_untranslated(self):
+        import vulnclaw.cli.tui as tui_mod
+        from vulnclaw.i18n import init_i18n
+
+        skill = {"name": "no-such-skill", "description": "raw frontmatter"}
+        try:
+            init_i18n(lang="en")
+            assert tui_mod.skill_display_description(skill) == "raw frontmatter"
+        finally:
+            init_i18n()
+
     def test_bare_slash_prompts_for_a_skill_name(self):
         from vulnclaw.cli.tui import dispatch_repl_slash
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -788,6 +788,39 @@ class TestCLI:
         assert "--allow-actions recon,scan" in draft.command_line
         assert "--block-actions exploit,post_exploitation" in draft.command_line
 
+    def test_tui_slash_dot_flag_applies_scope_state(self):
+        import vulnclaw.cli.tui as tui_mod
+
+        session = {"state": tui_mod.TuiState(), "_message": "", "_prompt": None}
+
+        tui_mod._dispatch_slash("/.only-port 443", session)
+        tui_mod._dispatch_slash("/.allow-actions recon,scan", session)
+        tui_mod._dispatch_slash("/.no-resume", session)
+
+        assert session["state"].only_port == "443"
+        assert session["state"].allow_actions == ["recon", "scan"]
+        assert session["state"].resume is False
+
+    def test_tui_slash_dot_flag_without_value_shows_skill_help(self):
+        import vulnclaw.cli.tui as tui_mod
+
+        session = {"state": tui_mod.TuiState(), "_message": "", "_prompt": None}
+
+        tui_mod._dispatch_slash("/.only-port", session)
+
+        assert session["_prompt"][0] == "message"
+        assert "--only-port" in session["_prompt"][1]
+
+    def test_textual_slash_dot_flag_dispatch_applies_state(self):
+        import vulnclaw.cli.tui as tui_mod
+        import vulnclaw.cli.tui_textual as textual_mod
+
+        session = {"state": tui_mod.TuiState(), "_message": "", "_prompt": None}
+
+        textual_mod._dispatch(session, "/.only-host example.com")
+
+        assert session["state"].only_host == "example.com"
+
     def test_tui_runtime_diagnostic_panel_renders_environment_summary(self, monkeypatch):
         import vulnclaw.cli.tui as tui_mod
         from vulnclaw.config.schema import VulnClawConfig

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -821,6 +821,41 @@ class TestCLI:
 
         assert session["state"].only_host == "example.com"
 
+    def test_tui_slash_palette_includes_available_skills(self):
+        import vulnclaw.cli.tui as tui_mod
+
+        entries = dict(tui_mod.build_slash_palette_entries())
+
+        assert "ctf-web" in entries
+        assert "secknowledge-skill" in entries
+        assert "target" in entries
+        assert "Skill" in entries["ctf-web"]
+
+    def test_tui_skill_slash_without_args_shows_skill_help(self):
+        import vulnclaw.cli.tui as tui_mod
+
+        session = {"state": tui_mod.TuiState(), "_message": "", "_prompt": None}
+
+        tui_mod._dispatch_slash("/ctf-web", session)
+
+        assert session["_prompt"][0] == "message"
+        assert "/ctf-web skill" in session["_prompt"][1]
+
+    def test_textual_skill_slash_with_args_launches_skill_prompt(self):
+        import vulnclaw.cli.tui as tui_mod
+        import vulnclaw.cli.tui_textual as textual_mod
+
+        session = {
+            "state": tui_mod.TuiState(target="https://example.com"),
+            "_message": "",
+            "_prompt": None,
+        }
+
+        result = textual_mod._dispatch(session, "/ctf-web find the flag")
+
+        assert result == "launch"
+        assert session["_nl_text"] == "Use VulnClaw skill ctf-web. find the flag"
+
     def test_tui_runtime_diagnostic_panel_renders_environment_summary(self, monkeypatch):
         import vulnclaw.cli.tui as tui_mod
         from vulnclaw.config.schema import VulnClawConfig
@@ -903,6 +938,123 @@ class TestCLI:
         assert saved and saved[0] is updated
         assert "模型/API 配置已保存" in output
         assert "API Key: 已更新" in output
+
+
+class TestClassicReplSlashPalette:
+    """Classic `vulnclaw` REPL: '/' skill palette and '/.' flag-skill wiring."""
+
+    def test_skill_entries_are_skills_only(self):
+        import vulnclaw.cli.tui as tui_mod
+
+        entries = dict(tui_mod.list_skill_palette_entries())
+
+        assert "ctf-web" in entries
+        assert "recon" in entries
+        # Textual-only slash commands must not leak into the classic REPL menu.
+        assert "target" not in entries
+        assert "mode" not in entries
+
+    def test_skill_entries_filter_by_prefix(self):
+        import vulnclaw.cli.tui as tui_mod
+
+        names = {name for name, _ in tui_mod.list_skill_palette_entries("re")}
+
+        assert "recon" in names
+        assert "reporting" in names
+        assert all(name.startswith("re") for name in names)
+
+    def test_bare_slash_prompts_for_a_skill_name(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/")
+
+        assert result.kind == "message"
+        assert "skill name" in result.text
+
+    def test_unknown_skill_reports_error(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/not-a-real-skill")
+
+        assert result.kind == "message"
+        assert "Unknown skill" in result.text
+
+    def test_skill_without_task_shows_help(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/recon")
+
+        assert result.kind == "message"
+        assert "recon" in result.text
+
+    def test_skill_with_task_rewrites_to_agent_prompt(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/recon scan the box")
+
+        assert result.kind == "run"
+        assert result.text == "Use VulnClaw skill recon. scan the box"
+
+    def test_flag_target_sets_target(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/.target example.com")
+
+        assert result.kind == "target"
+        assert result.value == "example.com"
+
+    def test_flag_target_without_value_asks_for_host(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/.target")
+
+        assert result.kind == "message"
+        assert "host value" in result.text
+
+    def test_non_target_flag_is_guidance_only(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        # B1 wiring: mode/scope flags render guidance, they do not mutate state.
+        result = dispatch_repl_slash("/.mode")
+
+        assert result.kind == "message"
+        assert "/.mode" in result.text
+
+    def test_unknown_flag_skill_reports_error(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/.zzz-not-a-flag")
+
+        assert result.kind == "message"
+        assert "Unknown flag skill" in result.text
+
+    def test_completer_offers_all_skills_on_bare_slash(self):
+        from prompt_toolkit.document import Document
+
+        from vulnclaw.cli.tui import build_repl_slash_completer, list_skill_palette_entries
+
+        completer = build_repl_slash_completer()
+        completions = list(completer.get_completions(Document("/", 1), None))
+
+        assert len(completions) == len(list_skill_palette_entries())
+
+    def test_completer_stops_after_skill_is_chosen(self):
+        from prompt_toolkit.document import Document
+
+        from vulnclaw.cli.tui import build_repl_slash_completer
+
+        completer = build_repl_slash_completer()
+        text = "/recon scan"
+        completions = list(completer.get_completions(Document(text, len(text)), None))
+
+        assert completions == []
+
+    def test_prompt_session_is_none_without_a_tty(self, monkeypatch):
+        import vulnclaw.cli.main as main_mod
+
+        monkeypatch.setattr(main_mod.sys.stdin, "isatty", lambda: False)
+
+        assert main_mod._make_repl_prompt_session() is None
 
 
 class TestCLISubCommands:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,8 +28,50 @@ class TestCLI:
         from vulnclaw.cli.main import app
 
         result = runner.invoke(app, ["--version"])
-        # Typer may return exit code 0 or 2 depending on version
-        assert __version__ in result.output or result.exit_code in (0, 2)
+        assert result.exit_code == 0
+        assert __version__ in result.output
+
+    def test_cli_manual_command(self, runner):
+        from vulnclaw.cli.main import app
+
+        result = runner.invoke(app, ["manual"])
+
+        assert result.exit_code == 0
+        assert "VULNCLAW(1)" in result.output
+        assert "COMMON TASK FLAGS" in result.output
+        assert "--only-port" in result.output
+        assert "network-scan" in result.output
+        assert "--parallel-agents" in result.output
+
+    def test_cli_manual_topic_markdown(self, runner):
+        from vulnclaw.cli.main import app
+
+        result = runner.invoke(app, ["manual", "network-scan", "--format", "markdown"])
+
+        assert result.exit_code == 0
+        assert "### `network-scan`" in result.output
+        assert "`--safe-probes / --no-safe-probes`" in result.output
+        assert "### `run`" not in result.output
+
+    def test_cli_man_alias_and_root_flag(self, runner):
+        from vulnclaw.cli.main import app
+
+        alias_result = runner.invoke(app, ["man", "config"])
+        root_result = runner.invoke(app, ["--man"])
+
+        assert alias_result.exit_code == 0
+        assert "CONFIG" in alias_result.output
+        assert "llm.api_keys" in alias_result.output
+        assert root_result.exit_code == 0
+        assert "VULNCLAW(1)" in root_result.output
+
+    def test_cli_manual_rejects_unknown_topic(self, runner):
+        from vulnclaw.cli.main import app
+
+        result = runner.invoke(app, ["manual", "does-not-exist"])
+
+        assert result.exit_code == 1
+        assert "unknown manual topic" in result.output
 
     def test_cli_init(self, runner):
         from vulnclaw.cli.main import app

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1028,15 +1028,17 @@ class TestClassicReplSlashPalette:
         assert result.kind == "message"
         assert "Unknown flag skill" in result.text
 
-    def test_completer_offers_all_skills_on_bare_slash(self):
+    def test_completer_offers_commands_and_skills_on_bare_slash(self):
         from prompt_toolkit.document import Document
 
-        from vulnclaw.cli.tui import build_repl_slash_completer, list_skill_palette_entries
+        from vulnclaw.cli.tui import build_repl_slash_completer, list_repl_palette_entries
 
         completer = build_repl_slash_completer()
         completions = list(completer.get_completions(Document("/", 1), None))
 
-        assert len(completions) == len(list_skill_palette_entries())
+        assert len(completions) == len(list_repl_palette_entries())
+        # Built-in commands come first, ahead of the skills.
+        assert [c.text for c in completions[:2]] == ["config", "language"]
 
     def test_completer_stops_after_skill_is_chosen(self):
         from prompt_toolkit.document import Document
@@ -1055,6 +1057,127 @@ class TestClassicReplSlashPalette:
         monkeypatch.setattr(main_mod.sys.stdin, "isatty", lambda: False)
 
         assert main_mod._make_repl_prompt_session() is None
+
+    def test_config_command_dispatches(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/config")
+
+        assert result.kind == "command"
+        assert result.value == "config"
+        assert result.text == ""
+
+    def test_config_alias_dispatches(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/cfg")
+
+        assert result.kind == "command"
+        assert result.value == "config"
+
+    def test_language_command_carries_argument(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/language en")
+
+        assert result.kind == "command"
+        assert result.value == "language"
+        assert result.text == "en"
+
+    def test_language_alias_dispatches(self):
+        from vulnclaw.cli.tui import dispatch_repl_slash
+
+        result = dispatch_repl_slash("/lang")
+
+        assert result.kind == "command"
+        assert result.value == "language"
+
+    def test_repl_palette_lists_commands_before_skills(self):
+        import vulnclaw.cli.tui as tui_mod
+
+        entries = tui_mod.list_repl_palette_entries()
+        names = [name for name, _ in entries]
+
+        assert names[:2] == ["config", "language"]
+        assert "recon" in names  # skills still follow the commands
+
+    def test_repl_palette_filters_commands_by_prefix(self):
+        import vulnclaw.cli.tui as tui_mod
+
+        names = [name for name, _ in tui_mod.list_repl_palette_entries("co")]
+
+        assert "config" in names
+        assert "language" not in names
+
+    def test_language_switch_updates_config(self, monkeypatch):
+        import vulnclaw.cli.main as main_mod
+        import vulnclaw.cli.tui as tui_mod
+        import vulnclaw.i18n as i18n_mod
+
+        saved = {}
+        monkeypatch.setattr(main_mod, "save_config", lambda cfg: saved.setdefault("cfg", cfg))
+        # Keep the switch pure: no real locale reload / global rebuild.
+        monkeypatch.setattr(i18n_mod, "init_i18n", lambda *a, **k: None)
+        monkeypatch.setattr(tui_mod, "rebuild_translations", lambda: None)
+
+        class _Cfg:
+            class session:
+                language = "auto"
+
+        class _Agent:
+            def __init__(self):
+                self.applied = None
+
+            def apply_config(self, cfg):
+                self.applied = cfg
+
+        cfg = _Cfg()
+        agent = _Agent()
+
+        out = main_mod._repl_switch_language("en", agent, cfg)
+
+        assert cfg.session.language == "en"
+        assert out is cfg
+        assert saved["cfg"] is cfg
+        assert agent.applied is cfg
+
+    def test_language_switch_rejects_unknown(self, monkeypatch):
+        import vulnclaw.cli.main as main_mod
+
+        called = {"saved": False}
+        monkeypatch.setattr(
+            main_mod, "save_config", lambda cfg: called.__setitem__("saved", True)
+        )
+
+        class _Cfg:
+            class session:
+                language = "en"
+
+        class _Agent:
+            def apply_config(self, cfg):  # pragma: no cover - must not run
+                raise AssertionError("apply_config should not be called")
+
+        cfg = _Cfg()
+        out = main_mod._repl_switch_language("klingon", _Agent(), cfg)
+
+        assert out is cfg
+        assert cfg.session.language == "en"  # unchanged
+        assert called["saved"] is False
+
+    def test_agent_apply_config_resets_client(self):
+        from vulnclaw.agent.core import AgentCore
+        from vulnclaw.config.settings import load_config
+
+        config = load_config()
+        agent = AgentCore.__new__(AgentCore)
+        agent._client = object()
+        agent._key_index = 3
+
+        agent.apply_config(config)
+
+        assert agent.config is config
+        assert agent._client is None
+        assert agent._key_index == 0
 
 
 class TestCLISubCommands:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -266,3 +266,74 @@ class TestSettingsLoad:
         assert config.session.plugin_runtime_enabled is False
         assert config.session.plugin_max_requests_per_target == 7
         assert config.session.evidence_min_report_level == "L2"
+
+    def test_env_var_api_keys_list(self, monkeypatch):
+        """VULNCLAW_LLM_API_KEYS (comma-separated) populates the key list."""
+        from vulnclaw.config.settings import load_config
+
+        monkeypatch.setenv("VULNCLAW_LLM_API_KEYS", "k1, k2 ,k3")
+        config = load_config()
+        assert config.llm.api_keys == ["k1", "k2", "k3"]
+
+    def test_env_var_repl_parallel_overrides(self, monkeypatch):
+        """VULNCLAW_SESSION_REPL_PARALLEL_* overrides session fan-out defaults."""
+        from vulnclaw.config.settings import load_config
+
+        monkeypatch.setenv("VULNCLAW_SESSION_REPL_PARALLEL_ENABLED", "false")
+        monkeypatch.setenv("VULNCLAW_SESSION_REPL_PARALLEL_AGENTS", "2")
+        monkeypatch.setenv("VULNCLAW_SESSION_REPL_PARALLEL_DEPTH", "2")
+        monkeypatch.setenv("VULNCLAW_SESSION_REPL_PARALLEL_WORKER_ROUNDS", "4")
+        monkeypatch.setenv("VULNCLAW_SESSION_REPL_PARALLEL_SURFACE_LIMIT", "9")
+
+        config = load_config()
+
+        assert config.session.repl_parallel_enabled is False
+        assert config.session.repl_parallel_agents == 2
+        assert config.session.repl_parallel_depth == 2
+        assert config.session.repl_parallel_worker_rounds == 4
+        assert config.session.repl_parallel_surface_limit == 9
+
+    def test_set_config_value_api_keys_from_string(self, monkeypatch, tmp_path):
+        """set_config_value('llm.api_keys', 'a,b') stores a parsed list."""
+        import vulnclaw.config.settings as settings_mod
+
+        monkeypatch.setattr(settings_mod, "CONFIG_FILE", tmp_path / "config.yaml")
+        monkeypatch.setattr(settings_mod, "CONFIG_DIR", tmp_path)
+        settings_mod.set_config_value("llm.api_keys", "a, b ,c")
+        config = settings_mod.load_config()
+        assert config.llm.api_keys == ["a", "b", "c"]
+
+    def test_set_config_value_repl_parallel_fields(self, monkeypatch, tmp_path):
+        """set_config_value coerces REPL parallel session fields."""
+        import vulnclaw.config.settings as settings_mod
+
+        monkeypatch.setattr(settings_mod, "CONFIG_FILE", tmp_path / "config.yaml")
+        monkeypatch.setattr(settings_mod, "CONFIG_DIR", tmp_path)
+
+        settings_mod.set_config_value("session.repl_parallel_enabled", "false")
+        settings_mod.set_config_value("session.repl_parallel_agents", "2")
+        settings_mod.set_config_value("session.repl_parallel_worker_rounds", "4")
+
+        config = settings_mod.load_config()
+        assert config.session.repl_parallel_enabled is False
+        assert config.session.repl_parallel_agents == 2
+        assert config.session.repl_parallel_worker_rounds == 4
+
+    def test_strip_defaults_drops_empty_api_keys(self):
+        from vulnclaw.config.settings import _strip_defaults
+
+        raw = {"llm": {"api_keys": [], "model": "gpt-4o", "provider": "openai"}}
+        _strip_defaults(raw)
+        assert "api_keys" not in raw["llm"]
+
+    def test_save_load_roundtrips_api_keys(self, monkeypatch, tmp_path):
+        import vulnclaw.config.settings as settings_mod
+        from vulnclaw.config.schema import VulnClawConfig
+
+        monkeypatch.setattr(settings_mod, "CONFIG_FILE", tmp_path / "config.yaml")
+        monkeypatch.setattr(settings_mod, "CONFIG_DIR", tmp_path)
+        config = VulnClawConfig()
+        config.llm.api_keys = ["x1", "x2"]
+        settings_mod.save_config(config)
+        reloaded = settings_mod.load_config()
+        assert reloaded.llm.api_keys == ["x1", "x2"]

--- a/tests/test_llm_failover.py
+++ b/tests/test_llm_failover.py
@@ -1,0 +1,293 @@
+"""Tests for multi-key failover rotation in the LLM call retry loop."""
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from vulnclaw.agent.llm_client import (
+    _call_with_persistent_retries,
+    _is_key_exhausted_error,
+)
+
+
+class FakeAgent:
+    """Minimal stand-in exposing the key-pool surface the retry loop uses."""
+
+    def __init__(self, keys):
+        self._key_pool = list(keys)
+        self._key_index = 0
+
+    def current_key(self):
+        return self._key_pool[self._key_index]
+
+    def rotate_api_key(self) -> bool:
+        if len(self._key_pool) > 1:
+            self._key_index = (self._key_index + 1) % len(self._key_pool)
+            return True
+        return False
+
+
+def _ok_response():
+    return SimpleNamespace(choices=[object()])
+
+
+def _full_ok_response():
+    message = SimpleNamespace(content="ok", tool_calls=None, reasoning_content=None)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class TestIsKeyExhaustedError:
+    def test_detects_rate_limit_and_quota_signals(self):
+        for text in [
+            "error code: 429 too many requests",
+            "rate limit exceeded",
+            "rate_limit_exceeded",
+            "your quota has been exhausted",
+            "deepseek: insufficient balance (402)",
+            "账户余额不足",
+            "code 1302 concurrency limit",
+            "code 1113 balance",
+        ]:
+            assert _is_key_exhausted_error(text.lower()) is True, text
+
+    def test_ignores_unrelated_errors(self):
+        for text in [
+            "connection reset by peer",
+            "model not found",
+            "invalid function arguments json string",
+        ]:
+            assert _is_key_exhausted_error(text.lower()) is False, text
+
+
+class TestRotateApiKey:
+    def test_rotate_advances_index(self):
+        agent = FakeAgent(["k1", "k2"])
+        assert agent.current_key() == "k1"
+        assert agent.rotate_api_key() is True
+        assert agent.current_key() == "k2"
+
+    def test_rotate_single_key_is_noop(self):
+        agent = FakeAgent(["only"])
+        assert agent.rotate_api_key() is False
+        assert agent.current_key() == "only"
+
+
+class TestFailover:
+    async def test_rotates_past_rate_limited_key(self):
+        agent = FakeAgent(["bad", "good"])
+
+        def request_fn():
+            if agent.current_key() == "bad":
+                raise RuntimeError("Error code: 429 - rate limit exceeded")
+            return _ok_response()
+
+        response, _ = await _call_with_persistent_retries(agent, request_fn, "test")
+        assert response.choices
+        assert agent.current_key() == "good"
+
+    async def test_rotates_past_invalid_key_then_succeeds(self):
+        agent = FakeAgent(["bad", "good"])
+
+        def request_fn():
+            if agent.current_key() == "bad":
+                raise RuntimeError("invalid api key provided")
+            return _ok_response()
+
+        response, _ = await _call_with_persistent_retries(agent, request_fn, "test")
+        assert response.choices
+        assert agent.current_key() == "good"
+
+    async def test_raises_when_all_keys_invalid(self):
+        agent = FakeAgent(["bad1", "bad2"])
+
+        def request_fn():
+            raise RuntimeError("invalid api key provided")
+
+        with pytest.raises(RuntimeError):
+            await _call_with_persistent_retries(agent, request_fn, "test")
+
+    async def test_single_key_auth_error_raises_fast(self):
+        agent = FakeAgent(["only"])
+
+        def request_fn():
+            raise RuntimeError("unauthorized: invalid api key")
+
+        with pytest.raises(RuntimeError):
+            await _call_with_persistent_retries(agent, request_fn, "test")
+
+
+class TestCallLlmUsesRotatedClient:
+    """Regression test: call_llm/call_llm_auto must not close over a stale client.
+
+    rotate_api_key() invalidates agent._client so the *next* _get_client() call
+    rebuilds with the new key. If call_llm_auto captured `client =
+    agent._get_client()` once and reused it across retries, every retry after a
+    rotation would still hit the old (failed) key's client. The retry loop must
+    call agent._get_client() fresh on every attempt.
+    """
+
+    async def test_call_llm_auto_retries_with_freshly_rotated_client(self, monkeypatch):
+        from vulnclaw.agent import llm_client
+
+        class DummyLoop:
+            async def run_in_executor(self, executor, fn):
+                return fn()
+
+        class DummyClient:
+            def __init__(self, key):
+                self.key = key
+                self.chat = SimpleNamespace(
+                    completions=SimpleNamespace(create=self._create)
+                )
+
+            def _create(self, **kwargs):
+                if self.key == "bad":
+                    raise RuntimeError("Error code: 429 - rate limit exceeded")
+                return _full_ok_response()
+
+        class DummyAgent:
+            _key_pool = ["bad", "good"]
+            _key_index = 0
+
+            class _Config:
+                class _LLM:
+                    model = "gpt-4o-mini"
+                    max_tokens = 256
+                    temperature = 0.1
+                    provider = "openai"
+                    reasoning_effort = "high"
+
+                llm = _LLM()
+
+            class _Context:
+                @staticmethod
+                def get_messages():
+                    return []
+
+                @staticmethod
+                def add_assistant_message(text):
+                    return None
+
+            config = _Config()
+            context = _Context()
+
+            def _build_openai_tools(self):
+                return []
+
+            def _get_client(self):
+                # Mirrors AgentCore._get_client(): reflects the *current*
+                # rotation index, not whatever was current when first called.
+                return DummyClient(self._key_pool[self._key_index])
+
+            def rotate_api_key(self) -> bool:
+                if len(self._key_pool) > 1:
+                    self._key_index = (self._key_index + 1) % len(self._key_pool)
+                    return True
+                return False
+
+        dummy = DummyAgent()
+        monkeypatch.setattr(llm_client.asyncio, "get_running_loop", lambda: DummyLoop())
+
+        result = await llm_client.call_llm_auto(dummy, "sys", "round")
+
+        assert dummy._key_index == 1
+        assert "ok" in result
+
+    async def test_call_llm_retries_with_freshly_rotated_client(self, monkeypatch):
+        from vulnclaw.agent import llm_client
+
+        class DummyLoop:
+            async def run_in_executor(self, executor, fn):
+                return fn()
+
+        class DummyClient:
+            def __init__(self, key):
+                self.key = key
+                self.chat = SimpleNamespace(
+                    completions=SimpleNamespace(create=self._create)
+                )
+
+            def _create(self, **kwargs):
+                if self.key == "bad":
+                    raise RuntimeError("invalid api key provided")
+                return _full_ok_response()
+
+        class DummyAgent:
+            _key_pool = ["bad", "good"]
+            _key_index = 0
+
+            class _Config:
+                class _LLM:
+                    model = "gpt-4o-mini"
+                    max_tokens = 256
+                    temperature = 0.1
+                    provider = "openai"
+                    reasoning_effort = "high"
+
+                llm = _LLM()
+
+            class _Context:
+                @staticmethod
+                def get_messages():
+                    return []
+
+            config = _Config()
+            context = _Context()
+
+            def _build_openai_tools(self):
+                return []
+
+            def _get_client(self):
+                return DummyClient(self._key_pool[self._key_index])
+
+            def rotate_api_key(self) -> bool:
+                if len(self._key_pool) > 1:
+                    self._key_index = (self._key_index + 1) % len(self._key_pool)
+                    return True
+                return False
+
+        dummy = DummyAgent()
+        monkeypatch.setattr(llm_client.asyncio, "get_running_loop", lambda: DummyLoop())
+
+        await llm_client.call_llm(dummy, "sys")
+
+        assert dummy._key_index == 1
+
+
+class TestAgentCoreRotation:
+    def _agent(self, **llm):
+        from vulnclaw.agent.core import AgentCore
+        from vulnclaw.config.schema import VulnClawConfig
+
+        config = VulnClawConfig()
+        for k, v in llm.items():
+            setattr(config.llm, k, v)
+        return AgentCore(config)
+
+    def test_pool_from_api_keys(self):
+        agent = self._agent(api_keys=["k1", "k2"])
+        assert agent._key_pool == ["k1", "k2"]
+        assert agent._current_api_key() == "k1"
+
+    def test_pool_falls_back_to_single_key(self):
+        agent = self._agent(api_key="solo")
+        assert agent._key_pool == ["solo"]
+        assert agent.rotate_api_key() is False
+
+    def test_rotate_advances_and_invalidates_client(self, monkeypatch):
+        fake_openai = ModuleType("openai")
+
+        class FakeOpenAI:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        fake_openai.OpenAI = FakeOpenAI
+        monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+        agent = self._agent(api_keys=["k1", "k2"])
+        agent._get_client()
+        assert agent._client is not None
+        assert agent.rotate_api_key() is True
+        assert agent._client is None
+        assert agent._current_api_key() == "k2"

--- a/tests/test_mcp_fetch_cookies.py
+++ b/tests/test_mcp_fetch_cookies.py
@@ -1,0 +1,81 @@
+"""Regression tests for the fetch tool's shared cookie-jar handling.
+
+Covers the bug where brute_force_login synced session cookies into
+MCPLifecycleManager._fetch_cookies, but _call_fetch created a fresh,
+cookie-less httpx.AsyncClient per call and never read or wrote that jar.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vulnclaw.config.schema import VulnClawConfig
+from vulnclaw.mcp.lifecycle import MCPLifecycleManager
+
+
+def _manager() -> MCPLifecycleManager:
+    return MCPLifecycleManager(VulnClawConfig())
+
+
+def _patch_fetch_transport(monkeypatch, handler):
+    class _RecordingAsyncClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(handler)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _RecordingAsyncClient)
+
+
+@pytest.mark.asyncio
+async def test_call_fetch_persists_response_cookies_into_shared_jar(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"set-cookie": "session=abc123; Path=/"},
+            text="ok",
+        )
+
+    _patch_fetch_transport(monkeypatch, handler)
+
+    manager = _manager()
+    await manager._call_fetch({"url": "https://example.com/login", "method": "GET"})
+
+    jar = manager._fetch_cookies
+    assert jar is not None
+    assert jar.get("session") == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_call_fetch_sends_previously_stored_cookies(monkeypatch):
+    seen_cookie_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_cookie_headers.append(request.headers.get("cookie"))
+        return httpx.Response(200, text="post-login content")
+
+    _patch_fetch_transport(monkeypatch, handler)
+
+    manager = _manager()
+    manager._fetch_cookies = httpx.Cookies()
+    manager._fetch_cookies.set("session", "abc123", domain="example.com", path="/")
+
+    await manager._call_fetch({"url": "https://example.com/dashboard", "method": "GET"})
+
+    assert seen_cookie_headers == ["session=abc123"]
+
+
+@pytest.mark.asyncio
+async def test_call_fetch_with_no_prior_session_sends_no_cookie_header(monkeypatch):
+    seen_cookie_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_cookie_headers.append(request.headers.get("cookie"))
+        return httpx.Response(200, text="ok")
+
+    _patch_fetch_transport(monkeypatch, handler)
+
+    manager = _manager()
+    await manager._call_fetch({"url": "https://example.com/", "method": "GET"})
+
+    assert seen_cookie_headers == [None]

--- a/tests/test_network_scan.py
+++ b/tests/test_network_scan.py
@@ -1,0 +1,136 @@
+import json
+
+NMAP_XML = """<?xml version="1.0"?>
+<nmaprun>
+  <host>
+    <status state="up"/>
+    <address addr="192.168.56.10" addrtype="ipv4"/>
+    <ports>
+      <port protocol="tcp" portid="23">
+        <state state="open"/>
+        <service name="telnet" product="BusyBox" version="1.31"/>
+      </port>
+      <port protocol="tcp" portid="443">
+        <state state="open"/>
+        <service name="https" product="nginx" version="1.24"/>
+        <script id="ssl-cert" output="self-signed certificate"/>
+      </port>
+    </ports>
+  </host>
+  <runstats><finished elapsed="1.23" summary="done"/></runstats>
+</nmaprun>
+"""
+
+
+def test_network_scan_profile_planning():
+    from vulnclaw.agent.network_scan import build_nmap_command, build_nmap_plan
+
+    plan = build_nmap_plan(profile="thorough")
+
+    assert plan.profile == "thorough"
+    assert plan.ports == "1-65535"
+    assert plan.timing == 3
+    command = build_nmap_command("/usr/bin/nmap", "192.168.56.10", plan)
+    assert command[:2] == ["/usr/bin/nmap", "-v"]
+    assert "--script" in command
+    assert "default,safe" in command
+    assert command[-1] == "192.168.56.10"
+
+
+def test_build_nmap_command_deescalates_without_root(monkeypatch):
+    from vulnclaw.agent.network_scan import (
+        build_nmap_command,
+        build_nmap_plan,
+        deescalate_nmap_argv,
+        without_privileged_nmap_args,
+    )
+
+    plan = build_nmap_plan(profile="thorough")
+    assert "-O" in plan.args
+
+    monkeypatch.setattr("vulnclaw.agent.network_scan.nmap_has_raw_socket_access", lambda: False)
+    command = build_nmap_command("/usr/bin/nmap", "192.168.56.10", plan)
+    assert "-O" not in command
+    assert "-sS" not in command
+
+    stealth = build_nmap_plan(profile="stealth")
+    assert without_privileged_nmap_args(stealth.args) == ("-q", "-sT", "-f")
+    assert "-O" not in deescalate_nmap_argv(
+        ["/usr/bin/nmap", "-sS", "-O", "-sV", "-oX", "-", "192.168.56.10"]
+    )
+
+
+def test_network_scan_adaptive_uses_prior_ports():
+    from vulnclaw.agent.network_scan import build_nmap_plan
+
+    plan = build_nmap_plan(
+        profile="adaptive",
+        prior_recon={
+            "network_services": [
+                {"host": "192.168.56.10", "port": 22, "protocol": "tcp"},
+                {"host": "192.168.56.10", "port": 8443, "protocol": "tcp"},
+            ]
+        },
+    )
+
+    assert plan.ports == "22,8443"
+    assert plan.timing == 3
+
+
+def test_detect_connected_wifi_target_uses_active_wireless_ipv4(monkeypatch):
+    import vulnclaw.agent.network_scan as network_scan
+
+    monkeypatch.setattr(network_scan, "_wifi_interfaces", lambda: ["wlp2s0"])
+    monkeypatch.setattr(network_scan, "_interface_is_up", lambda interface: True)
+    monkeypatch.setattr(
+        network_scan,
+        "_interface_ipv4_network",
+        lambda interface: network_scan.WifiScanTarget(
+            interface=interface,
+            address="192.168.1.42",
+            cidr="192.168.1.0/24",
+        ),
+    )
+
+    target = network_scan.detect_connected_wifi_target()
+
+    assert target.interface == "wlp2s0"
+    assert target.address == "192.168.1.42"
+    assert target.cidr == "192.168.1.0/24"
+
+
+def test_parse_nmap_xml_structured_ranks_weak_links():
+    from vulnclaw.agent.network_scan import parse_nmap_xml_structured, summarize_network_scan
+
+    structured = parse_nmap_xml_structured(NMAP_XML, "192.168.56.10")
+
+    assert len(structured["open_services"]) == 2
+    assert structured["weak_links"][0]["risk"] == "unencrypted_protocol"
+    assert structured["weak_links"][0]["severity"] == "High"
+    assert structured["weak_links"][1]["risk"] == "web_surface"
+    summary = summarize_network_scan(structured)
+    assert "Weak-link candidates: 2" in summary
+    assert "192.168.56.10:23" in summary
+
+
+def test_attach_network_scan_to_session_creates_candidate_findings():
+    from vulnclaw.agent.context import SessionState
+    from vulnclaw.agent.network_scan import (
+        attach_network_scan_to_session,
+        parse_nmap_xml_structured,
+    )
+
+    session = SessionState(target="192.168.56.10")
+    structured = parse_nmap_xml_structured(NMAP_XML, "192.168.56.10")
+
+    attach_network_scan_to_session(session, structured, profile="fast")
+
+    assert session.recon_data["network_scans"][0]["profile"] == "fast"
+    assert len(session.recon_data["network_services"]) == 2
+    assert {f.vuln_type for f in session.findings} == {
+        "unencrypted_protocol",
+        "web_surface",
+    }
+    assert all(f.verification_status == "pending" for f in session.findings)
+    assert session.step_records[-1].action == "network scan"
+    assert json.loads(session.step_records[-1].detail)["target"] == "192.168.56.10"

--- a/tests/test_parallel_agents.py
+++ b/tests/test_parallel_agents.py
@@ -1,0 +1,107 @@
+"""Tests for bounded parallel agent coordination."""
+
+from __future__ import annotations
+
+import pytest
+
+from vulnclaw.agent.context import SessionState, VulnerabilityFinding
+from vulnclaw.agent.parallel_agents import extract_attack_surfaces, run_parallel_pentest
+
+
+class FakeAgent:
+    def __init__(self) -> None:
+        self.session_state = SessionState(target="192.168.1.0/24")
+        self.calls: list[str] = []
+
+    async def auto_pentest(self, prompt, target=None, max_rounds=0, stream_sink=None):
+        self.calls.append(prompt)
+        if "authorized fast network scan" in prompt:
+            self.session_state.recon_data["network_services"] = [
+                {
+                    "host": "192.168.1.10",
+                    "port": 22,
+                    "protocol": "tcp",
+                    "service": "ssh",
+                },
+                {
+                    "host": "192.168.1.20",
+                    "port": 445,
+                    "protocol": "tcp",
+                    "service": "microsoft-ds",
+                },
+            ]
+            return ["root-discovery"]
+
+        self.session_state.add_finding(
+            VulnerabilityFinding(
+                title=f"Surface reviewed {len(self.calls)}",
+                severity="Info",
+                vuln_type="surface-review",
+                evidence=prompt,
+            )
+        )
+        self.session_state.notes.append("worker note")
+        return ["worker-result"]
+
+
+def test_extract_attack_surfaces_from_network_state_and_findings():
+    state = SessionState(target="192.168.1.0/24")
+    state.recon_data["network_services"] = [
+        {"host": "192.168.1.10", "port": 22, "protocol": "tcp", "service": "ssh"},
+        {"host": "192.168.1.10", "port": 22, "protocol": "tcp", "service": "ssh"},
+    ]
+    state.recon_data["network_scans"] = [
+        {
+            "weak_links": [
+                {"target": "192.168.1.20:445", "reason": "SMB exposed"},
+            ]
+        }
+    ]
+    state.add_finding(
+        VulnerabilityFinding(
+            title="Web finding",
+            vuln_type="web",
+            evidence="Observed at http://192.168.1.30/admin",
+        )
+    )
+
+    surfaces = extract_attack_surfaces(state)
+
+    assert [surface.target for surface in surfaces] == [
+        "192.168.1.10:22",
+        "192.168.1.20:445",
+        "http://192.168.1.30/admin",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_parallel_pentest_fans_out_and_merges_worker_state():
+    root = FakeAgent()
+    children: list[FakeAgent] = []
+
+    def factory():
+        child = FakeAgent()
+        children.append(child)
+        return child
+
+    result = await run_parallel_pentest(
+        root,
+        agent_factory=factory,
+        user_input="Perform an authorized fast network scan against 192.168.1.0/24.",
+        target="192.168.1.0/24",
+        discovery_rounds=1,
+        worker_rounds=2,
+        max_agents=2,
+        max_depth=1,
+    )
+
+    assert result.root_results == ["root-discovery"]
+    assert result.waves_completed == 1
+    assert [surface.target for surface in result.surfaces] == [
+        "192.168.1.10:22",
+        "192.168.1.20:445",
+    ]
+    assert len(children) == 2
+    assert len(root.session_state.findings) == 2
+    assert root.session_state.notes == ["worker note"]
+    assert all("Investigate this surface only" in child.calls[0] for child in children)

--- a/tests/test_pdf_exporter.py
+++ b/tests/test_pdf_exporter.py
@@ -1,0 +1,65 @@
+import pytest
+
+from vulnclaw.report import pdf_exporter
+
+SAMPLE_MD = """# Security Assessment
+
+**Target:** example.com
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 1 |
+| High | 2 |
+
+## Findings
+
+- SQL injection in login
+- Reflected XSS in search
+
+### Detail
+
+Some paragraph with `inline code` and **bold** text.
+
+```
+GET /admin HTTP/1.1
+Host: example.com
+```
+
+---
+
+1. First step
+2. Second step
+"""
+
+
+@pytest.mark.skipif(not pdf_exporter._HAVE_REPORTLAB, reason="reportlab ([pdf] extra) not installed")
+def test_export_pdf_writes_valid_file(tmp_path):
+    out = tmp_path / "report.pdf"
+    result = pdf_exporter.export_pdf(SAMPLE_MD, out, title="VulnClaw Report")
+    assert result == out
+    assert out.exists()
+    data = out.read_bytes()
+    assert data[:5] == b"%PDF-"
+    assert len(data) > 800  # non-trivial content rendered
+
+
+@pytest.mark.skipif(not pdf_exporter._HAVE_REPORTLAB, reason="reportlab not installed")
+def test_export_pdf_creates_parent_dirs(tmp_path):
+    out = tmp_path / "nested" / "dir" / "r.pdf"
+    pdf_exporter.export_pdf("# Hi\n\nbody", out)
+    assert out.exists()
+
+
+def test_export_pdf_without_reportlab_raises(monkeypatch):
+    monkeypatch.setattr(pdf_exporter, "_HAVE_REPORTLAB", False)
+    with pytest.raises(RuntimeError, match=r"vulnclaw\[pdf\]"):
+        pdf_exporter.export_pdf("# x", "/tmp/should-not-exist.pdf")
+
+
+def test_inline_escapes_and_formats():
+    out = pdf_exporter._inline("a & b <c> **bold** `code`")
+    assert "&amp;" in out and "&lt;c&gt;" in out
+    assert "<b>bold</b>" in out
+    assert 'face="Courier"' in out

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -335,6 +335,69 @@ class TestSkillDispatcher:
         assert skill["name"] == "crypto-toolkit"
 
 
+# ── flag_skills.py ────────────────────────────────────────────────
+
+
+class TestFlagSkills:
+    """Test slash-dot flag skill registry and TUI application helpers."""
+
+    def test_flag_skill_registry_includes_common_and_command_flags(self):
+        from vulnclaw.skills.flag_skills import find_flag_skill
+
+        assert find_flag_skill("/.only-port").canonical == "--only-port"
+        assert find_flag_skill("/.--allow-actions").canonical == "--allow-actions"
+        assert find_flag_skill("parallel-agents").canonical == "--parallel-agents"
+        assert find_flag_skill("allow-remote").canonical == "--allow-remote"
+        assert find_flag_skill("format").canonical == "--format"
+
+    def test_flag_skill_aliases_normalize_slash_dot_forms(self):
+        from vulnclaw.skills.flag_skills import find_flag_skill
+
+        expected = find_flag_skill("--only-port")
+        assert find_flag_skill("/.only-port") == expected
+        assert find_flag_skill("/.--only-port") == expected
+        assert find_flag_skill("only_port") == expected
+
+    def test_complete_flag_skills_filters_by_prefix(self):
+        from vulnclaw.skills.flag_skills import complete_flag_skills
+
+        names = [skill.name for skill in complete_flag_skills("only-")]
+        assert "only-port" in names
+        assert "only-host" in names
+        assert "blocked-host" not in names
+
+    def test_apply_flag_skill_to_tui_state(self):
+        from vulnclaw.cli.tui import TuiState
+        from vulnclaw.skills.flag_skills import apply_flag_skill_to_tui_state, find_flag_skill
+
+        state = TuiState()
+        result = apply_flag_skill_to_tui_state(find_flag_skill("only-port"), "443", state)
+
+        assert result.applied is True
+        assert state.only_port == "443"
+
+    def test_apply_flag_skill_rejects_invalid_port(self):
+        from vulnclaw.cli.tui import TuiState
+        from vulnclaw.skills.flag_skills import apply_flag_skill_to_tui_state, find_flag_skill
+
+        state = TuiState()
+        result = apply_flag_skill_to_tui_state(find_flag_skill("only-port"), "99999", state)
+
+        assert result.applied is False
+        assert result.error is True
+        assert state.only_port == ""
+
+    def test_no_resume_flag_applies_without_value(self):
+        from vulnclaw.cli.tui import TuiState
+        from vulnclaw.skills.flag_skills import apply_flag_skill_to_tui_state, find_flag_skill
+
+        state = TuiState(resume=True)
+        result = apply_flag_skill_to_tui_state(find_flag_skill("no-resume"), "", state)
+
+        assert result.applied is True
+        assert state.resume is False
+
+
 # ── crypto_tools.py ────────────────────────────────────────────────
 
 

--- a/tests/test_system_prompt_constraints.py
+++ b/tests/test_system_prompt_constraints.py
@@ -1,0 +1,36 @@
+from vulnclaw.agent.context import TaskConstraints
+from vulnclaw.agent.system_prompt import build_dynamic_system_prompt
+
+
+def _build(task_constraints=None):
+    return build_dynamic_system_prompt(
+        target="example.com",
+        phase=None,
+        skill_context=None,
+        mcp_tools=[],
+        enable_personnel_dim=False,
+        auto_mode=False,
+        user_input=None,
+        kb_context="",
+        task_constraints=task_constraints,
+    )
+
+
+def test_prompt_includes_constraints_block_when_constraints_set():
+    constraints = TaskConstraints(allowed_ports=[443], blocked_hosts=["internal.example.com"])
+
+    prompt = _build(task_constraints=constraints)
+
+    assert constraints.to_prompt_block() in prompt
+
+
+def test_prompt_omits_constraints_block_when_constraints_empty():
+    prompt = _build(task_constraints=TaskConstraints())
+
+    assert "当前任务硬约束" not in prompt
+
+
+def test_prompt_omits_constraints_block_when_constraints_none():
+    prompt = _build(task_constraints=None)
+
+    assert "当前任务硬约束" not in prompt

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -72,6 +72,111 @@ class TestWebServices:
         assert view.show_thinking is True
         assert view.python_execute_mode == "trusted-local"
 
+    def test_web_provider_service_lists_presets(self):
+        from vulnclaw.web.services.provider_service import get_provider_presets
+
+        view = get_provider_presets()
+        ids = {p.id for p in view.providers}
+        assert "openai" in ids
+        assert "custom" in ids
+        openai = next(p for p in view.providers if p.id == "openai")
+        assert openai.base_url == "https://api.openai.com/v1"
+        assert openai.default_model == "gpt-4o"
+        assert openai.label == "OpenAI"
+
+    def test_web_provider_service_fetch_models_uses_saved_key(self, monkeypatch):
+        import vulnclaw.web.services.provider_service as provider_service
+        from vulnclaw.config.schema import VulnClawConfig
+        from vulnclaw.web.schemas import ProviderModelsRequest
+
+        config = VulnClawConfig()
+        config.llm.api_key = "sk-fallback"
+        config.llm.api_keys = ["sk-primary", "sk-secondary"]
+        config.llm.base_url = "https://api.example.com/v1"
+        monkeypatch.setattr(provider_service, "load_config", lambda: config)
+
+        captured = {}
+
+        def fake_fetch(base_url, api_key, timeout=10.0):
+            captured["base_url"] = base_url
+            captured["api_key"] = api_key
+            return ["model-b", "model-a"]
+
+        monkeypatch.setattr(provider_service, "fetch_provider_models", fake_fetch)
+
+        resp = provider_service.fetch_models(ProviderModelsRequest())
+        assert resp.has_api_key is True
+        assert resp.models == ["model-b", "model-a"]
+        assert captured == {"base_url": "https://api.example.com/v1", "api_key": "sk-primary"}
+
+    def test_web_provider_service_fetch_models_requires_key(self, monkeypatch):
+        import vulnclaw.web.services.provider_service as provider_service
+        from vulnclaw.config.schema import VulnClawConfig
+        from vulnclaw.web.schemas import ProviderModelsRequest
+
+        config = VulnClawConfig()
+        config.llm.api_key = ""
+        monkeypatch.setattr(provider_service, "load_config", lambda: config)
+
+        def must_not_call(*args, **kwargs):
+            raise AssertionError("fetch_provider_models must not run without a key")
+
+        monkeypatch.setattr(provider_service, "fetch_provider_models", must_not_call)
+
+        resp = provider_service.fetch_models(ProviderModelsRequest())
+        assert resp.has_api_key is False
+        assert resp.models == []
+        assert "key" in resp.detail.lower()
+
+    def test_web_provider_service_fetch_models_honors_request_base_url(self, monkeypatch):
+        import vulnclaw.web.services.provider_service as provider_service
+        from vulnclaw.config.schema import VulnClawConfig
+        from vulnclaw.web.schemas import ProviderModelsRequest
+
+        config = VulnClawConfig()
+        config.llm.api_key = "sk-test"
+        config.llm.base_url = "https://config-default.example/v1"
+        monkeypatch.setattr(provider_service, "load_config", lambda: config)
+
+        captured = {}
+
+        def fake_fetch(base_url, api_key, timeout=10.0):
+            captured["base_url"] = base_url
+            return ["m"]
+
+        monkeypatch.setattr(provider_service, "fetch_provider_models", fake_fetch)
+
+        # A known provider preset base_url is trusted and gets the saved key.
+        resp = provider_service.fetch_models(
+            ProviderModelsRequest(base_url="https://api.openai.com/v1")
+        )
+        assert captured["base_url"] == "https://api.openai.com/v1"
+        assert resp.base_url == "https://api.openai.com/v1"
+        assert resp.models == ["m"]
+
+    def test_web_provider_service_fetch_models_rejects_untrusted_base_url(self, monkeypatch):
+        """An arbitrary client-supplied base_url must never receive the saved API key."""
+        import vulnclaw.web.services.provider_service as provider_service
+        from vulnclaw.config.schema import VulnClawConfig
+        from vulnclaw.web.schemas import ProviderModelsRequest
+
+        config = VulnClawConfig()
+        config.llm.api_key = "sk-test"
+        config.llm.base_url = "https://config-default.example/v1"
+        monkeypatch.setattr(provider_service, "load_config", lambda: config)
+
+        def must_not_call(*args, **kwargs):
+            raise AssertionError("fetch_provider_models must not run for an untrusted base_url")
+
+        monkeypatch.setattr(provider_service, "fetch_provider_models", must_not_call)
+
+        resp = provider_service.fetch_models(
+            ProviderModelsRequest(base_url="https://attacker.example/v1")
+        )
+        assert resp.models == []
+        assert resp.has_api_key is True
+        assert "base url" in resp.detail.lower() or "base_url" in resp.detail.lower()
+
     def test_web_target_service_lists_targets(self, monkeypatch, tmp_path):
         import vulnclaw.target_state.store as store_mod
         import vulnclaw.web.services.target_service as target_service
@@ -242,6 +347,47 @@ class TestWebServices:
         assert report_service.resolve_report_path(str(report)) == report.resolve()
         with pytest.raises(PermissionError):
             report_service.resolve_report_path(str(outside))
+
+    def test_web_report_service_rejects_unsupported_report_type(self, monkeypatch, tmp_path):
+        import vulnclaw.web.services.report_service as report_service
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        report = sessions_dir / "demo.txt"
+        report.write_text("demo", encoding="utf-8")
+        monkeypatch.setattr(report_service, "SESSIONS_DIR", sessions_dir)
+
+        with pytest.raises(PermissionError):
+            report_service.resolve_report_path(str(report))
+
+    def test_web_report_output_path_stays_in_sessions_dir(self, monkeypatch, tmp_path):
+        import vulnclaw.web.services.report_service as report_service
+
+        sessions_dir = tmp_path / "sessions"
+        monkeypatch.setattr(report_service, "SESSIONS_DIR", sessions_dir)
+
+        allowed = report_service.resolve_report_output_path(str(sessions_dir / "demo.md"), "markdown")
+        assert allowed == (sessions_dir / "demo.md").resolve()
+
+        with pytest.raises(PermissionError):
+            report_service.resolve_report_output_path(str(tmp_path / "outside.md"), "markdown")
+        with pytest.raises(PermissionError):
+            report_service.resolve_report_output_path(str(sessions_dir / "demo.html"), "markdown")
+
+    def test_web_target_service_rejects_snapshot_traversal(self, monkeypatch, tmp_path):
+        import vulnclaw.target_state.store as store_mod
+        import vulnclaw.web.services.target_service as target_service
+        from vulnclaw.agent.context import SessionState
+
+        monkeypatch.setattr(store_mod, "TARGETS_DIR", tmp_path)
+        monkeypatch.setattr(target_service, "TARGETS_DIR", tmp_path)
+
+        state = SessionState(target="https://example.com")
+        store_mod.save_target_state("https://example.com", state, command="scan")
+
+        assert target_service.get_preview("https://example.com", snapshot_id="../state") is None
+        assert target_service.get_diff("https://example.com", "../state") is None
+        assert target_service.rollback_target("https://example.com", "../state") is False
 
     def test_web_report_service_lists_reports_by_modified_time(self, monkeypatch, tmp_path):
         import os
@@ -735,6 +881,52 @@ class TestWebApp:
 
         assert web_app.resolve_web_index() == dist_dir / "index.html"
         assert web_app.resolve_web_asset("assets/app.js") == dist_dir / "index.html"
+
+    def test_resolve_web_asset_blocks_path_traversal(self, monkeypatch, tmp_path):
+        import vulnclaw.web.app as web_app
+
+        project = tmp_path / "project"
+        dist_dir = project / "frontend" / "dist"
+        static_dir = project / "static"
+        dist_dir.mkdir(parents=True)
+        static_dir.mkdir()
+        (dist_dir / "index.html").write_text("dist", encoding="utf-8")
+        outside = project / "secret.txt"
+        outside.write_text("secret", encoding="utf-8")
+
+        monkeypatch.setattr(web_app, "FRONTEND_DIST_DIR", dist_dir)
+        monkeypatch.setattr(web_app, "STATIC_DIR", static_dir)
+
+        assert web_app.resolve_web_asset("../secret.txt") == dist_dir / "index.html"
+        assert web_app.resolve_web_asset("..\\secret.txt") == dist_dir / "index.html"
+
+    def test_web_schema_rejects_unsafe_config_values(self):
+        from pydantic import ValidationError
+
+        from vulnclaw.web.schemas import ConfigUpdateRequest, ProviderModelsRequest
+
+        with pytest.raises(ValidationError):
+            ConfigUpdateRequest(base_url="file:///etc/passwd")
+        with pytest.raises(ValidationError):
+            ConfigUpdateRequest(base_url="https://user:pass@example.com/v1")
+        with pytest.raises(ValidationError):
+            ConfigUpdateRequest(max_rounds=0)
+        with pytest.raises(ValidationError):
+            ConfigUpdateRequest(python_execute_mode="unsafe")
+
+        assert ProviderModelsRequest(base_url=" https://api.example.com/v1/ ").base_url == (
+            "https://api.example.com/v1"
+        )
+
+    def test_cli_web_allows_loopback_aliases_in_dry_run(self):
+        from vulnclaw.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["web", "--host", "localhost", "--dry-run"])
+        assert result.exit_code == 0
+
+        result = runner.invoke(app, ["web", "--host", "::1", "--dry-run"])
+        assert result.exit_code == 0
 
     def test_frontend_scaffold_exists(self):
         root = Path(__file__).resolve().parents[1] / "frontend"

--- a/vulnclaw/agent/agent_context.py
+++ b/vulnclaw/agent/agent_context.py
@@ -1,0 +1,155 @@
+"""The typed seam between :class:`~vulnclaw.agent.core.AgentCore` and its helpers.
+
+Helper modules (``loop_controller``, ``llm_client``, ``builtin_tools``,
+``solver``, ``recon_tools`` …) are handed the agent and reach into its state and
+a handful of its methods. Historically that handle was typed ``agent: Any``,
+which hid the real contract and let the seam leak. :class:`AgentContext` names
+that contract exactly: the members those helpers actually touch, and nothing
+more.
+
+The protocol is deliberately faithful to the surface as it stands today —
+including the underscore-prefixed callbacks (``_get_client``,
+``_execute_mcp_tool`` …) that helpers still lean on. Those are internal agent
+machinery a helper reaches back into; typing them honestly documents the
+coupling rather than hiding it. Giving them real public homes is a later,
+larger change (extracting a concrete context object / role-specific ports), not
+part of hardening this seam.
+
+This module imports neither ``core`` nor the helpers, so it can be referenced
+from either side without an import cycle. The concrete types below are only
+needed for annotations, so they live under ``TYPE_CHECKING``; with
+``from __future__ import annotations`` every annotation is a lazy string and is
+never resolved at runtime. ``@runtime_checkable`` therefore verifies member
+*presence* (which is what the conformance test asserts), not signatures.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.context import ContextManager, PentestPhase, SessionState
+    from vulnclaw.agent.finding_parser import FindingParser
+    from vulnclaw.agent.llm_client import StreamSink
+    from vulnclaw.agent.runtime_state import AgentResult, RuntimeState
+    from vulnclaw.config.schema import VulnClawConfig
+
+
+@runtime_checkable
+class AgentContext(Protocol):
+    """The surface a helper module may rely on when handed the agent.
+
+    Any object passed to a helper as ``agent`` is expected to satisfy this
+    protocol. :class:`~vulnclaw.agent.core.AgentCore` satisfies it structurally;
+    a ``test_agent_context_protocol`` conformance test guards against drift.
+    Focused test doubles are intentionally *not* required to conform — they may
+    implement only the slice their unit under test exercises.
+    """
+
+    # ── Data the helpers read (and, for runtime/context, mutate) ──────────
+    runtime: RuntimeState
+    context: ContextManager
+    config: VulnClawConfig
+    mcp_manager: Any
+    _finding_parser: FindingParser
+    _kb_retriever: Any
+    _kb_context_cache: dict[Any, str]
+
+    @property
+    def session_state(self) -> SessionState:
+        """The current session state (shorthand for ``context.state``)."""
+        ...
+
+    # ── LLM client / credential plumbing ─────────────────────────────────
+    def _get_client(self) -> Any:
+        """Return the lazily-built, credential-resolved LLM client."""
+        ...
+
+    def rotate_api_key(self) -> bool:
+        """Advance to the next key in the failover pool; ``False`` if none."""
+        ...
+
+    # ── Tool + prompt construction the helpers call back into ────────────
+    def _build_openai_tools(self) -> list[dict]:
+        """Assemble the OpenAI function-calling schema (MCP + built-in)."""
+        ...
+
+    async def _execute_mcp_tool(self, tool_name: str, args: dict) -> str:
+        """Execute a tool via the MCP manager or the built-in tools."""
+        ...
+
+    def _build_system_prompt(
+        self,
+        target: Optional[str] = None,
+        auto_mode: bool = False,
+        user_input: Optional[str] = None,
+    ) -> str:
+        """Build the dynamic system prompt for the current turn."""
+        ...
+
+    def _build_round_context(self, round_num: int, max_rounds: int) -> str:
+        """Build the per-round context string for the auto loop."""
+        ...
+
+    # ── Input / output analysis callbacks ────────────────────────────────
+    def _detect_target(self, user_input: str) -> Optional[str]:
+        """Extract a target from user input, if any."""
+        ...
+
+    def _detect_phase(self, user_input: str) -> Optional[PentestPhase]:
+        """Detect the pentest phase implied by user input."""
+        ...
+
+    def _detect_phase_from_output(self, output: str) -> Optional[PentestPhase]:
+        """Detect a phase-transition signal in LLM output."""
+        ...
+
+    def _detect_attack_path(self, output: str) -> Optional[str]:
+        """Detect the canonical attack path/technique in LLM output."""
+        ...
+
+    def _is_meaningful_step(self, step: str) -> bool:
+        """Whether a step represents real progress (not a pure failure)."""
+        ...
+
+    def _is_completion_signal(self, output: str) -> bool:
+        """Whether LLM output signals task completion."""
+        ...
+
+    def _track_failed_target(self, response_text: str) -> Optional[str]:
+        """Record target-level failures; return a blocked hostname if any."""
+        ...
+
+    def _update_recon_dimension_completion(self, response: str) -> None:
+        """Auto-detect which recon dimensions have been explored."""
+        ...
+
+    async def _generate_attack_summary(self) -> str:
+        """Generate the attack-chain narrative for a cycle report."""
+        ...
+
+    # ── Runtime / reflexion lifecycle ────────────────────────────────────
+    def _reset_runtime_state(
+        self,
+        user_input: str = "",
+        detected_phase: Optional[PentestPhase] = None,
+    ) -> None:
+        """Reset per-run runtime state to avoid cross-run contamination."""
+        ...
+
+    def _save_reflexion_snapshot(self) -> None:
+        """Persist the current reflexion state onto the session snapshot."""
+        ...
+
+    # ── Loop entry point some helpers re-enter ───────────────────────────
+    async def auto_pentest(
+        self,
+        user_input: str,
+        target: Optional[str] = None,
+        max_rounds: int = 15,
+        on_step: Optional[Callable[[int, AgentResult], None]] = None,
+        *,
+        stream_sink: Optional[StreamSink] = None,
+    ) -> list[AgentResult]:
+        """Run the autonomous penetration-test loop."""
+        ...

--- a/vulnclaw/agent/anti_loop.py
+++ b/vulnclaw/agent/anti_loop.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 from vulnclaw.agent.context import PentestPhase
 
@@ -67,7 +71,7 @@ def is_completion_signal(output: str) -> bool:
     return any(signal in output for signal in completion_signals)
 
 
-def track_failed_target(agent, response_text: str) -> Optional[str]:
+def track_failed_target(agent: AgentContext, response_text: str) -> Optional[str]:
     """Track target-level failures and detect repeatedly failed targets."""
     hostname = None
     url_match = re.search(r'https?://([^\s/<>"\')\]]+)', response_text)

--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -12,7 +12,11 @@ import subprocess
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 from urllib.parse import urlparse
 
 from vulnclaw.agent.constraint_policy import validate_tool_action
@@ -84,7 +88,7 @@ LAB_MODE_PATTERNS: list[str] = [
 ]
 
 
-async def execute_mcp_tool(agent: Any, tool_name: str, args: dict[str, Any]) -> str:
+async def execute_mcp_tool(agent: AgentContext, tool_name: str, args: dict[str, Any]) -> str:
     """Execute a tool call via MCP manager or built-in tools."""
     session = getattr(agent, "session_state", None)
     constraints = getattr(session, "task_constraints", None)
@@ -199,7 +203,7 @@ async def execute_mcp_tool(agent: Any, tool_name: str, args: dict[str, Any]) -> 
         return f"[!] 工具执行错误 ({tool_name}): {e}"
 
 
-def enforce_port_constraints(agent: Any, ports: list[int], *, target: str = "") -> str | None:
+def enforce_port_constraints(agent: AgentContext, ports: list[int], *, target: str = "") -> str | None:
     """Return a user-facing violation message when requested ports are out of scope."""
     session = getattr(agent, "session_state", None)
     constraints = getattr(session, "task_constraints", None)
@@ -224,7 +228,7 @@ def enforce_port_constraints(agent: Any, ports: list[int], *, target: str = "") 
 
 
 def enforce_host_path_constraints(
-    agent: Any, *, host: str = "", path: str = "", target: str = ""
+    agent: AgentContext, *, host: str = "", path: str = "", target: str = ""
 ) -> str | None:
     """Return a user-facing violation when host/path are out of scope."""
     session = getattr(agent, "session_state", None)
@@ -679,7 +683,7 @@ def build_openai_tools(mcp_manager: Any) -> list[dict[str, Any]]:
     return tools
 
 
-async def execute_nmap(agent: Any, args: dict[str, Any]) -> str:
+async def execute_nmap(agent: AgentContext, args: dict[str, Any]) -> str:
     target = args.get("target", "").strip()
     if not target:
         return "[!] nmap_scan 需要 target 参数（目标 IP 或域名）"
@@ -918,7 +922,7 @@ def parse_nmap_xml(xml_output: str, target: str) -> str:
     return "\n".join(lines) or f"nmap 扫描完成（无输出）: {target}"
 
 
-def _resolve_python_execute_mode(agent: Any) -> str:
+def _resolve_python_execute_mode(agent: AgentContext) -> str:
     safety = getattr(agent.config, "safety", None)
     if safety is None:
         return "trusted-local"
@@ -940,7 +944,7 @@ def _validate_python_execute_mode(mode: str, code: str) -> str | None:
 
 
 def _write_python_audit(
-    agent: Any,
+    agent: AgentContext,
     *,
     purpose: str,
     code: str,
@@ -974,7 +978,7 @@ def _write_python_audit(
         return
 
 
-async def execute_python(agent: Any, args: dict[str, Any]) -> str:
+async def execute_python(agent: AgentContext, args: dict[str, Any]) -> str:
     code = args.get("code", "")
     purpose = args.get("purpose", "")
     if not code.strip():
@@ -1136,7 +1140,7 @@ async def execute_python(agent: Any, args: dict[str, Any]) -> str:
 
 
 def _sync_cookies_to_shared_jar(
-    agent: Any, cookies: list[tuple[str, str, str, str]]
+    agent: AgentContext, cookies: list[tuple[str, str, str, str]]
 ) -> None:
     """Copy session cookies into the agent's shared _fetch_cookies jar.
 
@@ -1163,7 +1167,7 @@ def _sync_cookies_to_shared_jar(
         pass
 
 
-async def execute_brute_force(agent: Any, args: dict[str, Any]) -> str:
+async def execute_brute_force(agent: AgentContext, args: dict[str, Any]) -> str:
     """Execute a login brute-force with automatic CSRF/session management.
 
     Handles the full flow in one call:

--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -16,6 +16,23 @@ from typing import Any
 from urllib.parse import urlparse
 
 from vulnclaw.agent.constraint_policy import validate_tool_action
+from vulnclaw.agent.network_scan import (
+    attach_network_scan_to_session,
+    build_nmap_command,
+    build_nmap_plan,
+    deescalate_nmap_argv,
+    nmap_failure_needs_deescalation,
+    nmap_has_raw_socket_access,
+    parse_nmap_xml_structured,
+    summarize_network_scan,
+    target_is_private_literal,
+    without_privileged_nmap_args,
+)
+from vulnclaw.intel.tools import (
+    INTEL_TOOL_NAMES,
+    dispatch_intel_tool,
+    intel_tool_schemas,
+)
 
 BLOCKED_PATTERNS: list[str] = [
     r"os\.\s*system\s*\(",
@@ -87,6 +104,9 @@ async def execute_mcp_tool(agent: Any, tool_name: str, args: dict[str, Any]) -> 
                     detail=json.dumps(args, ensure_ascii=False)[:500],
                 )
             return f"[constraint_violation] {tool_violation}"
+
+    if tool_name in INTEL_TOOL_NAMES:
+        return await dispatch_intel_tool(agent, tool_name, args)
 
     if tool_name == "python_execute":
         return await execute_python(agent, args)
@@ -410,6 +430,10 @@ def build_openai_tools(mcp_manager: Any) -> list[dict[str, Any]]:
                             "type": "integer",
                             "description": "扫描速度模板 0-5（默认4），数字越大越快但越容易被检测",
                         },
+                        "profile": {
+                            "type": "string",
+                            "description": "可选网络扫描画像：adaptive/fast/thorough/stealth。画像会联动调整端口、速度、服务探测与安全脚本。",
+                        },
                     },
                     "required": ["target"],
                 },
@@ -635,6 +659,8 @@ def build_openai_tools(mcp_manager: Any) -> list[dict[str, Any]]:
         }
     )
 
+    tools.extend(intel_tool_schemas())
+
     if mcp_manager:
         for schema in mcp_manager.get_tool_schemas():
             tools.append(
@@ -671,7 +697,7 @@ async def execute_nmap(agent: Any, args: dict[str, Any]) -> str:
         if ips:
             ip = ips[0][4][0]
             is_reserved, reason = is_reserved_ip(ip)
-            if is_reserved:
+            if is_reserved and not target_is_private_literal(target):
                 return (
                     f"[SKIP] 目标 {target} 解析到保留/内网地址 ({reason}, IP: {ip})\n"
                     f"跳过 nmap 扫描。建议直接通过 Web 指纹、目录枚举等方法收集信息，"
@@ -683,6 +709,7 @@ async def execute_nmap(agent: Any, args: dict[str, Any]) -> str:
     scan_type = args.get("scan_type", "top_ports")
     custom_ports = args.get("ports", "")
     timing = int(args.get("timing", 4))
+    profile = str(args.get("profile", "") or "").strip().lower()
 
     nmap_cmd = shutil.which("nmap")
     if not nmap_cmd:
@@ -697,27 +724,61 @@ async def execute_nmap(agent: Any, args: dict[str, Any]) -> str:
     if not nmap_cmd:
         return "[!] nmap 未安装或不在 PATH 中。请确认 nmap 已安装并加入系统 PATH。"
 
-    cmd = [nmap_cmd, "-v" if scan_type == "full" else "-q", f"-T{max(0, min(5, timing))}"]
-    if scan_type == "top_ports":
-        cmd.extend(["--top-ports", "100", "-oX", "-"])
-    elif scan_type == "syn":
-        cmd.extend(["-sS", "-oX", "-"])
-    elif scan_type == "tcp":
-        cmd.extend(["-sT", "-oX", "-"])
-    elif scan_type == "service":
-        cmd.extend(["-sV", "-oX", "-"])
-    elif scan_type == "os":
-        cmd.extend(["-O", "-oX", "-"])
-    elif scan_type == "vuln":
-        cmd.extend(["--script", "vuln", "-oX", "-"])
-    elif scan_type == "full":
-        cmd.extend(["-sS", "-O", "-sV", "--script", "default,safe", "-oX", "-"])
+    if profile:
+        plan = build_nmap_plan(
+            profile=profile,
+            scan_type=str(scan_type or ""),
+            ports=str(custom_ports or ""),
+            timing=timing,
+            prior_recon=getattr(getattr(agent, "session_state", None), "recon_data", {}),
+        )
+        privileged = nmap_has_raw_socket_access()
+        cmd = build_nmap_command(nmap_cmd, target, plan, privileged=privileged)
+        deescalated_note = (
+            ""
+            if privileged or plan.args == without_privileged_nmap_args(plan.args)
+            else "[i] 非管理员权限运行：已跳过操作系统指纹识别（-O），SYN 扫描降级为 connect 扫描（-sT）。\n"
+        )
     else:
-        cmd.extend(["-sV", "-oX", "-"])
+        plan = None
+        privileged = nmap_has_raw_socket_access()
+        deescalated_note = ""
+        cmd = [nmap_cmd, "-v" if scan_type == "full" else "-q", f"-T{max(0, min(5, timing))}"]
+        if scan_type == "top_ports":
+            cmd.extend(["--top-ports", "100", "-oX", "-"])
+        elif scan_type == "syn":
+            cmd.extend(["-sS" if privileged else "-sT", "-oX", "-"])
+            if not privileged:
+                deescalated_note = "[i] 非管理员权限运行：使用 connect 扫描（-sT）代替 SYN 扫描（-sS）。\n"
+        elif scan_type == "tcp":
+            cmd.extend(["-sT", "-oX", "-"])
+        elif scan_type == "service":
+            cmd.extend(["-sV", "-oX", "-"])
+        elif scan_type == "os":
+            if privileged:
+                cmd.extend(["-O", "-oX", "-"])
+            else:
+                cmd.extend(["-sV", "-oX", "-"])
+                deescalated_note = (
+                    "[i] 非管理员权限运行：操作系统指纹识别（-O）不可用，改用服务探测（-sV）。\n"
+                )
+        elif scan_type == "vuln":
+            cmd.extend(["--script", "vuln", "-oX", "-"])
+        elif scan_type == "full":
+            if privileged:
+                cmd.extend(["-sS", "-O", "-sV", "--script", "default,safe", "-oX", "-"])
+            else:
+                cmd.extend(["-sT", "-sV", "--script", "default,safe", "-oX", "-"])
+                deescalated_note = (
+                    "[i] 非管理员权限运行：已跳过操作系统指纹识别（-O），"
+                    "SYN 扫描降级为 connect 扫描（-sT）。\n"
+                )
+        else:
+            cmd.extend(["-sV", "-oX", "-"])
 
-    if custom_ports:
-        cmd.extend(["-p", custom_ports])
-    cmd.append(target)
+        if custom_ports:
+            cmd.extend(["-p", custom_ports])
+        cmd.append(target)
 
     try:
         kwargs: dict[str, Any] = {
@@ -733,6 +794,17 @@ async def execute_nmap(agent: Any, args: dict[str, Any]) -> str:
             startupinfo.wShowWindow = subprocess.SW_HIDE
             kwargs["startupinfo"] = startupinfo
         result = subprocess.run(cmd, **kwargs)
+        if (
+            result.returncode != 0
+            and not result.stdout
+            and nmap_failure_needs_deescalation(result.stderr or "")
+        ):
+            fallback_cmd = deescalate_nmap_argv(cmd)
+            if fallback_cmd != cmd:
+                fallback = subprocess.run(fallback_cmd, **kwargs)
+                if fallback.returncode == 0 or fallback.stdout:
+                    result = fallback
+                    deescalated_note = "[i] 权限错误后已使用非特权 nmap 参数重试。\n"
     except subprocess.TimeoutExpired:
         return "[!] nmap 扫描超时（120秒），请减少扫描范围或使用更快的 timing"
     except PermissionError:
@@ -742,7 +814,20 @@ async def execute_nmap(agent: Any, args: dict[str, Any]) -> str:
 
     if result.returncode != 0 and not result.stdout:
         return f"[!] nmap 扫描失败（{result.returncode}）: {result.stderr[:500]}"
-    return parse_nmap_xml(result.stdout or result.stderr, target)
+    output = result.stdout or result.stderr
+    human_summary = parse_nmap_xml(output, target)
+    structured = parse_nmap_xml_structured(output, target)
+    if getattr(agent, "session_state", None) is not None:
+        attach_network_scan_to_session(
+            agent.session_state,
+            structured,
+            profile=profile or str(scan_type or "top_ports"),
+            safe_probes=profile != "vuln",
+        )
+    if profile:
+        network_summary = summarize_network_scan(structured)
+        return f"{deescalated_note}{human_summary}\n\n{network_summary}"
+    return f"{deescalated_note}{human_summary}"
 
 
 def is_reserved_ip(ip: str) -> tuple[bool, str]:

--- a/vulnclaw/agent/constraint_policy.py
+++ b/vulnclaw/agent/constraint_policy.py
@@ -120,6 +120,13 @@ def infer_tool_action(tool_name: str, args: dict[str, object]) -> str:
     if normalized_tool in LOCAL_META_TOOLS:
         return "recon"  # 仅本地操作，配合 validate_tool_action 豁免
 
+    # Intel tools: read-only lookups (no target egress) and active recon
+    # (low-impact target/3rd-party contact) both classify as passive "recon".
+    from vulnclaw.intel.tools import READ_ONLY_INTEL_TOOLS, RECON_INTEL_TOOLS
+
+    if normalized_tool in READ_ONLY_INTEL_TOOLS or normalized_tool in RECON_INTEL_TOOLS:
+        return "recon"
+
     if normalized_tool == "nmap_scan":
         return "recon"
 

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -371,6 +371,7 @@ class AgentCore:
             auto_mode=auto_mode,
             user_input=user_input,
             kb_context=kb_context,
+            task_constraints=self.context.state.task_constraints,
         )
 
     def _get_active_skill_context(self, user_input: Optional[str] = None) -> Optional[str]:

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -62,6 +62,9 @@ class AgentCore:
         self.mcp_manager = mcp_manager
         self.context = ContextManager()
         self._client = None
+        # Failover key pool: prefer llm.api_keys, else the single llm.api_key.
+        self._key_pool = config.llm.key_pool()
+        self._key_index = 0
         self.runtime = RuntimeState()
         self._reset_runtime_state()
         # Optional KB retriever — lazily initialized on first use
@@ -228,6 +231,24 @@ class AgentCore:
         except Exception:
             pass
 
+    def _current_api_key(self) -> str:
+        """Return the static API key currently selected from the failover pool."""
+        if self._key_pool:
+            return self._key_pool[self._key_index]
+        return self.config.llm.api_key
+
+    def rotate_api_key(self) -> bool:
+        """Advance to the next key in the failover pool.
+
+        Invalidates the cached client so the next call rebuilds with the new
+        key. Returns False (no-op) when there is nothing to rotate to.
+        """
+        if len(self._key_pool) <= 1:
+            return False
+        self._key_index = (self._key_index + 1) % len(self._key_pool)
+        self._client = None
+        return True
+
     def _get_client(self):
         """Lazy-initialize OpenAI client with dynamic credential resolution.
 
@@ -261,7 +282,13 @@ class AgentCore:
                     raise RuntimeError("请安装 openai 包: pip install openai")
             return self._client
 
-        token = resolve_llm_token(llm)
+        auth_mode = str(getattr(llm, "auth_mode", "") or "static").strip().lower()
+        if auth_mode in ("", "static"):
+            # Respect the failover rotation index rather than always resolving
+            # the primary key, so rotate_api_key() actually switches keys.
+            token = self._current_api_key()
+        else:
+            token = resolve_llm_token(llm)
         if self._client is None:
             try:
                 self._client = make_openai_client(

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -125,6 +125,18 @@ class AgentCore:
         self.context.reset()
         self._reset_runtime_state()
 
+    def apply_config(self, config: VulnClawConfig) -> None:
+        """Adopt an updated config (e.g. after the in-REPL config editor).
+
+        The cached OpenAI client is bound to a specific ``base_url``, so drop it
+        and rebuild the failover key pool; the next call re-creates the client
+        with the new provider / model / key.
+        """
+        self.config = config
+        self._client = None
+        self._key_pool = config.llm.key_pool()
+        self._key_index = 0
+
     def _reset_runtime_state(
         self,
         user_input: str = "",

--- a/vulnclaw/agent/ctf_mode.py
+++ b/vulnclaw/agent/ctf_mode.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 
 def detect_flag_claim(output: str) -> Optional[str]:
@@ -22,7 +26,7 @@ def detect_flag_claim(output: str) -> Optional[str]:
     return None
 
 
-def update_ctf_state(agent, response_text: str, result_should_continue: bool) -> bool:
+def update_ctf_state(agent: AgentContext, response_text: str, result_should_continue: bool) -> bool:
     """Update flag claim/verification state and return should_continue."""
     if agent.runtime.claimed_flag and not agent.runtime.flag_verified:
         verification_markers = [

--- a/vulnclaw/agent/kb_context.py
+++ b/vulnclaw/agent/kb_context.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 from vulnclaw.kb.retriever import KnowledgeRetriever, RetrieverStatus
 
 logger = logging.getLogger(__name__)
 
 
-def _retriever_for(agent) -> Optional[KnowledgeRetriever]:
+def _retriever_for(agent: AgentContext) -> Optional[KnowledgeRetriever]:
     """Return the agent's KB retriever, lazily initializing it once.
 
     Returns None when the retriever cannot be constructed at all, so callers
@@ -27,7 +31,7 @@ def _retriever_for(agent) -> Optional[KnowledgeRetriever]:
     return agent._kb_retriever
 
 
-def build_kb_context(agent, user_input: Optional[str] = None) -> str:
+def build_kb_context(agent: AgentContext, user_input: Optional[str] = None) -> str:
     """Build knowledge-base context for prompt injection.
 
     Results are cached per agent for identical queries within a session so the

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -6,7 +6,11 @@ import asyncio
 import inspect
 import json
 import sys
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 from vulnclaw.agent.token_counter import estimate_tokens, truncate_messages
 from vulnclaw.agent.tool_call_manager import (
@@ -17,7 +21,7 @@ from vulnclaw.agent.tool_call_manager import (
 _CONTEXT_USABLE_RATIO = 0.9
 
 
-def _fit_context_window(agent: Any, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _fit_context_window(agent: AgentContext, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Truncate messages to fit the configured context window (90% usable budget)."""
     llm = getattr(agent, "config", None)
     llm = getattr(llm, "llm", None) if llm is not None else None
@@ -113,7 +117,7 @@ def _is_openai_reasoning_model(provider: str, model: str) -> bool:
 
 
 def build_chat_completion_kwargs(
-    agent: Any,
+    agent: AgentContext,
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None = None,
     *,
@@ -155,7 +159,7 @@ def build_chat_completion_kwargs(
 
 
 async def _call_with_persistent_retries(
-    agent: Any, request_fn, stage_label: str
+    agent: AgentContext, request_fn, stage_label: str
 ) -> tuple[Any, int]:
     """Keep retrying retriable LLM calls until success or manual interruption.
 
@@ -256,7 +260,7 @@ def _format_tool_results_fallback(
 
 
 async def call_llm(
-    agent: Any,
+    agent: AgentContext,
     system_prompt: str,
     *,
     stream_sink: Optional["StreamSink"] = None,
@@ -285,7 +289,7 @@ async def call_llm(
 
 
 async def call_llm_auto(
-    agent: Any,
+    agent: AgentContext,
     system_prompt: str,
     round_context: str,
     *,
@@ -550,7 +554,7 @@ def _assemble_tool_calls(tool_calls_chunks: list[dict]) -> list[Any]:
 
 
 async def call_llm_stream(
-    agent: Any,
+    agent: AgentContext,
     system_prompt: str,
     stream_sink: Optional["StreamSink"] = None,
 ) -> str:
@@ -664,7 +668,7 @@ async def call_llm_stream(
 
 
 async def call_llm_auto_stream(
-    agent: Any,
+    agent: AgentContext,
     system_prompt: str,
     round_context: str,
     stream_sink: Optional["StreamSink"] = None,

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -82,6 +82,28 @@ def _is_non_retriable_llm_error(error_text: str) -> bool:
     return any(marker in error_text for marker in hard_fail_markers)
 
 
+def _is_key_exhausted_error(error_text: str) -> bool:
+    """Return True for errors that mean the *current* API key is unusable.
+
+    These are rate-limit / quota / balance exhaustion signals where switching to
+    a different key is the right recovery. Covers OpenAI-style 429/quota plus
+    deepseek (402 insufficient balance) and zhipu (codes 1302/1113, 余额) errors.
+    """
+    exhausted_markers = [
+        "rate limit",
+        "rate_limit",
+        "too many requests",
+        "429",
+        "quota",
+        "insufficient balance",
+        "余额",  # zhipu/deepseek: account balance insufficient
+        "402",
+        "1302",  # zhipu: concurrency / rate limit
+        "1113",  # zhipu: account balance insufficient
+    ]
+    return any(marker in error_text for marker in exhausted_markers)
+
+
 def _is_openai_reasoning_model(provider: str, model: str) -> bool:
     """Return True for OpenAI models that use the newer reasoning parameter set."""
     if provider.lower() != "openai":
@@ -142,6 +164,9 @@ async def _call_with_persistent_retries(
     """
     loop = asyncio.get_running_loop()
     retry_attempts = 0
+    pool_size = len(getattr(agent, "_key_pool", None) or [])
+    can_rotate = pool_size > 1 and callable(getattr(agent, "rotate_api_key", None))
+    keys_tried: set[int] = set()
 
     while True:
         try:
@@ -163,7 +188,40 @@ async def _call_with_persistent_retries(
             raise
         except Exception as exc:
             error_text = str(exc).lower()
-            if _is_non_retriable_llm_error(error_text):
+            is_exhausted = _is_key_exhausted_error(error_text)
+            is_auth = _is_non_retriable_llm_error(error_text)
+
+            # Multi-key failover: rotate past a rate-limited / quota-drained /
+            # invalid key to the next one before falling back to plain retry.
+            if can_rotate and (is_exhausted or is_auth):
+                keys_tried.add(getattr(agent, "_key_index", 0))
+                if len(keys_tried) < pool_size:
+                    agent.rotate_api_key()
+                    retry_attempts += 1
+                    print(
+                        f"[!] {stage_label} 当前密钥失败 ({exc})，切换到下一个 API 密钥并重试...",
+                        file=sys.stdout,
+                        flush=True,
+                    )
+                    continue
+                # Every key has now failed in this burst.
+                if is_auth and not is_exhausted:
+                    # All keys are invalid/unauthorized -> nothing to recover.
+                    raise
+                # All keys rate-limited: keep cycling, but back off first so we
+                # never hard-fail on transient quota limits.
+                keys_tried.clear()
+                agent.rotate_api_key()
+                retry_attempts += 1
+                print(
+                    f"[!] {stage_label} 所有 API 密钥均已限流，第 {retry_attempts} 次重连尝试中... (5s 后重试)",
+                    file=sys.stdout,
+                    flush=True,
+                )
+                await asyncio.sleep(5)
+                continue
+
+            if is_auth and not is_exhausted:
                 raise
 
             retry_attempts += 1
@@ -207,8 +265,6 @@ async def call_llm(
     if stream_sink is not None:
         return await call_llm_stream(agent, system_prompt, stream_sink)
 
-    client = agent._get_client()
-
     messages = [{"role": "system", "content": system_prompt}]
     messages.extend(agent.context.get_messages())
     messages = _fit_context_window(agent, messages)
@@ -218,7 +274,7 @@ async def call_llm(
 
     response, retry_attempts = await _call_with_persistent_retries(
         agent,
-        lambda: client.chat.completions.create(**kwargs),
+        lambda: agent._get_client().chat.completions.create(**kwargs),
         "单轮",
     )
 
@@ -239,8 +295,6 @@ async def call_llm_auto(
     if stream_sink is not None:
         return await call_llm_auto_stream(agent, system_prompt, round_context, stream_sink)
 
-    client = agent._get_client()
-
     messages = [{"role": "system", "content": system_prompt}]
     messages.extend(agent.context.get_messages())
     messages.append({"role": "user", "content": round_context})
@@ -251,7 +305,7 @@ async def call_llm_auto(
 
     response, retry_attempts = await _call_with_persistent_retries(
         agent,
-        lambda: client.chat.completions.create(**kwargs),
+        lambda: agent._get_client().chat.completions.create(**kwargs),
         "自主循环",
     )
 
@@ -323,7 +377,7 @@ async def call_llm_auto(
             kwargs["messages"] = _fit_context_window(agent, messages)
             response2, second_retry_attempts = await _call_with_persistent_retries(
                 agent,
-                lambda: client.chat.completions.create(**kwargs),
+                lambda: agent._get_client().chat.completions.create(**kwargs),
                 "工具总结",
             )
             final_text = extract_response(response2.choices[0].message)
@@ -601,7 +655,7 @@ async def call_llm_stream(
     # Use existing call_llm as fallback
     response_fallback, _ = await _call_with_persistent_retries(
         agent,
-        lambda: client.chat.completions.create(**kwargs),
+        lambda: agent._get_client().chat.completions.create(**kwargs),
         "单轮",
     )
 

--- a/vulnclaw/agent/loop_controller.py
+++ b/vulnclaw/agent/loop_controller.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import re
 from collections import Counter
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 from vulnclaw.agent.constraint_policy import validate_phase_transition
 from vulnclaw.agent.context import PentestPhase
@@ -21,11 +25,11 @@ from vulnclaw.agent.runtime_state import AgentResult, PersistentCycleResult
 RECON_MIN_ROUNDS = 8
 
 
-def _reasoning_enabled(agent: Any) -> bool:
+def _reasoning_enabled(agent: AgentContext) -> bool:
     return getattr(getattr(agent.config, "session", None), "reasoning_state_enabled", True)
 
 
-def _sync_reasoning_path(agent: Any, path_name: str, *, success: bool) -> None:
+def _sync_reasoning_path(agent: AgentContext, path_name: str, *, success: bool) -> None:
     """把识别到的攻击路径落进结构化推理状态，并刷新优先级。"""
     if not path_name or not _reasoning_enabled(agent):
         return
@@ -43,7 +47,7 @@ def _sync_reasoning_path(agent: Any, path_name: str, *, success: bool) -> None:
     reasoning.auto_prioritize()
 
 
-def _sync_reasoning_constraint(agent: Any, path_name: str, category: FailureCategory) -> None:
+def _sync_reasoning_constraint(agent: AgentContext, path_name: str, category: FailureCategory) -> None:
     """把识别到的障碍（WAF/过滤等）落进结构化推理状态，描述保持稳定以便去重。"""
     if not _reasoning_enabled(agent):
         return
@@ -65,7 +69,7 @@ def _sync_reasoning_constraint(agent: Any, path_name: str, category: FailureCate
     )
 
 
-def _configure_reflexion(agent: Any) -> None:
+def _configure_reflexion(agent: AgentContext) -> None:
     reflexion = getattr(agent.runtime, "reflexion", None)
     session = getattr(agent.config, "session", None)
     if not reflexion or not session:
@@ -81,7 +85,7 @@ def _configure_reflexion(agent: Any) -> None:
 
 
 async def auto_pentest(
-    agent: Any,
+    agent: AgentContext,
     user_input: str,
     target: str | None = None,
     max_rounds: int = 15,
@@ -286,7 +290,7 @@ async def auto_pentest(
 
 
 async def persistent_pentest(
-    agent: Any,
+    agent: AgentContext,
     user_input: str,
     target: str | None = None,
     rounds_per_cycle: int = 100,

--- a/vulnclaw/agent/network_scan.py
+++ b/vulnclaw/agent/network_scan.py
@@ -1,0 +1,564 @@
+"""Network scan planning and weak-link analysis helpers."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from vulnclaw.agent.context import (
+    PentestPhase,
+    SessionState,
+    StepStatus,
+    VulnerabilityFinding,
+)
+
+NETWORK_SCAN_PROFILES = {"adaptive", "fast", "thorough", "stealth"}
+
+_PRIVILEGED_NMAP_FLAGS = frozenset({"-O", "--osscan-guess"})
+_NMAP_PRIVILEGE_ERRORS = (
+    "requires root privileges",
+    "requires administrator privileges",
+    "operation not permitted",
+)
+
+
+def nmap_has_raw_socket_access() -> bool:
+    """Return True when nmap can use raw sockets / OS fingerprinting on this host."""
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            return bool(ctypes.windll.shell32.IsUserAnAdmin())
+        except Exception:
+            return False
+    try:
+        return os.geteuid() == 0
+    except AttributeError:
+        return False
+
+
+def without_privileged_nmap_args(args: tuple[str, ...]) -> tuple[str, ...]:
+    """Drop root-only nmap flags and downgrade SYN scans to connect scans."""
+    result: list[str] = []
+    for arg in args:
+        if arg in _PRIVILEGED_NMAP_FLAGS:
+            continue
+        if arg == "-sS":
+            if "-sT" not in args and "-sT" not in result:
+                result.append("-sT")
+            continue
+        result.append(arg)
+    return tuple(result)
+
+
+def deescalate_nmap_argv(cmd: list[str]) -> list[str]:
+    """Return a copy of an nmap argv list safe for unprivileged execution."""
+    if not cmd:
+        return cmd
+    nmap_cmd, *rest = cmd
+    args: list[str] = []
+    index = 0
+    while index < len(rest):
+        arg = rest[index]
+        if arg in _PRIVILEGED_NMAP_FLAGS:
+            index += 1
+            continue
+        if arg == "-sS":
+            if "-sT" not in rest and "-sT" not in args:
+                args.append("-sT")
+            index += 1
+            continue
+        args.append(arg)
+        index += 1
+    return [nmap_cmd, *args]
+
+
+def nmap_failure_needs_deescalation(stderr: str) -> bool:
+    lowered = (stderr or "").lower()
+    return any(message in lowered for message in _NMAP_PRIVILEGE_ERRORS)
+
+
+@dataclass(frozen=True)
+class NmapPlan:
+    profile: str
+    scan_type: str
+    ports: str
+    timing: int
+    args: tuple[str, ...]
+    safe_probe: bool = True
+
+
+@dataclass(frozen=True)
+class WifiScanTarget:
+    interface: str
+    address: str
+    cidr: str
+
+
+RISK_RULES: list[dict[str, Any]] = [
+    {
+        "ports": {23},
+        "services": {"telnet"},
+        "severity": "High",
+        "risk": "unencrypted_protocol",
+        "reason": "Telnet exposes plaintext authentication and management traffic.",
+        "next_action": "Confirm banner and replace with SSH or restrict access.",
+    },
+    {
+        "ports": {21},
+        "services": {"ftp"},
+        "severity": "Medium",
+        "risk": "legacy_file_transfer",
+        "reason": "FTP is commonly misconfigured for anonymous or weak authentication.",
+        "next_action": "Check banner and anonymous-login exposure without brute force.",
+    },
+    {
+        "ports": {135, 139, 445},
+        "services": {"microsoft-ds", "netbios-ssn", "smb"},
+        "severity": "Medium",
+        "risk": "exposed_windows_file_sharing",
+        "reason": "SMB/NetBIOS exposure often leaks host, share, or domain information.",
+        "next_action": "Run safe SMB enumeration scripts and verify patch posture.",
+    },
+    {
+        "ports": {3389},
+        "services": {"ms-wbt-server", "rdp"},
+        "severity": "High",
+        "risk": "remote_desktop_exposed",
+        "reason": "RDP is a high-value remote access surface.",
+        "next_action": "Confirm NLA/TLS posture and restrict exposure.",
+    },
+    {
+        "ports": {1433, 1521, 3306, 5432, 27017},
+        "services": {"mysql", "postgresql", "ms-sql-s", "oracle", "mongodb"},
+        "severity": "High",
+        "risk": "database_exposed",
+        "reason": "Database services should rarely be broadly reachable.",
+        "next_action": "Confirm service/version and access controls without credential attacks.",
+    },
+    {
+        "ports": {161},
+        "services": {"snmp"},
+        "severity": "Medium",
+        "risk": "snmp_exposed",
+        "reason": "SNMP may disclose system and network details.",
+        "next_action": "Run safe SNMP discovery and verify community-string exposure only if permitted.",
+    },
+    {
+        "ports": {80, 443, 8000, 8080, 8443, 8888},
+        "services": {"http", "https", "http-proxy"},
+        "severity": "Low",
+        "risk": "web_surface",
+        "reason": "Web service requires application-layer fingerprinting.",
+        "next_action": "Collect title, headers, TLS details, and obvious admin paths.",
+    },
+]
+
+
+def build_nmap_plan(
+    *,
+    profile: str = "adaptive",
+    scan_type: str = "",
+    ports: str = "",
+    timing: int | None = None,
+    prior_recon: dict[str, Any] | None = None,
+) -> NmapPlan:
+    """Build a deterministic nmap plan from profile and explicit overrides."""
+    normalized = (profile or "adaptive").strip().lower()
+    if normalized not in NETWORK_SCAN_PROFILES:
+        normalized = "adaptive"
+
+    explicit_scan_type = (scan_type or "").strip().lower()
+    explicit_ports = (ports or "").strip()
+    timing_override = max(0, min(5, int(timing))) if timing is not None else None
+
+    if normalized == "fast":
+        plan = NmapPlan(
+            profile=normalized,
+            scan_type=explicit_scan_type or "service",
+            ports=explicit_ports or "1-1000",
+            timing=timing_override if timing_override is not None else 4,
+            args=("-q", "-sV", "-F"),
+        )
+    elif normalized == "thorough":
+        plan = NmapPlan(
+            profile=normalized,
+            scan_type=explicit_scan_type or "full",
+            ports=explicit_ports or "1-65535",
+            timing=timing_override if timing_override is not None else 3,
+            args=("-v", "-sV", "-O", "--script", "default,safe"),
+        )
+    elif normalized == "stealth":
+        plan = NmapPlan(
+            profile=normalized,
+            scan_type=explicit_scan_type or "syn",
+            ports=explicit_ports or "1-1000",
+            timing=timing_override if timing_override is not None else 1,
+            args=("-q", "-sS", "-f"),
+        )
+    else:
+        adaptive_ports = explicit_ports or _ports_from_prior_recon(prior_recon) or "1-1000"
+        plan = NmapPlan(
+            profile=normalized,
+            scan_type=explicit_scan_type or "service",
+            ports=adaptive_ports,
+            timing=timing_override if timing_override is not None else 3,
+            args=("-q", "-sV", "--script", "safe"),
+        )
+
+    return plan
+
+
+def build_nmap_command(
+    nmap_cmd: str,
+    target: str,
+    plan: NmapPlan,
+    *,
+    privileged: bool | None = None,
+) -> list[str]:
+    """Render a safe argv list for subprocess-based nmap execution."""
+    args = plan.args
+    if privileged is None:
+        privileged = nmap_has_raw_socket_access()
+    if not privileged:
+        args = without_privileged_nmap_args(args)
+    cmd = [nmap_cmd, *args, f"-T{plan.timing}", "-oX", "-"]
+    if plan.ports:
+        cmd.extend(["-p", plan.ports])
+    cmd.append(target)
+    return cmd
+
+
+def detect_connected_wifi_target() -> WifiScanTarget:
+    """Detect the active Wi-Fi IPv4 network to use as the default scan target."""
+    candidates = _wifi_interfaces()
+    if not candidates:
+        raise RuntimeError(
+            "No wireless interface was detected. Provide an explicit target, "
+            "for example: vulnclaw network-scan 192.168.1.0/24"
+        )
+
+    for interface in candidates:
+        if not _interface_is_up(interface):
+            continue
+        target = _interface_ipv4_network(interface)
+        if target is not None:
+            return target
+
+    raise RuntimeError(
+        "A wireless interface was detected, but no active IPv4 Wi-Fi network was found. "
+        "Connect to Wi-Fi or provide an explicit target."
+    )
+
+
+def parse_nmap_xml_structured(xml_output: str, target: str) -> dict[str, Any]:
+    """Parse nmap XML into structured hosts, services, and weak-link hints."""
+    if not xml_output or "<nmaprun" not in xml_output:
+        return {
+            "target": target,
+            "hosts": [],
+            "open_services": [],
+            "weak_links": [],
+            "error": "nmap XML output was not available",
+        }
+
+    try:
+        root = ET.fromstring(xml_output)
+    except ET.ParseError as exc:
+        return {
+            "target": target,
+            "hosts": [],
+            "open_services": [],
+            "weak_links": [],
+            "error": f"nmap XML parse failed: {exc}",
+        }
+
+    hosts: list[dict[str, Any]] = []
+    open_services: list[dict[str, Any]] = []
+    weak_links: list[dict[str, Any]] = []
+
+    for host in root.findall(".//host"):
+        addrs = [a.get("addr", "") for a in host.findall("address") if a.get("addr")]
+        hostnames = [h.get("name", "") for h in host.findall(".//hostname") if h.get("name")]
+        status = host.find("status")
+        host_ip = addrs[0] if addrs else target
+        host_record = {
+            "address": host_ip,
+            "hostnames": hostnames,
+            "status": status.get("state", "unknown") if status is not None else "unknown",
+            "ports": [],
+        }
+
+        for port in host.findall(".//port"):
+            state = port.find("state")
+            if state is None or state.get("state") != "open":
+                continue
+            service = port.find("service")
+            scripts = [
+                {"id": script.get("id", ""), "output": script.get("output", "")}
+                for script in port.findall("script")
+            ]
+            service_record = {
+                "host": host_ip,
+                "port": _safe_int(port.get("portid", "")),
+                "protocol": port.get("protocol", "tcp"),
+                "state": state.get("state", "open"),
+                "service": service.get("name", "") if service is not None else "",
+                "product": service.get("product", "") if service is not None else "",
+                "version": service.get("version", "") if service is not None else "",
+                "extrainfo": service.get("extrainfo", "") if service is not None else "",
+                "scripts": scripts,
+            }
+            host_record["ports"].append(service_record)
+            open_services.append(service_record)
+            weak_link = classify_weak_link(service_record)
+            if weak_link:
+                weak_links.append(weak_link)
+
+        hosts.append(host_record)
+
+    return {
+        "target": target,
+        "hosts": hosts,
+        "open_services": open_services,
+        "weak_links": sorted(weak_links, key=lambda item: _severity_rank(item["severity"])),
+    }
+
+
+def classify_weak_link(service: dict[str, Any]) -> dict[str, Any] | None:
+    port = int(service.get("port") or 0)
+    name = str(service.get("service", "") or "").lower()
+    for rule in RISK_RULES:
+        if port in rule["ports"] or name in rule["services"]:
+            host = service.get("host", "")
+            return {
+                "host": host,
+                "port": port,
+                "protocol": service.get("protocol", "tcp"),
+                "service": service.get("service", ""),
+                "product": service.get("product", ""),
+                "version": service.get("version", ""),
+                "severity": rule["severity"],
+                "risk": rule["risk"],
+                "reason": rule["reason"],
+                "next_action": rule["next_action"],
+                "target": f"{host}:{port}" if host and port else host or str(port),
+            }
+    return None
+
+
+def summarize_network_scan(structured: dict[str, Any], *, max_items: int = 8) -> str:
+    services = structured.get("open_services", [])
+    weak_links = structured.get("weak_links", [])
+    lines = [
+        "Network scan weak-link summary",
+        f"- Open services: {len(services)}",
+        f"- Weak-link candidates: {len(weak_links)}",
+    ]
+    for item in weak_links[:max_items]:
+        product = " ".join(
+            part for part in (item.get("product", ""), item.get("version", "")) if part
+        )
+        product_suffix = f" ({product})" if product else ""
+        lines.append(
+            f"- {item['severity']}: {item['target']} {item.get('service', '')}{product_suffix} "
+            f"- {item['risk']}: {item['reason']}"
+        )
+    return "\n".join(lines)
+
+
+def attach_network_scan_to_session(
+    session: SessionState,
+    structured: dict[str, Any],
+    *,
+    profile: str,
+    safe_probes: bool = True,
+) -> None:
+    """Persist network scan facts and candidate weak-link findings into session state."""
+    if not structured:
+        return
+
+    session.phase = PentestPhase.VULN_DISCOVERY
+    network_scans = session.recon_data.setdefault("network_scans", [])
+    network_scans.append(
+        {
+            "target": structured.get("target", session.target or ""),
+            "profile": profile,
+            "safe_probes": safe_probes,
+            "open_services": structured.get("open_services", []),
+            "weak_links": structured.get("weak_links", []),
+        }
+    )
+    session.recon_data["network_services"] = _dedupe_services(
+        session.recon_data.get("network_services", []), structured.get("open_services", [])
+    )
+
+    for weak_link in structured.get("weak_links", []):
+        finding = VulnerabilityFinding(
+            title=f"Exposed {weak_link.get('service') or weak_link.get('risk')} on {weak_link.get('target')}",
+            severity=weak_link.get("severity", "Medium"),
+            vuln_type=weak_link.get("risk", "network_exposure"),
+            description=weak_link.get("reason", ""),
+            evidence=(
+                f"nmap identified {weak_link.get('service') or 'service'} on "
+                f"{weak_link.get('target')} during {profile} network scan."
+            ),
+            remediation=weak_link.get("next_action", ""),
+            evidence_level="L2",
+            lifecycle_status="pending_verification",
+            finding_id=(
+                f"network:{weak_link.get('risk', 'network_exposure')}:"
+                f"{weak_link.get('host', '')}:{weak_link.get('port', '')}"
+            )[:50],
+        )
+        session.add_finding(finding)
+
+    session.add_step(
+        f"network_scan:{structured.get('target', session.target or '')}:{profile}",
+        action="network scan",
+        target=str(structured.get("target", session.target or "")),
+        result=(
+            f"{len(structured.get('open_services', []))} open services, "
+            f"{len(structured.get('weak_links', []))} weak-link candidates"
+        ),
+        status=StepStatus.SUCCESS,
+        detail=json.dumps(structured, ensure_ascii=False)[:4000],
+    )
+
+
+def target_is_private_literal(target: str) -> bool:
+    """Return true when the user explicitly supplied a private/reserved IP or network."""
+    text = (target or "").strip()
+    try:
+        if "/" in text:
+            network = ipaddress.ip_network(text, strict=False)
+            return network.is_private or network.is_loopback or network.is_link_local
+        addr = ipaddress.ip_address(text)
+        return addr.is_private or addr.is_loopback or addr.is_link_local
+    except ValueError:
+        return False
+
+
+def _wifi_interfaces() -> list[str]:
+    interfaces: list[str] = []
+    try:
+        result = subprocess.run(
+            ["iw", "dev"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("Interface "):
+                    iface = stripped.split(maxsplit=1)[1].strip()
+                    if iface and iface not in interfaces:
+                        interfaces.append(iface)
+    except Exception:
+        pass
+
+    sys_net = Path("/sys/class/net")
+    try:
+        for path in sorted(sys_net.iterdir()):
+            if (path / "wireless").exists() and path.name not in interfaces:
+                interfaces.append(path.name)
+    except Exception:
+        pass
+
+    return interfaces
+
+
+def _interface_is_up(interface: str) -> bool:
+    try:
+        state = (Path("/sys/class/net") / interface / "operstate").read_text(
+            encoding="utf-8"
+        )
+        return state.strip().lower() in {"up", "unknown"}
+    except Exception:
+        return True
+
+
+def _interface_ipv4_network(interface: str) -> WifiScanTarget | None:
+    try:
+        result = subprocess.run(
+            ["ip", "-o", "-4", "addr", "show", "dev", interface],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if "inet" not in parts:
+            continue
+        inet_index = parts.index("inet")
+        if inet_index + 1 >= len(parts):
+            continue
+        cidr = parts[inet_index + 1]
+        try:
+            iface = ipaddress.ip_interface(cidr)
+        except ValueError:
+            continue
+        network = iface.network
+        if network.prefixlen >= 31:
+            continue
+        return WifiScanTarget(
+            interface=interface,
+            address=str(iface.ip),
+            cidr=str(network),
+        )
+
+    return None
+
+
+def _ports_from_prior_recon(prior_recon: dict[str, Any] | None) -> str:
+    if not prior_recon:
+        return ""
+    ports: set[int] = set()
+    for service in prior_recon.get("network_services", []) or []:
+        if not isinstance(service, dict):
+            continue
+        port = _safe_int(service.get("port", ""))
+        if port:
+            ports.add(port)
+    if not ports:
+        return ""
+    return ",".join(str(port) for port in sorted(ports))
+
+
+def _dedupe_services(existing: list[Any], current: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_key: dict[str, dict[str, Any]] = {}
+    for item in existing + current:
+        if not isinstance(item, dict):
+            continue
+        key = f"{item.get('host', '')}:{item.get('port', '')}:{item.get('protocol', '')}"
+        by_key[key] = item
+    return list(by_key.values())
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _severity_rank(severity: str) -> int:
+    return {"Critical": 0, "High": 1, "Medium": 2, "Low": 3, "Info": 4}.get(severity, 5)

--- a/vulnclaw/agent/parallel_agents.py
+++ b/vulnclaw/agent/parallel_agents.py
@@ -1,0 +1,246 @@
+"""Bounded multi-agent coordination for parallel attack-surface work."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from vulnclaw.agent.context import SessionState, VulnerabilityFinding
+
+
+@dataclass(frozen=True)
+class AttackSurface:
+    """A concrete surface a child agent can investigate."""
+
+    target: str
+    kind: str = "surface"
+    reason: str = ""
+
+
+@dataclass
+class ParallelAgentRunResult:
+    """Summary of a parallel multi-agent run."""
+
+    root_results: list[Any] = field(default_factory=list)
+    worker_results: list[Any] = field(default_factory=list)
+    surfaces: list[AttackSurface] = field(default_factory=list)
+    waves_completed: int = 0
+
+
+AgentFactory = Callable[[], Any]
+
+
+def extract_attack_surfaces(session: SessionState, *, limit: int = 20) -> list[AttackSurface]:
+    """Extract high-value concrete surfaces from the current session state."""
+    surfaces: list[AttackSurface] = []
+
+    for service in session.recon_data.get("network_services", []) or []:
+        if not isinstance(service, dict):
+            continue
+        host = str(service.get("host", "") or "").strip()
+        port = service.get("port")
+        proto = str(service.get("protocol", "tcp") or "tcp").strip()
+        service_name = str(service.get("service", "") or "").strip()
+        if not host or not port:
+            continue
+        surfaces.append(
+            AttackSurface(
+                target=f"{host}:{port}",
+                kind="service",
+                reason=f"{proto}/{service_name or 'unknown'} discovered during network scan",
+            )
+        )
+
+    for scan in session.recon_data.get("network_scans", []) or []:
+        if not isinstance(scan, dict):
+            continue
+        for weak_link in scan.get("weak_links", []) or []:
+            if not isinstance(weak_link, dict):
+                continue
+            target = str(weak_link.get("target", "") or "").strip()
+            if target:
+                surfaces.append(
+                    AttackSurface(
+                        target=target,
+                        kind="weak_link",
+                        reason=str(weak_link.get("reason", "") or "weak-link candidate"),
+                    )
+                )
+
+    for key, kind in (("subdomains", "host"), ("paths", "path")):
+        for value in session.recon_data.get(key, []) or []:
+            target = str(value).strip()
+            if target:
+                surfaces.append(AttackSurface(target=target, kind=kind, reason=f"recon {key}"))
+
+    for finding in session.findings:
+        location = _extract_location(finding)
+        if location:
+            surfaces.append(
+                AttackSurface(
+                    target=location,
+                    kind="finding",
+                    reason=f"{finding.title} ({finding.verification_status})",
+                )
+            )
+
+    return _dedupe_surfaces(surfaces)[:limit]
+
+
+async def run_parallel_pentest(
+    root_agent: Any,
+    *,
+    agent_factory: AgentFactory,
+    user_input: str,
+    target: str,
+    discovery_rounds: int = 1,
+    worker_rounds: int = 3,
+    max_agents: int = 3,
+    max_depth: int = 1,
+    surface_limit: int = 20,
+    stream_sink: Any = None,
+) -> ParallelAgentRunResult:
+    """Run a root discovery pass, then fan out bounded child agents by surface."""
+    discovery_rounds = max(1, discovery_rounds)
+    worker_rounds = max(1, worker_rounds)
+    max_agents = max(1, max_agents)
+    max_depth = max(1, max_depth)
+
+    summary = ParallelAgentRunResult()
+    summary.root_results = await root_agent.auto_pentest(
+        user_input,
+        target=target,
+        max_rounds=discovery_rounds,
+        stream_sink=stream_sink,
+    )
+
+    seen: set[str] = set()
+    for depth in range(1, max_depth + 1):
+        surfaces = [
+            surface
+            for surface in extract_attack_surfaces(root_agent.session_state, limit=surface_limit)
+            if surface.target not in seen
+        ][:max_agents]
+        if not surfaces:
+            break
+
+        for surface in surfaces:
+            seen.add(surface.target)
+        summary.surfaces.extend(surfaces)
+
+        worker_results = await _run_surface_wave(
+            root_agent,
+            agent_factory=agent_factory,
+            surfaces=surfaces,
+            worker_rounds=worker_rounds,
+        )
+        summary.worker_results.extend(worker_results)
+        summary.waves_completed = depth
+
+    return summary
+
+
+async def _run_surface_wave(
+    root_agent: Any,
+    *,
+    agent_factory: AgentFactory,
+    surfaces: list[AttackSurface],
+    worker_rounds: int,
+) -> list[Any]:
+    semaphore = asyncio.Semaphore(max(1, len(surfaces)))
+
+    async def _run_one(surface: AttackSurface) -> Any:
+        async with semaphore:
+            child = agent_factory()
+            _seed_child_session(child.session_state, root_agent.session_state, surface)
+            prompt = _surface_prompt(surface, root_agent.session_state)
+            result = await child.auto_pentest(
+                prompt,
+                target=root_agent.session_state.target,
+                max_rounds=worker_rounds,
+            )
+            merge_session_state(root_agent.session_state, child.session_state)
+            return {"surface": surface, "results": result}
+
+    return await asyncio.gather(*(_run_one(surface) for surface in surfaces))
+
+
+def merge_session_state(parent: SessionState, child: SessionState) -> None:
+    """Merge child findings, recon data, notes, and steps into a parent session."""
+    for finding in child.findings:
+        parent.add_finding(finding)
+
+    for key, value in child.recon_data.items():
+        existing = parent.recon_data.get(key)
+        if isinstance(value, list):
+            if not isinstance(existing, list):
+                parent.recon_data[key] = list(value)
+            else:
+                parent.recon_data[key] = existing + [item for item in value if item not in existing]
+        elif isinstance(value, dict):
+            merged = dict(existing) if isinstance(existing, dict) else {}
+            merged.update(value)
+            parent.recon_data[key] = merged
+        elif key not in parent.recon_data or not parent.recon_data[key]:
+            parent.recon_data[key] = value
+
+    for note in child.notes:
+        if note not in parent.notes:
+            parent.notes.append(note)
+    for step in child.executed_steps:
+        if step not in parent.executed_steps:
+            parent.executed_steps.append(step)
+    for record in child.step_records:
+        if record not in parent.step_records:
+            parent.step_records.append(record)
+
+
+def _seed_child_session(child: SessionState, parent: SessionState, surface: AttackSurface) -> None:
+    child.target = parent.target
+    child.phase = parent.phase
+    child.task_constraints = parent.task_constraints.model_copy(deep=True)
+    child.recon_data = copy.deepcopy(parent.recon_data)
+    child.resume_summary = (
+        f"Parallel worker assigned to {surface.kind} {surface.target}. "
+        f"Reason: {surface.reason}. Preserve scope constraints."
+    )
+
+
+def _surface_prompt(surface: AttackSurface, session: SessionState) -> str:
+    constraints = session.task_constraints.to_prompt_block()
+    constraints_suffix = f"\n\n{constraints}" if constraints else ""
+    return (
+        f"Parallel worker task for authorized testing of attack surface {surface.target}. "
+        f"Surface type: {surface.kind}. Reason: {surface.reason}. "
+        "Investigate this surface only. Record concrete evidence, candidate findings, "
+        "safe verification results, and new surfaces discovered. "
+        "Do not brute force credentials, run destructive payloads, or perform post-exploitation "
+        "unless the inherited task constraints explicitly allow exploit actions."
+        f"{constraints_suffix}"
+    )
+
+
+def _dedupe_surfaces(surfaces: list[AttackSurface]) -> list[AttackSurface]:
+    seen: set[str] = set()
+    deduped: list[AttackSurface] = []
+    for surface in surfaces:
+        key = surface.target.strip().lower()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(surface)
+    return deduped
+
+
+def _extract_location(finding: VulnerabilityFinding) -> str:
+    text = f"{finding.evidence or ''}\n{finding.description or ''}"
+    url_match = re.search(r"https?://[^\s<>'\")\]]+", text)
+    if url_match:
+        return url_match.group(0)
+    host_port_match = re.search(r"\b(?:\d{1,3}\.){3}\d{1,3}:\d{1,5}\b", text)
+    if host_port_match:
+        return host_port_match.group(0)
+    return ""

--- a/vulnclaw/agent/prompt_context.py
+++ b/vulnclaw/agent/prompt_context.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
 
 
-def build_round_context(agent: Any, round_num: int, max_rounds: int) -> str:
+
+def build_round_context(agent: AgentContext, round_num: int, max_rounds: int) -> str:
     """Build context string for the current round in auto loop."""
     state = agent.context.state
     constraints_summary = ""
@@ -319,7 +323,7 @@ def build_round_context(agent: Any, round_num: int, max_rounds: int) -> str:
     )
 
 
-async def generate_attack_summary(agent: Any) -> str:
+async def generate_attack_summary(agent: AgentContext) -> str:
     """Generate a detailed attack path summary for the cycle report."""
     state = agent.context.state
 

--- a/vulnclaw/agent/recon_tools.py
+++ b/vulnclaw/agent/recon_tools.py
@@ -20,7 +20,11 @@ import json
 import re
 import socket
 from datetime import datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 from urllib.parse import urljoin, urlparse
 
 from vulnclaw.agent.builtin_tools import enforce_host_path_constraints
@@ -101,7 +105,7 @@ _SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 
-def _get_recon_cfg(agent: Any) -> Any:
+def _get_recon_cfg(agent: AgentContext) -> Any:
     from vulnclaw.config.schema import ReconConfig
 
     cfg = getattr(getattr(agent, "config", None), "recon", None)
@@ -297,7 +301,7 @@ def _make_client(cfg: Any):
     return httpx.AsyncClient(verify=False, timeout=cfg.http_timeout, follow_redirects=True)
 
 
-async def execute_space_search(agent: Any, args: dict[str, Any]) -> str:
+async def execute_space_search(agent: AgentContext, args: dict[str, Any]) -> str:
     """统一空间测绘查询。engine ∈ {fofa,hunter,quake,shodan,zoomeye,zerozone,all}。"""
     cfg = _get_recon_cfg(agent)
     engine = str(args.get("engine", "fofa") or "fofa").strip().lower()
@@ -350,7 +354,7 @@ _SUBDOMAIN_BRUTE = (
 )
 
 
-async def execute_subdomain_enum(agent: Any, args: dict[str, Any]) -> str:
+async def execute_subdomain_enum(agent: AgentContext, args: dict[str, Any]) -> str:
     """子域名枚举：空间测绘被动聚合 + 可选小字典 DNS 爆破。"""
     cfg = _get_recon_cfg(agent)
     domain = str(args.get("domain", "") or "").strip().lower()
@@ -493,7 +497,7 @@ def extract_from_js(content: str, base_host: str = "") -> dict[str, list[str]]:
     }
 
 
-async def execute_js_recon(agent: Any, args: dict[str, Any]) -> str:
+async def execute_js_recon(agent: AgentContext, args: dict[str, Any]) -> str:
     """抓取目标页面及其引用的 JS 文件，提取端点 / 域名 / 密钥。"""
     cfg = _get_recon_cfg(agent)
     url = str(args.get("url", "") or "").strip()
@@ -712,7 +716,7 @@ async def _probe_endpoints(
     return results
 
 
-async def execute_unauth_test(agent: Any, args: dict[str, Any]) -> str:
+async def execute_unauth_test(agent: AgentContext, args: dict[str, Any]) -> str:
     """对一批接口逐个做未授权访问探测（仅安全 GET，跳过破坏性接口）。"""
     cfg = _get_recon_cfg(agent)
     base = str(args.get("base_url") or args.get("url") or "").strip()
@@ -776,7 +780,7 @@ def _load_wordlist(cfg: Any) -> list[str]:
 _HIT_CODES = {200, 201, 204, 301, 302, 307, 401, 403, 405, 500}
 
 
-async def execute_dir_enum(agent: Any, args: dict[str, Any]) -> str:
+async def execute_dir_enum(agent: AgentContext, args: dict[str, Any]) -> str:
     """目录枚举：并发字典爆破，带 404 基线 / 全局伪装识别与状态码过滤。"""
     cfg = _get_recon_cfg(agent)
     base = str(args.get("url", "") or "").strip()

--- a/vulnclaw/agent/recon_tracker.py
+++ b/vulnclaw/agent/recon_tracker.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 RECON_MIN_ROUNDS = 8  # 信息收集阶段最低轮数，低于此数 [DONE] 被忽略
 
@@ -133,7 +137,7 @@ RECON_DIM_KEYWORDS: dict[str, list[str]] = {
 }
 
 
-def update_recon_dimension_completion(agent: Any, response: str) -> None:
+def update_recon_dimension_completion(agent: AgentContext, response: str) -> None:
     """Auto-detect which recon dimensions have been explored.
 
     Uses signal-weighted sources instead of blindly scanning all round text.

--- a/vulnclaw/agent/skill_context.py
+++ b/vulnclaw/agent/skill_context.py
@@ -2,26 +2,29 @@
 
 from __future__ import annotations
 
+import re
 from typing import Optional
+
+_EXPLICIT_SKILL_RE = re.compile(
+    r"\buse\s+vulnclaw\s+skill\s+([A-Za-z0-9][A-Za-z0-9_-]*)\b",
+    re.IGNORECASE,
+)
 
 
 def get_active_skill_context(user_input: Optional[str] = None) -> Optional[str]:
     """Get context from the most relevant Skill based on user input."""
     if user_input:
         try:
+            explicit_skill = _load_explicit_skill(user_input)
+            if explicit_skill:
+                return _format_skill_context(explicit_skill)
+
             from vulnclaw.skills.dispatcher import SkillDispatcher
 
             dispatcher = SkillDispatcher()
             skill = dispatcher.dispatch(user_input)
             if skill:
-                context = skill.get("content", "")
-                refs = skill.get("references", [])
-                if refs:
-                    ref_list = ", ".join(refs[:10])
-                    if len(refs) > 10:
-                        ref_list += f", ... ({len(refs)} total)"
-                    context += f"\n\n## 可用参考文档\n以下参考文档可在需要时通过 load_skill_reference 加载: {ref_list}"
-                return context
+                return _format_skill_context(skill)
         except Exception:
             pass
 
@@ -34,3 +37,24 @@ def get_active_skill_context(user_input: Optional[str] = None) -> Optional[str]:
     except Exception:
         pass
     return None
+
+
+def _load_explicit_skill(user_input: str) -> Optional[dict]:
+    match = _EXPLICIT_SKILL_RE.search(user_input)
+    if not match:
+        return None
+
+    from vulnclaw.skills.loader import load_skill_by_name
+
+    return load_skill_by_name(match.group(1))
+
+
+def _format_skill_context(skill: dict) -> str:
+    context = skill.get("content", "")
+    refs = skill.get("references", [])
+    if refs:
+        ref_list = ", ".join(refs[:10])
+        if len(refs) > 10:
+            ref_list += f", ... ({len(refs)} total)"
+        context += f"\n\n## 可用参考文档\n以下参考文档可在需要时通过 load_skill_reference 加载: {ref_list}"
+    return context

--- a/vulnclaw/agent/solver.py
+++ b/vulnclaw/agent/solver.py
@@ -17,7 +17,11 @@ import contextvars
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 from vulnclaw.agent.blackboard import Blackboard, BoardIntent, IntentStatus
 from vulnclaw.agent.llm_client import build_chat_completion_kwargs, call_llm_auto
@@ -239,7 +243,7 @@ def _extract_json(text: str) -> Optional[dict]:
     return None
 
 
-async def _structured_call(agent: Any, prompt: str, *, max_tokens: int = 900) -> str:
+async def _structured_call(agent: AgentContext, prompt: str, *, max_tokens: int = 900) -> str:
     """无工具的结构化 LLM 调用（用于 Reason / Conclude）。"""
     client = agent._get_client()
     messages = [{"role": "user", "content": prompt}]
@@ -469,14 +473,14 @@ def _add_fallback_recovery_intents(board: Blackboard, max_intents: int) -> int:
     return added
 
 
-async def reason_step(agent: Any, board: Blackboard, max_intents: int) -> dict:
+async def reason_step(agent: AgentContext, board: Blackboard, max_intents: int) -> dict:
     raw = await _structured_call(agent, _reason_prompt(board, max_intents), max_tokens=1200)
     parsed = _extract_json(raw)
     return parsed or {}
 
 
 async def frontier_recovery_step(
-    agent: Any,
+    agent: AgentContext,
     board: Blackboard,
     max_intents: int,
     streak: int,
@@ -489,7 +493,7 @@ async def frontier_recovery_step(
 
 
 async def explore_step(
-    agent: Any,
+    agent: AgentContext,
     board: Blackboard,
     intent: BoardIntent,
     *,
@@ -575,7 +579,7 @@ async def explore_step(
 
 
 async def solve(
-    agent: Any,
+    agent: AgentContext,
     *,
     origin: str,
     goal: str,
@@ -883,7 +887,7 @@ async def solve(
 
 
 async def _explore_batch(
-    agent: Any,
+    agent: AgentContext,
     board: Blackboard,
     intents: list[BoardIntent],
     *,

--- a/vulnclaw/agent/system_prompt.py
+++ b/vulnclaw/agent/system_prompt.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from vulnclaw.agent.prompts import AUTO_PENTEST_INSTRUCTION, RECON_INSTRUCTION, build_system_prompt
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.context import TaskConstraints
 
 
 def build_dynamic_system_prompt(
@@ -17,6 +20,7 @@ def build_dynamic_system_prompt(
     auto_mode: bool,
     user_input: Optional[str],
     kb_context: str,
+    task_constraints: Optional["TaskConstraints"] = None,
 ) -> str:
     """Build the dynamic system prompt for one turn."""
     prompt = build_system_prompt(
@@ -83,5 +87,10 @@ def build_dynamic_system_prompt(
 
     if kb_context:
         prompt += "\n\n" + kb_context
+
+    if task_constraints is not None:
+        constraints_block = task_constraints.to_prompt_block()
+        if constraints_block:
+            prompt += "\n\n" + constraints_block
 
     return prompt

--- a/vulnclaw/agent/tool_call_manager.py
+++ b/vulnclaw/agent/tool_call_manager.py
@@ -6,13 +6,17 @@ import asyncio
 import json
 import re
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 # Default concurrency cap used when the agent config does not specify one.
 DEFAULT_TOOL_MAX_CONCURRENT = 5
 
 
-async def handle_tool_calls(agent: Any, message: Any) -> str:
+async def handle_tool_calls(agent: AgentContext, message: Any) -> str:
     """Handle tool calls from the LLM response (legacy single-turn)."""
     results: list[str] = []
     # [修改] 2026-06-10 Nyaecho - 修复 tool_calls 属性访问问题，使用 getattr 防止 AttributeError
@@ -25,7 +29,7 @@ async def handle_tool_calls(agent: Any, message: Any) -> str:
 
 
 async def handle_tool_calls_with_results(
-    agent: Any, message: Any
+    agent: AgentContext, message: Any
 ) -> tuple[list[dict[str, Any]], list[str]]:
     """Handle tool calls with deduplication and rate limiting."""
     max_calls_per_round = 10
@@ -74,7 +78,7 @@ async def handle_tool_calls_with_results(
     return results, skipped_info
 
 
-def _resolve_parallel_settings(agent: Any) -> tuple[bool, int]:
+def _resolve_parallel_settings(agent: AgentContext) -> tuple[bool, int]:
     """Read tool parallelization settings from the agent config with safe defaults."""
     safety = getattr(getattr(agent, "config", None), "safety", None)
     if safety is None:
@@ -87,7 +91,7 @@ def _resolve_parallel_settings(agent: Any) -> tuple[bool, int]:
 
 
 async def _execute_parallel(
-    agent: Any, to_execute: list[dict[str, Any]], max_concurrent: int
+    agent: AgentContext, to_execute: list[dict[str, Any]], max_concurrent: int
 ) -> list[dict[str, Any] | None]:
     """Run independent tool calls concurrently, capped by a semaphore.
 
@@ -123,7 +127,7 @@ def _extract_structured_content(tool_result: Any) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-async def _execute_single(agent: Any, item: dict[str, Any]) -> dict[str, Any] | None:
+async def _execute_single(agent: AgentContext, item: dict[str, Any]) -> dict[str, Any] | None:
     """Execute one tool call with isolated error handling.
 
     Returns a result dict on success, or ``None`` when the call raised — matching

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -1686,6 +1686,16 @@ config_app = typer.Typer(help="Manage configuration")
 app.add_typer(config_app, name="config")
 
 
+@config_app.callback(invoke_without_command=True)
+def config_root(ctx: typer.Context) -> None:
+    """Open the interactive config editor when no subcommand is provided."""
+    if ctx.resilient_parsing or ctx.invoked_subcommand is not None:
+        return
+    from vulnclaw.cli.tui import run_config_tui
+
+    run_config_tui()
+
+
 @config_app.command("set")
 def config_set(
     key: str = typer.Argument(..., help="Config key in dot notation, e.g. llm.api_key"),

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -896,6 +896,7 @@ def _generate_report_for_target(
     *,
     current_session=None,
     report_format: str = "markdown",
+    output_path: Optional[str] = None,
 ) -> str:
     """Generate a report for a target using the best available source data."""
     from vulnclaw.agent.context import SessionState
@@ -905,16 +906,16 @@ def _generate_report_for_target(
     if current_session is not None and (
         current_session.findings or current_session.executed_steps or current_session.notes
     ):
-        path = generate_report(current_session, report_format=report_format)
+        path = generate_report(current_session, output_path, report_format=report_format)
         return str(path)
 
     state = load_target_state(target)
     if state:
-        path = generate_report_from_target_state(state)
+        path = generate_report_from_target_state(state, output_path=output_path)
         return str(path)
 
     session = SessionState(target=target)
-    path = generate_report(session, report_format=report_format)
+    path = generate_report(session, output_path, report_format=report_format)
     return str(path)
 
 
@@ -1123,6 +1124,9 @@ def run(
     else:
         total_findings = orchestrated.summary["findings_count"]
         console.print(_("cli.pentest_finished", findings=total_findings))
+
+    report_path = _generate_report_for_target(target, output_path=output)
+    console.print(f"[+] Report generated: {report_path}")
 
 
 @app.command()

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -1126,7 +1126,7 @@ def run(
         console.print(_("cli.pentest_finished", findings=total_findings))
 
     report_path = _generate_report_for_target(target, output_path=output)
-    console.print(f"[+] Report generated: {report_path}")
+    console.print(_("cli.report_generated", path=report_path))
 
 
 @app.command()

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -330,6 +330,54 @@ def _read_repl_line(
     return pt_session.prompt(HTML(f"vulnclaw {body}<b>&gt; </b>"))
 
 
+def _run_repl_command(name: str, args: str, agent: Any, config: Any) -> Any:
+    """Execute a built-in classic-REPL slash command.
+
+    Returns the (possibly reloaded) config so the caller can keep using it.
+    """
+    if name == "config":
+        from vulnclaw.cli.tui import run_config_tui
+
+        run_config_tui()
+        # The editor writes to disk; reload and rebind the running agent so
+        # provider/model/key changes take effect without restarting.
+        new_config = load_config()
+        agent.apply_config(new_config)
+        console.print(
+            f"[green]✓[/] Config reloaded: "
+            f"{new_config.llm.provider}/{new_config.llm.model}"
+        )
+        return new_config
+
+    if name == "language":
+        return _repl_switch_language(args, agent, config)
+
+    return config
+
+
+def _repl_switch_language(args: str, agent: Any, config: Any) -> Any:
+    """Switch the interface language from the classic REPL."""
+    from vulnclaw.cli.tui import _SUPPORTED_LANGUAGES, rebuild_translations
+    from vulnclaw.i18n import init_i18n
+
+    lang = args.strip().lower()
+    if lang not in _SUPPORTED_LANGUAGES:
+        console.print(
+            "[yellow]Usage:[/] /language <"
+            + " | ".join(_SUPPORTED_LANGUAGES)
+            + f">  (current: {config.session.language})"
+        )
+        return config
+
+    config.session.language = lang
+    save_config(config)
+    init_i18n(lang=lang if lang != "auto" else None, config=config)
+    rebuild_translations()
+    agent.apply_config(config)
+    console.print(f"[green]✓[/] Language set to [bold]{lang}[/].")
+    return config
+
+
 def _run_repl() -> None:
     """Run the interactive REPL loop."""
     from vulnclaw.agent.core import AgentCore
@@ -403,6 +451,9 @@ def _run_repl() -> None:
                     if restored_loaded:
                         console.print(_("cli.target_restored", target=current_target))
                     console.print(_("cli.target_set", target=current_target))
+                    continue
+                if result.kind == "command":
+                    config = _run_repl_command(result.value, result.text, agent, config)
                     continue
                 # result.kind == "run": fall through with the rewritten prompt.
                 user_input = result.text

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 import sys
 import time
-from typing import Optional
+from typing import Any, Optional
 
 
 def _configure_windows_console() -> None:
@@ -258,6 +258,78 @@ async def _run_repl_agent_call(agent, *, call, after_result) -> None:
     await run_repl_call(call=call, after_result=after_result)
 
 
+def _make_repl_prompt_session() -> Any:
+    """Build a prompt_toolkit session with the skill palette, or None if unavailable.
+
+    Returns None when stdin is not a TTY (pipes, CI, ``--once`` smoke tests) or
+    prompt_toolkit cannot attach, so the REPL falls back to plain input.
+    """
+    debug = bool(os.environ.get("VULNCLAW_DEBUG_INPUT"))
+    try:
+        if not sys.stdin.isatty():
+            if debug:
+                console.print("[dim](slash palette off: stdin is not a TTY)[/]")
+            return None
+        from prompt_toolkit import PromptSession
+
+        from vulnclaw.cli.tui import build_repl_slash_completer
+
+        session = PromptSession(
+            completer=build_repl_slash_completer(),
+            complete_while_typing=True,
+        )
+
+        # `complete_while_typing` reopens the menu on insertion but not on
+        # deletion, so backspacing to a bare '/' leaves it closed. Re-trigger
+        # completion on any change while the line still starts with '/'.
+        def _reopen_palette_on_edit(buff: Any) -> None:
+            if buff.complete_state is None and buff.text.startswith("/"):
+                buff.start_completion(select_first=False)
+
+        session.default_buffer.on_text_changed += _reopen_palette_on_edit
+
+        if debug:
+            console.print("[dim](slash palette on)[/]")
+        return session
+    except Exception as exc:
+        # Surface the reason instead of silently dropping to plain input.
+        from rich.markup import escape as _esc
+
+        console.print(f"[yellow](slash palette unavailable: {_esc(str(exc))})[/]")
+        return None
+
+
+def _read_repl_line(
+    pt_session: Any,
+    target: Optional[str],
+    phase: str,
+    auto_mode: bool,
+) -> str:
+    """Read one REPL line, using the slash palette when a session is available."""
+    if pt_session is None:
+        prompt_parts = []
+        if target:
+            prompt_parts.append(f"[bold cyan]{target}[/]")
+        prompt_parts.append(f"[dim]{phase}[/]")
+        if auto_mode:
+            prompt_parts.append("[bold yellow]AUTO[/]")
+        prompt_str = " | ".join(prompt_parts) if prompt_parts else "vulnclaw"
+        return console.input(f"vulnclaw {prompt_str}> ")
+
+    import html as _html
+
+    from prompt_toolkit.formatted_text import HTML
+
+    parts = []
+    if target:
+        parts.append(f"<ansicyan><b>{_html.escape(target)}</b></ansicyan>")
+    parts.append(f"<ansibrightblack>{_html.escape(phase)}</ansibrightblack>")
+    if auto_mode:
+        parts.append("<ansiyellow><b>AUTO</b></ansiyellow>")
+    body = " | ".join(parts) if parts else "vulnclaw"
+    return pt_session.prompt(HTML(f"vulnclaw {body}<b>&gt; </b>"))
+
+
 def _run_repl() -> None:
     """Run the interactive REPL loop."""
     from vulnclaw.agent.core import AgentCore
@@ -298,19 +370,16 @@ def _run_repl() -> None:
     _last_ctrlc_time = 0.0
     last_auto_input: str = ""
 
+    # Interactive slash palette: skills under '/', flag skills under '/.'.
+    # Falls back to plain input when there is no TTY (pipes, CI smoke tests).
+    _pt_session = _make_repl_prompt_session()
+
     while True:
         try:
-            # Build prompt string
-            prompt_parts = []
-            if current_target:
-                prompt_parts.append(f"[bold cyan]{current_target}[/]")
-            prompt_parts.append(f"[dim]{current_phase}[/]")
-            if auto_mode_active:
-                prompt_parts.append("[bold yellow]AUTO[/]")
-            prompt_str = " | ".join(prompt_parts) if prompt_parts else "vulnclaw"
-
-            # Read input
-            user_input = console.input(f"vulnclaw {prompt_str}> ").strip()
+            # Read input (slash palette when interactive, plain prompt otherwise)
+            user_input = _read_repl_line(
+                _pt_session, current_target, current_phase, auto_mode_active
+            ).strip()
 
             if not user_input:
                 if last_auto_input:
@@ -318,6 +387,25 @@ def _run_repl() -> None:
                     console.print(f"[dim]↻ Resuming auto pentest: {last_auto_input[:60]}...[/]")
                 else:
                     continue
+
+            # Handle slash commands: '/' selects a skill, '/.' a flag skill.
+            if user_input.startswith("/"):
+                from vulnclaw.cli.tui import dispatch_repl_slash
+
+                result = dispatch_repl_slash(user_input)
+                if result.kind == "message":
+                    console.print(result.text)
+                    continue
+                if result.kind == "target":
+                    current_target, current_phase, restored_loaded = _prepare_repl_target(
+                        agent, result.value, current_target, current_phase
+                    )
+                    if restored_loaded:
+                        console.print(_("cli.target_restored", target=current_target))
+                    console.print(_("cli.target_set", target=current_target))
+                    continue
+                # result.kind == "run": fall through with the rewritten prompt.
+                user_input = result.text
 
             # Handle built-in commands
             cmd_lower = user_input.lower()

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -49,6 +49,7 @@ from vulnclaw import __version__
 from vulnclaw.agent.constraint_policy import validate_action_constraints
 from vulnclaw.agent.input_analysis import extract_task_constraints
 from vulnclaw.agent.think_filter import format_think_tags, strip_think_tags
+from vulnclaw.cli.manual import available_topics, render_manual
 from vulnclaw.config.settings import (
     apply_provider_preset,
     list_providers,
@@ -1344,6 +1345,188 @@ def scan(
     asyncio.run(_run())
 
 
+@app.command("network-scan")
+def network_scan(
+    target: Optional[str] = typer.Argument(
+        None, help="目标主机/IP/CIDR，默认使用当前连接的 Wi-Fi 子网"
+    ),
+    profile: str = typer.Option(
+        "adaptive",
+        "--profile",
+        help="网络扫描画像：adaptive、fast、thorough、stealth",
+    ),
+    ports: Optional[str] = typer.Option(None, "--ports", help="端口范围，如 80,443,1-1000"),
+    max_rounds: int = typer.Option(
+        0, "--max-rounds", help="Agent 后续跟进轮数（0=使用配置默认值）"
+    ),
+    parallel_agents: int = typer.Option(
+        1,
+        "--parallel-agents",
+        min=1,
+        help="在已发现的攻击面上并行派生的子 Agent 数量（1 表示不启用并行）",
+    ),
+    parallel_depth: int = typer.Option(
+        1,
+        "--parallel-depth",
+        min=1,
+        help="子 Agent 攻击面发现的有界波次数",
+    ),
+    worker_rounds: int = typer.Option(
+        3,
+        "--worker-rounds",
+        min=1,
+        help="每个子 Agent worker 的执行轮数",
+    ),
+    surface_limit: int = typer.Option(
+        20,
+        "--surface-limit",
+        min=1,
+        help="用于子 Agent 并行派生的最大攻击面数量",
+    ),
+    safe_probes: bool = typer.Option(
+        True,
+        "--safe-probes/--no-safe-probes",
+        help="nmap 扫描后默认仅执行非破坏性的验证探测",
+    ),
+    prompt: Optional[str] = typer.Option(
+        None, "--prompt", help="Custom natural language prompt (overrides auto-generated prompt)"
+    ),
+    only_port: Optional[int] = typer.Option(
+        None, "--only-port", help="Restrict testing to a single port"
+    ),
+    only_host: Optional[str] = typer.Option(
+        None, "--only-host", help="Restrict testing to a single host"
+    ),
+    blocked_host: Optional[str] = typer.Option(
+        None, "--blocked-host", help="Explicitly blocked host"
+    ),
+    allow_actions: Optional[str] = typer.Option(
+        None, "--allow-actions", help="Comma-separated allowed actions"
+    ),
+    block_actions: Optional[str] = typer.Option(
+        None, "--block-actions", help="Comma-separated blocked actions"
+    ),
+    resume: bool = typer.Option(True, "--resume/--no-resume", help="Resume previous target state"),
+    snapshot: Optional[str] = typer.Option(
+        None, "--snapshot", help="Resume from a specific target snapshot id"
+    ),
+) -> None:
+    """运行基于 nmap 的网络扫描，并对薄弱环节进行跟进。"""
+    normalized_profile = profile.strip().lower()
+    if normalized_profile not in {"adaptive", "fast", "thorough", "stealth"}:
+        err_console.print("[!] profile 必须是以下之一: adaptive, fast, thorough, stealth")
+        raise typer.Exit(1)
+
+    detected_wifi = None
+    scan_target = target.strip() if target else ""
+    if not scan_target:
+        from vulnclaw.agent.network_scan import detect_connected_wifi_target
+
+        try:
+            detected_wifi = detect_connected_wifi_target()
+            scan_target = detected_wifi.cidr
+        except RuntimeError as exc:
+            err_console.print(f"[!] {exc}")
+            raise typer.Exit(1)
+
+    port_hint = f" limited to ports {ports}" if ports else ""
+    follow_up = (
+        "Then prioritize weak links and perform safe, non-destructive verification probes only."
+        if safe_probes
+        else "Then summarize weak links without running follow-up probes."
+    )
+    task_prompt = prompt if prompt else (
+        f"Perform an authorized {normalized_profile} network scan against {scan_target}{port_hint}. "
+        f"Use the nmap_scan tool with profile={normalized_profile}"
+        f"{f' and ports={ports}' if ports else ''}. "
+        f"{follow_up} Record open services and candidate weak-link findings in target state. "
+        "Do not brute force credentials, run destructive payloads, or perform post-exploitation."
+    )
+    task_prompt = _append_cli_constraints_compat(
+        task_prompt,
+        only_port,
+        only_host,
+        None,
+        blocked_host,
+        None,
+    )
+
+    effective_allow_actions = allow_actions
+    effective_block_actions = block_actions
+    if safe_probes and not allow_actions and not block_actions:
+        effective_allow_actions = "recon,scan"
+    task_prompt = _append_action_constraints(
+        task_prompt, effective_allow_actions, effective_block_actions
+    )
+
+    violation = validate_action_constraints("scan", extract_task_constraints(task_prompt))
+    if violation is not None:
+        err_console.print(f"[!] {violation}")
+        raise typer.Exit(1)
+
+    console.print(
+        Panel(
+            f"目标: [bold]{scan_target}[/]\n"
+            + (
+                f"Wi-Fi 接口: [bold]{detected_wifi.interface}[/] ({detected_wifi.address})\n"
+                if detected_wifi
+                else ""
+            )
+            +
+            f"画像: [bold]{normalized_profile}[/]\n"
+            f"端口: [bold]{ports or '画像默认'}[/]\n"
+            f"跟进策略: [bold]{'安全探测' if safe_probes else '仅摘要'}[/]\n"
+            f"并行 Agent 数: [bold]{parallel_agents}[/]"
+            + (
+                f"（深度 {parallel_depth}，每个 worker {worker_rounds} 轮）"
+                if parallel_agents > 1
+                else ""
+            ),
+            title="网络扫描",
+            border_style="cyan",
+        )
+    )
+
+    async def _run():
+        async def runner(agent, _config):
+            sink = TerminalStreamSink(console, _config.session.show_thinking)
+            rounds = max_rounds if max_rounds > 0 else _config.session.max_rounds
+            if parallel_agents > 1:
+                from vulnclaw.agent.parallel_agents import run_parallel_pentest
+
+                def agent_factory():
+                    return agent.__class__(_config, getattr(agent, "mcp_manager", None))
+
+                return await run_parallel_pentest(
+                    agent,
+                    agent_factory=agent_factory,
+                    user_input=task_prompt,
+                    target=scan_target,
+                    discovery_rounds=rounds,
+                    worker_rounds=worker_rounds,
+                    max_agents=parallel_agents,
+                    max_depth=parallel_depth,
+                    surface_limit=surface_limit,
+                    stream_sink=sink,
+                )
+            return await agent.auto_pentest(
+                task_prompt,
+                target=scan_target,
+                max_rounds=rounds,
+                stream_sink=sink,
+            )
+
+        await _run_cli_orchestrated_task(
+            command="network-scan",
+            target=scan_target,
+            resume=resume,
+            snapshot=snapshot,
+            runner=runner,
+        )
+
+    asyncio.run(_run())
+
+
 @app.command()
 def exploit(
     target: str = typer.Argument(..., help="Target host/IP/URL"),
@@ -1418,6 +1601,12 @@ def report(
     target_mode: bool = typer.Option(
         False, "--target", help="Interpret argument as target and generate report from target state"
     ),
+    pdf: bool = typer.Option(
+        False, "--pdf", help="Also export the report to PDF (requires the vulnclaw[pdf] extra)"
+    ),
+    pdf_out: str = typer.Option(
+        "", "--pdf-out", help="PDF output path (default: the report path with a .pdf suffix)"
+    ),
 ) -> None:
     """Generate a report from a session file or target state."""
     if target_mode:
@@ -1427,12 +1616,68 @@ def report(
         if not state:
             err_console.print(f"[!] Target state not found: {session}")
             raise typer.Exit(1)
-        generate_report_from_target_state(state)
+        report_path = generate_report_from_target_state(state)
     else:
         from vulnclaw.report.generator import generate_report_from_file
 
-        generate_report_from_file(session)
-    console.print("[+] Report generated")
+        report_path = generate_report_from_file(session)
+    console.print(f"[+] Report generated: {report_path}")
+
+    if pdf:
+        from pathlib import Path
+
+        from vulnclaw.report.pdf_exporter import export_pdf
+
+        out = Path(pdf_out) if pdf_out else Path(report_path).with_suffix(".pdf")
+        try:
+            markdown = Path(report_path).read_text(encoding="utf-8")
+            export_pdf(markdown, out, title="VulnClaw Report")
+        except RuntimeError as exc:
+            err_console.print(f"[!] {exc}")
+            raise typer.Exit(1) from exc
+        console.print(f"[+] PDF exported: {out}")
+
+
+def _print_cli_manual(topic: Optional[str], output_format: str) -> None:
+    """Print the packaged CLI manual, normalizing user-facing errors."""
+    try:
+        console.out(render_manual(output_format, topic), end="")
+    except ValueError as exc:
+        err_console.print(f"[!] {exc}")
+        err_console.print(f"    Available topics: {', '.join(available_topics())}")
+        raise typer.Exit(1) from exc
+
+
+@app.command("manual")
+def manual_command(
+    topic: Optional[str] = typer.Argument(
+        None, help="Optional manual topic, e.g. run, solve, network-scan, config"
+    ),
+    output_format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text, markdown, man",
+    ),
+) -> None:
+    """Print the full VulnClaw CLI manual."""
+    _print_cli_manual(topic, output_format)
+
+
+@app.command("man")
+def man_command(
+    topic: Optional[str] = typer.Argument(
+        None, help="Optional manual topic, e.g. run, solve, network-scan, config"
+    ),
+    output_format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text, markdown, man",
+    ),
+) -> None:
+    """Alias for 'vulnclaw manual'."""
+    _print_cli_manual(topic, output_format)
 
 
 # 鈹€鈹€ Config sub-command group 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
@@ -2256,8 +2501,29 @@ def _extract_target_from_input(user_input: str) -> Optional[str]:
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Show version and exit.",
+        is_eager=True,
+    ),
+    show_manual: bool = typer.Option(
+        False,
+        "--man",
+        "--manual",
+        help="Show the full CLI manual and exit.",
+        is_eager=True,
+    ),
+) -> None:
     """Open the classic CLI/REPL by default."""
+    if version:
+        console.print(__version__)
+        raise typer.Exit()
+    if show_manual:
+        _print_cli_manual(None, "text")
+        raise typer.Exit()
     if ctx.invoked_subcommand is None:
         _run_repl()
 
@@ -2419,7 +2685,7 @@ def web(
     ),
 ) -> None:
     """Run the local Web UI."""
-    if host != "127.0.0.1":
+    if not _is_loopback_bind_host(host):
         if not allow_remote:
             err_console.print(
                 "[!] Refusing to bind the Web UI to a non-local address without --allow-remote."
@@ -2463,6 +2729,19 @@ def web(
     from vulnclaw.web.app import create_app
 
     uvicorn.run(create_app(), host=host, port=port, log_level="info")
+
+
+def _is_loopback_bind_host(host: str) -> bool:
+    """Return True when a requested bind host is loopback-only."""
+    normalized = host.strip().strip("[]").lower()
+    if normalized in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        import ipaddress
+
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 if __name__ == "__main__":

--- a/vulnclaw/cli/manual.py
+++ b/vulnclaw/cli/manual.py
@@ -1,0 +1,945 @@
+"""Full CLI manual rendering for VulnClaw."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vulnclaw import __version__
+from vulnclaw.config.schema import PROVIDER_PRESETS
+
+
+@dataclass(frozen=True)
+class ManualTopic:
+    """A CLI manual topic or command."""
+
+    name: str
+    summary: str
+    usage: str
+    flags: tuple[tuple[str, str], ...] = ()
+    notes: tuple[str, ...] = ()
+    examples: tuple[str, ...] = ()
+    aliases: tuple[str, ...] = ()
+
+
+ROOT_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("--help", "Show Typer's short help for the root command or selected subcommand."),
+    ("--version", "Print the installed VulnClaw version and exit."),
+    ("--man, --manual", "Print this full CLI manual and exit."),
+)
+
+COMMON_TASK_FLAGS: tuple[tuple[str, str], ...] = (
+    (
+        "--prompt TEXT",
+        "Replace the built-in task prompt entirely. Use this when the default command intent is "
+        "close but you need exact wording, credentials context, a lab note, or a custom workflow.",
+    ),
+    (
+        "--only-port PORT",
+        "Add a hard scope hint that only this TCP/UDP port is in scope. Valid ports are 1-65535.",
+    ),
+    (
+        "--only-host HOST",
+        "Restrict testing to one host even when a URL, CIDR, recon data, or target history points "
+        "at related hosts.",
+    ),
+    (
+        "--only-path PATH",
+        "Restrict web testing to one path such as /admin. Available on URL-oriented task commands.",
+    ),
+    (
+        "--blocked-host HOST",
+        "Mark a host as explicitly out of scope. Tool calls to that host are blocked where VulnClaw "
+        "can infer the destination.",
+    ),
+    (
+        "--blocked-path PATH",
+        "Mark a path as explicitly out of scope. Available on URL-oriented task commands.",
+    ),
+    (
+        "--allow-actions CSV",
+        "Comma-separated action allowlist. Common values are recon, scan, exploit, "
+        "post_exploitation, report, run, and persistent. If set, commands outside the allowlist "
+        "are blocked before the task starts, and tool/phase checks continue during the run.",
+    ),
+    (
+        "--block-actions CSV",
+        "Comma-separated action denylist using the same action names as --allow-actions.",
+    ),
+    (
+        "--resume / --no-resume",
+        "Resume saved target history by default. Use --no-resume for a clean run that ignores "
+        "stored target state.",
+    ),
+    (
+        "--snapshot ID",
+        "Resume from a specific target-state snapshot instead of the latest one.",
+    ),
+)
+
+ACTION_NAMES = (
+    "recon",
+    "scan",
+    "exploit",
+    "post_exploitation",
+    "report",
+    "run",
+    "persistent",
+)
+
+COMMANDS: tuple[ManualTopic, ...] = (
+    ManualTopic(
+        name="run",
+        summary="Run the full authorized pentest workflow against one target.",
+        usage="vulnclaw run TARGET [--scope full|web|api|mobile] [--output PATH] [COMMON TASK FLAGS]",
+        flags=(
+            ("TARGET", "Required host, IP, URL, or other authorized target identifier."),
+            (
+                "--scope TEXT",
+                "High-level test focus. Built-in wording recognizes full, web, api, and mobile, "
+                "but the value is passed into the task prompt, so custom labels are possible.",
+            ),
+            (
+                "--output PATH",
+                "After the run, generate a report at PATH from the saved target state. A .html "
+                "suffix writes HTML; otherwise the configured report format is used.",
+            ),
+        ),
+        notes=(
+            "Requires configured LLM credentials (llm.api_key or auth_mode) before the task starts.",
+            "By default (session.engine=solve) this runs the goal-driven solve loop — no fixed round "
+            "count, bounded by session.solve_max_steps/solve_max_intents/solve_max_tool_rounds — and "
+            "stops when the exploration frontier is exhausted, same underlying engine as `vulnclaw "
+            "solve`. Set session.engine=rounds to use the legacy fixed-round auto_pentest loop "
+            "instead (bounded by session.max_rounds).",
+            "Use --allow-actions recon,scan when you want broad coverage but no exploitation.",
+        ),
+        examples=(
+            "vulnclaw run https://lab.example --scope web --allow-actions recon,scan",
+            "vulnclaw run 10.10.10.5 --output reports/lab.md --no-resume",
+        ),
+    ),
+    ManualTopic(
+        name="solve",
+        summary="Goal-driven solve loop with no fixed round count.",
+        usage=(
+            "vulnclaw solve TARGET [--goal TEXT] [--max-steps N] [--max-intents N] "
+            "[--max-tool-rounds N] [--resume/--no-resume] [--snapshot ID]"
+        ),
+        flags=(
+            ("TARGET", "Required host, IP, URL, or other authorized target identifier."),
+            (
+                "--goal TEXT",
+                "Success condition, e.g. 'capture the flag' or 'get a shell'. Defaults to finding "
+                "and verifying a flag/shell/high-value vulnerability.",
+            ),
+            ("--prompt TEXT", "Custom task description that overrides the auto-generated one."),
+            (
+                "--max-steps N",
+                "Safety cap on explore steps (not a fixed workflow length; default 40).",
+            ),
+            ("--max-intents N", "Max new intents generated per reason step (default 3)."),
+            (
+                "--max-tool-rounds N",
+                "Max tool-calling rounds per intent exploration (default 4).",
+            ),
+            ("--resume / --no-resume", "Resume saved target history by default."),
+            ("--snapshot ID", "Resume from a specific target-state snapshot instead of the latest one."),
+        ),
+        notes=(
+            "Unlike run/persistent, solve has no fixed round count: it searches a Fact/Intent graph "
+            "from the target toward the goal and stops on success or when no path remains.",
+            "This is the same engine `run` uses by default (session.engine=solve); `solve` exposes "
+            "its tuning knobs directly on the command line instead of through config.",
+        ),
+        examples=(
+            "vulnclaw solve https://lab.example --goal 'get a shell'",
+            "vulnclaw solve 10.10.10.5 --max-steps 60 --max-intents 4",
+        ),
+    ),
+    ManualTopic(
+        name="persistent",
+        summary="Run repeated pentest cycles and optionally write a report after each cycle.",
+        usage="vulnclaw persistent TARGET [--rounds N] [--cycles N] [--no-report] [COMMON TASK FLAGS]",
+        flags=(
+            ("TARGET", "Required authorized target."),
+            (
+                "--rounds N, -r N",
+                "Rounds per cycle. 0 means use session.persistent_rounds_per_cycle from config.",
+            ),
+            (
+                "--cycles N, -c N",
+                "Maximum number of cycles. 0 means use session.persistent_max_cycles from config; "
+                "if that config value is also 0, the run is unlimited until interrupted.",
+            ),
+            ("--no-report", "Disable the normal persistent-cycle report generation."),
+        ),
+        notes=(
+            "Persistent mode is for long authorized lab or assessment runs where VulnClaw should "
+            "keep cycling through recon, scan, verification, and reporting.",
+            "Use Ctrl+C to interrupt. The command still prints a final summary.",
+        ),
+        examples=(
+            "vulnclaw persistent https://lab.example --rounds 25 --cycles 4",
+            "vulnclaw persistent 10.0.0.0/24 --allow-actions recon,scan --no-report",
+        ),
+    ),
+    ManualTopic(
+        name="recon",
+        summary="Run reconnaissance only, without exploitation.",
+        usage="vulnclaw recon TARGET [COMMON TASK FLAGS]",
+        flags=(("TARGET", "Required host, IP, URL, CIDR, or domain to investigate."),),
+        notes=(
+            "The default prompt asks for authorized reconnaissance without exploitation.",
+            "Good first command when you only want asset discovery, fingerprinting, and notes.",
+        ),
+        examples=("vulnclaw recon example.com --only-host example.com",),
+    ),
+    ManualTopic(
+        name="scan",
+        summary="Run vulnerability discovery without exploitation.",
+        usage="vulnclaw scan TARGET [--ports PORTS] [COMMON TASK FLAGS]",
+        flags=(
+            ("TARGET", "Required authorized target."),
+            (
+                "--ports PORTS",
+                "Port list or range hint such as 80,443,8080. This is prompt guidance, not an "
+                "nmap-only switch; use network-scan for direct nmap profile control.",
+            ),
+        ),
+        notes=(
+            "The default prompt asks VulnClaw to identify vulnerabilities without exploitation.",
+            "Use --block-actions exploit for an explicit denylist in addition to the scan wording.",
+        ),
+        examples=("vulnclaw scan https://lab.example --ports 80,443 --block-actions exploit",),
+    ),
+    ManualTopic(
+        name="network-scan",
+        summary="Run nmap-based network discovery and optional safe follow-up probes.",
+        usage=(
+            "vulnclaw network-scan [TARGET] [--profile adaptive|fast|thorough|stealth] "
+            "[--ports PORTS] [--parallel-agents N]"
+        ),
+        flags=(
+            (
+                "TARGET",
+                "Optional host, IP, or CIDR. If omitted, VulnClaw tries to detect the connected "
+                "Wi-Fi subnet and scan that CIDR.",
+            ),
+            (
+                "--profile TEXT",
+                "nmap scan profile. adaptive uses target history and defaults; fast favors speed; "
+                "thorough expands coverage; stealth lowers scan intensity.",
+            ),
+            ("--ports PORTS", "Port list or range for nmap, for example 22,80,443 or 1-1000."),
+            (
+                "--max-rounds N",
+                "Agent follow-up rounds after nmap. 0 means use session.max_rounds.",
+            ),
+            (
+                "--parallel-agents N",
+                "Number of child agents to fan out across discovered surfaces. 1 disables fan-out.",
+            ),
+            (
+                "--parallel-depth N",
+                "Number of child-agent discovery waves when --parallel-agents is greater than 1.",
+            ),
+            ("--worker-rounds N", "Agent rounds per child surface worker."),
+            (
+                "--surface-limit N",
+                "Maximum discovered surfaces considered for child-agent fan-out.",
+            ),
+            (
+                "--safe-probes / --no-safe-probes",
+                "With safe probes on, VulnClaw defaults to --allow-actions recon,scan and performs "
+                "only non-destructive verification probes after nmap. With --no-safe-probes, it "
+                "summarizes weak links without follow-up probes.",
+            ),
+            ("--only-port PORT", "Restrict follow-up analysis to one port."),
+            ("--only-host HOST", "Restrict follow-up analysis to one host."),
+            ("--blocked-host HOST", "Exclude a host from follow-up analysis."),
+            ("--allow-actions CSV", "Override the safe-probe action allowlist."),
+            ("--block-actions CSV", "Add an action denylist."),
+            ("--resume / --no-resume", "Use or ignore saved target history."),
+            ("--snapshot ID", "Resume from a specific target-state snapshot."),
+        ),
+        notes=(
+            "This is the command to use when you want nmap involved directly.",
+            "The built-in profile validation accepts adaptive, fast, thorough, and stealth.",
+        ),
+        examples=(
+            "vulnclaw network-scan --profile fast",
+            "vulnclaw network-scan 192.168.56.0/24 --ports 22,80,443 --parallel-agents 3",
+        ),
+    ),
+    ManualTopic(
+        name="exploit",
+        summary="Run an authorized exploitation-focused task.",
+        usage="vulnclaw exploit TARGET [--cve CVE-ID] [--cmd CMD] [COMMON TASK FLAGS]",
+        flags=(
+            ("TARGET", "Required authorized target."),
+            ("--cve CVE-ID", "Tell VulnClaw to focus on a specific CVE."),
+            (
+                "--cmd CMD",
+                "Verification command for command-execution style findings. Defaults to id.",
+            ),
+        ),
+        notes=(
+            "Use only against systems where exploitation is explicitly authorized.",
+            "Scope flags still apply and are checked before the command starts.",
+        ),
+        examples=(
+            "vulnclaw exploit https://lab.example --cve CVE-2024-1234 --only-path /vulnerable",
+        ),
+    ),
+    ManualTopic(
+        name="report",
+        summary="Generate a report from a saved session file or from target history.",
+        usage="vulnclaw report SESSION_JSON [--target] [--pdf] [--pdf-out PATH]",
+        flags=(
+            (
+                "SESSION_JSON",
+                "Path to a saved session JSON file. With --target, this argument is interpreted "
+                "as a target name instead.",
+            ),
+            (
+                "--target",
+                "Generate from the current target-state history rather than a session JSON file.",
+            ),
+            (
+                "--pdf",
+                "Also export a PDF. Requires the pdf extra, for example pip install 'vulnclaw[pdf]'.",
+            ),
+            (
+                "--pdf-out PATH",
+                "PDF output path. Defaults to the generated report path with a .pdf suffix.",
+            ),
+        ),
+        notes=(
+            "Reports include verified findings, false-positive/review status, attack path summary, "
+            "and recorded scope governance where available.",
+        ),
+        examples=(
+            "vulnclaw report ~/.vulnclaw/sessions/session_001.json",
+            "vulnclaw report https://lab.example --target --pdf",
+        ),
+    ),
+    ManualTopic(
+        name="config",
+        summary="Manage config values and provider presets.",
+        usage=(
+            "vulnclaw config list\n"
+            "vulnclaw config get KEY\n"
+            "vulnclaw config set KEY VALUE\n"
+            "vulnclaw config provider [NAME|--list]"
+        ),
+        flags=(
+            ("set KEY VALUE", "Set a dot-notated config key such as llm.model or session.max_rounds."),
+            ("get KEY", "Print one config value. Secret-looking keys are masked."),
+            ("list", "Print the full effective config as YAML."),
+            ("provider NAME", "Switch provider preset and fill base_url/model defaults."),
+            ("provider --list, -l", "List provider presets and show the current provider."),
+        ),
+        notes=(
+            "A config subcommand is required; running vulnclaw config alone prints usage and exits.",
+            "Useful LLM keys: llm.provider, llm.api_key, llm.api_keys, llm.auth_mode, "
+            "llm.chatgpt_auto_proxy, llm.base_url, llm.model, llm.max_tokens, "
+            "llm.max_context_tokens, llm.temperature, llm.reasoning_effort. Use `vulnclaw login` "
+            "instead of llm.api_key for OAuth-based ChatGPT-subscription auth.",
+            "Useful session keys: session.output_dir, session.report_format, session.max_rounds, "
+            "session.engine (solve|rounds), session.solve_max_steps, session.solve_max_intents, "
+            "session.solve_max_tool_rounds, session.solve_max_parallel, session.show_thinking, "
+            "session.persistent_rounds_per_cycle, session.persistent_max_cycles, "
+            "session.persistent_auto_report, session.language, session.reasoning_state_enabled, "
+            "session.reflexion_enabled, session.plugin_runtime_enabled. The repl_parallel_* keys "
+            "(repl_parallel_enabled/agents/depth/worker_rounds/surface_limit) only apply to the "
+            "legacy 'rounds' engine's network-scan --parallel-agents fan-out, not to 'solve'.",
+            "Useful safety keys: safety.enable_python_execute, safety.python_execute_mode, "
+            "safety.python_execute_max_lines, safety.tool_parallel, safety.tool_max_concurrent.",
+        ),
+        examples=(
+            "vulnclaw config provider --list",
+            "vulnclaw config provider deepseek",
+            "vulnclaw config set llm.api_keys 'key-one,key-two,key-three'",
+            "vulnclaw config set session.max_rounds 25",
+            "vulnclaw config set session.engine rounds",
+        ),
+    ),
+    ManualTopic(
+        name="kb",
+        summary="Manage the local security knowledge base.",
+        usage="vulnclaw kb update\nvulnclaw kb status",
+        flags=(
+            ("update", "Seed or refresh bundled knowledge-base entries."),
+            ("status", "Show whether semantic retrieval is active, keyword fallback is active, or no data is available."),
+        ),
+        notes=(
+            "Semantic retrieval requires the kb extra. Without it, VulnClaw falls back to keyword retrieval when data exists.",
+        ),
+        examples=("vulnclaw kb update", "vulnclaw kb status"),
+    ),
+    ManualTopic(
+        name="target-state",
+        summary="Inspect, compare, restore, or clear persisted target history.",
+        usage=(
+            "vulnclaw target-state list TARGET\n"
+            "vulnclaw target-state preview TARGET [--snapshot ID]\n"
+            "vulnclaw target-state diff TARGET FROM_ID [--to TO_ID]\n"
+            "vulnclaw target-state rollback TARGET SNAPSHOT_ID\n"
+            "vulnclaw target-state clear TARGET"
+        ),
+        flags=(
+            ("list TARGET", "List up to 20 recent snapshots for a target."),
+            ("preview TARGET", "Show phase, resume strategy, finding counts, priority assets, and next actions."),
+            ("preview --snapshot ID", "Preview a specific snapshot."),
+            ("diff TARGET FROM_ID --to TO_ID", "Compare two snapshots, or compare FROM_ID to current state when --to is omitted."),
+            ("rollback TARGET SNAPSHOT_ID", "Restore target history to a snapshot."),
+            ("clear TARGET", "Delete persisted target history for a target."),
+        ),
+        notes=(
+            "Task commands use target state when --resume is enabled, which is the default.",
+            "Use --no-resume on run/recon/scan/exploit/persistent/network-scan to ignore this history.",
+        ),
+        examples=(
+            "vulnclaw target-state list https://lab.example",
+            "vulnclaw target-state preview https://lab.example",
+            "vulnclaw target-state diff https://lab.example snap-a --to snap-b",
+        ),
+        aliases=("target", "state", "history"),
+    ),
+    ManualTopic(
+        name="plugins",
+        summary="Inspect and run vulnerability detection plugins.",
+        usage=(
+            "vulnclaw plugins list [--stage STAGE] [--tag TAG]\n"
+            "vulnclaw plugins info PLUGIN_ID\n"
+            "vulnclaw plugins run PLUGIN_ID --target TARGET [--stage STAGE] [--option KEY=VALUE] "
+            "[--input FILE]"
+        ),
+        flags=(
+            ("list --stage STAGE", "Filter the plugin list by stage, e.g. discovery."),
+            ("list --tag TAG", "Filter the plugin list by tag."),
+            ("info PLUGIN_ID", "Print full JSON metadata for one plugin."),
+            ("run PLUGIN_ID", "Required plugin id to run."),
+            ("run --target TARGET", "Target host/IP/URL for the plugin run."),
+            ("run --stage STAGE", "Plugin stage to run under (default: discovery)."),
+            (
+                "run --option KEY=VALUE, -o KEY=VALUE",
+                "Plugin option, repeatable. The value is parsed as JSON when possible.",
+            ),
+            ("run --input FILE", "JSON file whose contents are merged into the plugin options."),
+        ),
+        notes=(
+            "Plugins are the structured, non-LLM detection checks (headers, JS endpoints, JWT, "
+            "etc.) that back session.plugin_runtime_enabled during autonomous runs.",
+            "session.plugin_default_timeout and session.plugin_max_requests_per_target bound "
+            "plugin execution during autonomous runs; the CLI run command has no such cap.",
+        ),
+        examples=(
+            "vulnclaw plugins list",
+            "vulnclaw plugins info builtin.web.headers",
+            "vulnclaw plugins run builtin.web.headers --target https://lab.example",
+        ),
+    ),
+    ManualTopic(
+        name="tui",
+        summary="Open the terminal workbench for guided task setup.",
+        usage="vulnclaw tui [--target TARGET] [--mode quick|standard|deep|continuous] [SCOPE FLAGS]",
+        flags=(
+            ("--target TARGET, -t TARGET", "Pre-fill the authorized target."),
+            (
+                "--mode MODE, -m MODE",
+                "Pre-fill workbench mode. quick maps to recon, standard maps to run, deep maps to "
+                "scan, and continuous maps to persistent.",
+            ),
+            ("--only-port PORT", "Pre-fill a single allowed port."),
+            ("--only-host HOST", "Pre-fill a single allowed host."),
+            ("--only-path PATH", "Pre-fill a single allowed path."),
+            ("--blocked-host HOST", "Pre-fill an excluded host."),
+            ("--blocked-path PATH", "Pre-fill an excluded path."),
+            ("--allow-actions CSV", "Pre-fill allowed actions."),
+            ("--block-actions CSV", "Pre-fill blocked actions."),
+            ("--resume / --no-resume", "Pre-fill target history resume behavior."),
+            ("--dry-run", "Render the launch summary and exit without starting a task."),
+            ("--once", "Render the dashboard once and exit, useful for smoke tests."),
+        ),
+        notes=(
+            "The TUI exposes the same scope and action controls as the CLI task commands.",
+        ),
+        examples=(
+            "vulnclaw tui",
+            "vulnclaw tui --target https://lab.example --mode quick --only-port 443",
+            "vulnclaw tui --dry-run --target https://lab.example --mode deep",
+        ),
+    ),
+    ManualTopic(
+        name="web",
+        summary="Start the local FastAPI/React web UI.",
+        usage="vulnclaw web [--host HOST] [--port PORT] [--dry-run] [--allow-remote]",
+        flags=(
+            ("--host HOST", "Bind address. Defaults to 127.0.0.1."),
+            ("--port PORT", "Bind port. Defaults to 7788."),
+            ("--dry-run", "Validate imports and print launch information without starting uvicorn."),
+            (
+                "--allow-remote",
+                "Required when --host is not 127.0.0.1. This prevents accidentally exposing the Web UI.",
+            ),
+        ),
+        notes=(
+            "Install the web extra if FastAPI/uvicorn are missing: pip install 'vulnclaw[web]'.",
+            "Keep the Web UI on localhost unless you intentionally need remote access.",
+        ),
+        examples=("vulnclaw web", "vulnclaw web --port 8080 --dry-run"),
+    ),
+    ManualTopic(
+        name="repl",
+        summary="Start the classic natural-language REPL.",
+        usage="vulnclaw repl\nvulnclaw",
+        flags=(
+            ("no arguments", "Running vulnclaw with no subcommand opens this REPL by default."),
+        ),
+        notes=(
+            "REPL commands include help, status, target TARGET, tools, report [TARGET], persistent [TARGET], think [on|off], clear, and exit.",
+            "Natural-language inputs that include an auto-mode keyword and a target enter autonomous pentest mode.",
+            "Bounded parallel child-agent fan-out is available from the network-scan command's --parallel-agents flag, not from the REPL directly.",
+        ),
+        examples=("vulnclaw", "vulnclaw repl"),
+    ),
+    ManualTopic(
+        name="init",
+        summary="Create the VulnClaw config directories and initial config file.",
+        usage="vulnclaw init",
+        notes=(
+            "Creates ~/.vulnclaw by default, unless VULNCLAW_CONFIG_DIR points somewhere else.",
+        ),
+        examples=("vulnclaw init",),
+    ),
+    ManualTopic(
+        name="doctor",
+        summary="Check runtime readiness and configured integrations.",
+        usage="vulnclaw doctor",
+        notes=(
+            "Checks Python, node, npx, uvx, nmap, LLM config, MCP service registration, and exposed tool count.",
+            "Use this before a real run when provider, MCP, or frontend tooling feels unclear.",
+        ),
+        examples=("vulnclaw doctor",),
+    ),
+    ManualTopic(
+        name="login",
+        summary="Sign in with a ChatGPT subscription (Codex \"Sign in with ChatGPT\").",
+        usage="vulnclaw login [--proxy-url URL] [--no-browser] [--set-default/--no-set-default]",
+        flags=(
+            (
+                "--proxy-url URL",
+                "Use an external OpenAI-compatible proxy base_url instead of the built-in bridge.",
+            ),
+            ("--no-browser", "Print the sign-in URL instead of opening a browser."),
+            (
+                "--set-default / --no-set-default",
+                "Set llm.auth_mode=oauth on success (default: set it).",
+            ),
+        ),
+        notes=(
+            "Opens the ChatGPT consent page, stores a refreshable token, and (with "
+            "llm.chatgpt_auto_proxy) starts a built-in local proxy that bridges chat.completions "
+            "to the ChatGPT backend.",
+            "This reuses OpenAI's first-party Codex OAuth client. Using a ChatGPT subscription "
+            "through a non-official client may violate OpenAI's Terms of Service and can get your "
+            "account restricted; proceed at your own risk.",
+            "Use `vulnclaw logout` to remove stored tokens, or `vulnclaw config set llm.auth_mode "
+            "static` plus llm.api_key to switch back to a static API key.",
+        ),
+        examples=("vulnclaw login", "vulnclaw login --no-browser"),
+    ),
+    ManualTopic(
+        name="logout",
+        summary="Remove stored OAuth tokens from the ChatGPT sign-in flow.",
+        usage="vulnclaw logout",
+        notes=("Does not change llm.auth_mode; switch it back to static separately if needed.",),
+        examples=("vulnclaw logout",),
+    ),
+    ManualTopic(
+        name="manual",
+        summary="Print this full manual.",
+        usage="vulnclaw manual [TOPIC] [--format text|markdown|man]\nvulnclaw man [TOPIC] [--format text|markdown|man]\nvulnclaw --man",
+        flags=(
+            ("TOPIC", "Optional command/topic name such as scan, network-scan, config, or target-state."),
+            ("--format text, -f text", "Human terminal format. This is the default."),
+            ("--format markdown, -f markdown", "Markdown suitable for docs or README snippets."),
+            ("--format man, -f man", "roff man-page format suitable for saving as vulnclaw.1."),
+        ),
+        notes=(
+            "The manual command is packaged with VulnClaw, so it works from installed wheels and source checkouts.",
+        ),
+        examples=(
+            "vulnclaw manual",
+            "vulnclaw manual network-scan",
+            "vulnclaw manual --format man",
+        ),
+        aliases=("man", "help-man"),
+    ),
+)
+
+TASK_COMMAND_NAMES = {"run", "persistent", "recon", "scan", "network-scan", "exploit"}
+
+
+def render_manual(output_format: str = "text", topic: str | None = None) -> str:
+    """Render the VulnClaw manual in text, markdown, or roff man-page format."""
+
+    fmt = output_format.strip().lower()
+    if fmt not in {"text", "markdown", "man"}:
+        raise ValueError("manual format must be one of: text, markdown, man")
+
+    topics = _select_topics(topic)
+    normalized_topic = _normalize_topic(topic)
+    if fmt == "markdown":
+        return _render_markdown(topics, normalized_topic)
+    if fmt == "man":
+        return _render_man(topics, normalized_topic)
+    return _render_text(topics, normalized_topic)
+
+
+def available_topics() -> list[str]:
+    """Return the user-facing topic names accepted by the manual command."""
+
+    return [topic.name for topic in COMMANDS]
+
+
+def _select_topics(topic: str | None) -> tuple[ManualTopic, ...]:
+    normalized = _normalize_topic(topic)
+    if not normalized:
+        return COMMANDS
+
+    by_name = {item.name: item for item in COMMANDS}
+    for item in COMMANDS:
+        by_name.update({alias: item for alias in item.aliases})
+
+    selected = by_name.get(normalized)
+    if not selected:
+        raise ValueError(
+            f"unknown manual topic '{topic}'. Available topics: {', '.join(available_topics())}"
+        )
+    return (selected,)
+
+
+def _normalize_topic(topic: str | None) -> str:
+    return (topic or "").strip().lower().replace("_", "-")
+
+
+def _provider_names() -> str:
+    return ", ".join(provider.value for provider in PROVIDER_PRESETS)
+
+
+def _render_text(topics: tuple[ManualTopic, ...], topic: str) -> str:
+    lines: list[str] = [
+        "VULNCLAW(1) - VulnClaw CLI Manual",
+        f"Version: {__version__}",
+        "",
+        "SYNOPSIS",
+        "  vulnclaw [--help] [--version] [--man] [COMMAND] [ARGS]...",
+        "  vulnclaw manual [TOPIC] [--format text|markdown|man]",
+        "",
+        "DESCRIPTION",
+        "  VulnClaw is an AI-assisted CLI for authorized security testing. It combines",
+        "  natural-language tasking, scoped autonomous loops, target history, reports,",
+        "  MCP/built-in tools, a terminal workbench, and an optional local Web UI.",
+        "",
+        "ROOT OPTIONS",
+    ]
+    lines.extend(_render_text_pairs(ROOT_OPTIONS, indent_spaces=2))
+    lines.extend(
+        [
+            "",
+            "FAST START",
+            "  vulnclaw init",
+            "  vulnclaw config provider deepseek",
+            "  vulnclaw config set llm.api_key <key>",
+            "  vulnclaw doctor",
+            "  vulnclaw run https://authorized-target.example --allow-actions recon,scan",
+            "",
+            "COMMAND MAP",
+        ]
+    )
+    for item in COMMANDS:
+        lines.append(f"  {item.name:<13} {item.summary}")
+
+    if not topic or any(item.name in TASK_COMMAND_NAMES for item in topics):
+        lines.extend(_common_sections_text())
+
+    lines.extend(["", "COMMAND DETAILS"])
+    for item in topics:
+        lines.extend(_topic_text(item))
+
+    lines.extend(
+        [
+            "",
+            "CONFIG AND ENVIRONMENT",
+            f"  Provider presets: {_provider_names()}",
+            "  Config directory: ~/.vulnclaw by default, or VULNCLAW_CONFIG_DIR when set.",
+            "  High-value env vars: VULNCLAW_LLM_API_KEY, VULNCLAW_LLM_API_KEYS,",
+            "  VULNCLAW_LLM_PROVIDER, VULNCLAW_LLM_BASE_URL, VULNCLAW_LLM_MODEL,",
+            "  VULNCLAW_SESSION_OUTPUT_DIR, VULNCLAW_SESSION_MAX_ROUNDS,",
+            "  VULNCLAW_SESSION_SHOW_THINKING, VULNCLAW_SAFETY_PYTHON_EXECUTE_ENABLED.",
+            "",
+            "SAFETY",
+            "  VulnClaw is for authorized testing only. Scope flags and action constraints",
+            "  are there to make allowed boundaries explicit and enforceable, but they do",
+            "  not replace written authorization or a clear rules-of-engagement document.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _common_sections_text() -> list[str]:
+    lines = [
+        "",
+        "COMMON TASK FLAGS",
+    ]
+    lines.extend(_render_text_pairs(COMMON_TASK_FLAGS, indent_spaces=2))
+    lines.extend(
+        [
+            "",
+            "ACTION CONSTRAINTS",
+            f"  Recognized action names: {', '.join(ACTION_NAMES)}.",
+            "  Example: --allow-actions recon,scan blocks direct exploit/report commands",
+            "  and also constrains tool and phase transitions during agent execution.",
+        ]
+    )
+    return lines
+
+
+def _topic_text(topic: ManualTopic) -> list[str]:
+    lines = [
+        "",
+        topic.name.upper(),
+        f"  {topic.summary}",
+        "",
+        "  Usage:",
+    ]
+    for usage_line in topic.usage.splitlines():
+        lines.append(f"    {usage_line}")
+
+    if topic.flags:
+        lines.extend(["", "  Arguments and flags:"])
+        lines.extend(_render_text_pairs(topic.flags, indent_spaces=4))
+    if topic.notes:
+        lines.extend(["", "  Notes:"])
+        lines.extend(f"    - {note}" for note in topic.notes)
+    if topic.examples:
+        lines.extend(["", "  Examples:"])
+        lines.extend(f"    {example}" for example in topic.examples)
+    return lines
+
+
+def _render_text_pairs(pairs: tuple[tuple[str, str], ...], indent_spaces: int) -> list[str]:
+    pad = " " * indent_spaces
+    lines: list[str] = []
+    for name, description in pairs:
+        lines.append(f"{pad}{name}")
+        lines.append(f"{pad}  {description}")
+    return lines
+
+
+def _render_markdown(topics: tuple[ManualTopic, ...], topic: str) -> str:
+    lines: list[str] = [
+        "# VulnClaw CLI Manual",
+        "",
+        f"Version: `{__version__}`",
+        "",
+        "## Synopsis",
+        "",
+        "```bash",
+        "vulnclaw [--help] [--version] [--man] [COMMAND] [ARGS]...",
+        "vulnclaw manual [TOPIC] [--format text|markdown|man]",
+        "```",
+        "",
+        "## Description",
+        "",
+        "VulnClaw is an AI-assisted CLI for authorized security testing. It combines natural-language tasking, scoped autonomous loops, target history, reports, MCP/built-in tools, a terminal workbench, and an optional local Web UI.",
+        "",
+        "## Root Options",
+        "",
+    ]
+    lines.extend(_markdown_table(["Option", "Meaning"], ROOT_OPTIONS))
+    lines.extend(
+        [
+            "",
+            "## Fast Start",
+            "",
+            "```bash",
+            "vulnclaw init",
+            "vulnclaw config provider deepseek",
+            "vulnclaw config set llm.api_key <key>",
+            "vulnclaw doctor",
+            "vulnclaw run https://authorized-target.example --allow-actions recon,scan",
+            "```",
+            "",
+            "## Command Map",
+            "",
+        ]
+    )
+    lines.extend(_markdown_table(["Command", "Summary"], tuple((c.name, c.summary) for c in COMMANDS)))
+
+    if not topic or any(item.name in TASK_COMMAND_NAMES for item in topics):
+        lines.extend(
+            [
+                "",
+                "## Common Task Flags",
+                "",
+            ]
+        )
+        lines.extend(_markdown_table(["Flag", "Meaning"], COMMON_TASK_FLAGS))
+        lines.extend(
+            [
+                "",
+                "## Action Constraints",
+                "",
+                f"Recognized action names: `{', '.join(ACTION_NAMES)}`.",
+                "",
+                "Example: `--allow-actions recon,scan` blocks direct exploit/report commands and also constrains tool and phase transitions during agent execution.",
+            ]
+        )
+
+    lines.extend(["", "## Command Details", ""])
+    for item in topics:
+        lines.extend(_topic_markdown(item))
+
+    lines.extend(
+        [
+            "",
+            "## Config And Environment",
+            "",
+            f"Provider presets: `{_provider_names()}`.",
+            "",
+            "Config directory: `~/.vulnclaw` by default, or `VULNCLAW_CONFIG_DIR` when set.",
+            "",
+            "High-value env vars: `VULNCLAW_LLM_API_KEY`, `VULNCLAW_LLM_API_KEYS`, `VULNCLAW_LLM_PROVIDER`, `VULNCLAW_LLM_BASE_URL`, `VULNCLAW_LLM_MODEL`, `VULNCLAW_SESSION_OUTPUT_DIR`, `VULNCLAW_SESSION_MAX_ROUNDS`, `VULNCLAW_SESSION_SHOW_THINKING`, `VULNCLAW_SAFETY_PYTHON_EXECUTE_ENABLED`.",
+            "",
+            "## Safety",
+            "",
+            "VulnClaw is for authorized testing only. Scope flags and action constraints make allowed boundaries explicit and enforceable, but they do not replace written authorization or a clear rules-of-engagement document.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _topic_markdown(topic: ManualTopic) -> list[str]:
+    lines = [
+        f"### `{topic.name}`",
+        "",
+        topic.summary,
+        "",
+        "```bash",
+        *topic.usage.splitlines(),
+        "```",
+    ]
+    if topic.flags:
+        lines.extend(["", "Arguments and flags:", ""])
+        lines.extend(_markdown_table(["Name", "Meaning"], topic.flags))
+    if topic.notes:
+        lines.extend(["", "Notes:", ""])
+        lines.extend(f"- {note}" for note in topic.notes)
+    if topic.examples:
+        lines.extend(["", "Examples:", "", "```bash", *topic.examples, "```"])
+    lines.append("")
+    return lines
+
+
+def _markdown_table(headers: list[str], rows: tuple[tuple[str, str], ...]) -> list[str]:
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for left, right in rows:
+        lines.append(f"| `{left}` | {right} |")
+    return lines
+
+
+def _render_man(topics: tuple[ManualTopic, ...], topic: str) -> str:
+    lines = [
+        f'.TH VULNCLAW 1 "" "VulnClaw {__version__}" "VulnClaw Manual"',
+        ".SH NAME",
+        "vulnclaw \\- AI-assisted authorized security-testing CLI",
+        ".SH SYNOPSIS",
+        ".B vulnclaw",
+        "[--help] [--version] [--man] [COMMAND] [ARGS]...",
+        ".br",
+        ".B vulnclaw manual",
+        "[TOPIC] [--format text|markdown|man]",
+        ".SH DESCRIPTION",
+        "VulnClaw combines natural-language tasking, scoped autonomous loops, target history, reports, MCP and built-in tools, a terminal workbench, and an optional local Web UI.",
+        ".SH ROOT OPTIONS",
+    ]
+    lines.extend(_roff_pairs(ROOT_OPTIONS))
+    lines.extend(
+        [
+            ".SH COMMAND MAP",
+        ]
+    )
+    lines.extend(_roff_pairs(tuple((item.name, item.summary) for item in COMMANDS)))
+
+    if not topic or any(item.name in TASK_COMMAND_NAMES for item in topics):
+        lines.extend([".SH COMMON TASK FLAGS"])
+        lines.extend(_roff_pairs(COMMON_TASK_FLAGS))
+        lines.extend(
+            [
+                ".SH ACTION CONSTRAINTS",
+                f"Recognized action names: {', '.join(ACTION_NAMES)}.",
+            ]
+        )
+
+    lines.append(".SH COMMAND DETAILS")
+    for item in topics:
+        lines.extend(_topic_roff(item))
+
+    lines.extend(
+        [
+            ".SH CONFIG AND ENVIRONMENT",
+            f"Provider presets: {_provider_names()}.",
+            ".PP",
+            "Config directory: ~/.vulnclaw by default, or VULNCLAW_CONFIG_DIR when set.",
+            ".PP",
+            "High-value env vars: VULNCLAW_LLM_API_KEY, VULNCLAW_LLM_API_KEYS, VULNCLAW_LLM_PROVIDER, VULNCLAW_LLM_BASE_URL, VULNCLAW_LLM_MODEL, VULNCLAW_SESSION_OUTPUT_DIR, VULNCLAW_SESSION_MAX_ROUNDS, VULNCLAW_SESSION_SHOW_THINKING, VULNCLAW_SAFETY_PYTHON_EXECUTE_ENABLED.",
+            ".SH SAFETY",
+            "VulnClaw is for authorized testing only. Scope flags and action constraints make allowed boundaries explicit and enforceable, but they do not replace written authorization or a clear rules-of-engagement document.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _topic_roff(topic: ManualTopic) -> list[str]:
+    lines = [
+        ".SS " + _roff_escape(topic.name),
+        _roff_escape(topic.summary),
+        ".PP",
+        ".B Usage:",
+    ]
+    for usage_line in topic.usage.splitlines():
+        lines.extend([".br", _roff_escape(usage_line)])
+    if topic.flags:
+        lines.extend([".PP", ".B Arguments and flags:"])
+        lines.extend(_roff_pairs(topic.flags))
+    if topic.notes:
+        lines.extend([".PP", ".B Notes:"])
+        for note in topic.notes:
+            lines.extend([".IP \\[bu] 2", _roff_escape(note)])
+    if topic.examples:
+        lines.extend([".PP", ".B Examples:"])
+        for example in topic.examples:
+            lines.extend([".br", _roff_escape(example)])
+    return lines
+
+
+def _roff_pairs(pairs: tuple[tuple[str, str], ...]) -> list[str]:
+    lines: list[str] = []
+    for name, description in pairs:
+        lines.extend(
+            [
+                f".TP\n.B {_roff_escape(name)}",
+                _roff_escape(description),
+            ]
+        )
+    return lines
+
+
+def _roff_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("-", "\\-")

--- a/vulnclaw/cli/tui.py
+++ b/vulnclaw/cli/tui.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Callable, Literal, Optional
 
 # [修改] 2026-06-10 Nyaecho - 将 prompt_toolkit 导入移到 _run_pt_tui() 函数内部，避免硬性依赖
@@ -25,6 +26,11 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 from rich.text import Text
 
+from vulnclaw.config.schema import (
+    BUILTIN_MCP_SERVERS,
+    MCPServerConfig,
+    MCPTransportConfig,
+)
 from vulnclaw.config.settings import (
     apply_provider_preset,
     fetch_provider_models,
@@ -1577,3 +1583,502 @@ def _default_launcher(draft: TuiTaskDraft) -> None:
         cli_main.persistent(rounds=0, cycles=0, no_report=False, **common)
     else:
         cli_main.run(scope="full", output=None, **common)
+
+
+# ── Interactive config editor ──────────────────────────────────────
+# [新增] 从 VulnBot 移植的交互式配置编辑器, 适配 VulnClaw 的 schema
+# (新增 recon 分区, api_key 掩码, 三种 MCP transport, OAuth 字段只读)
+
+
+def _split_csv_items(raw: str) -> list[str]:
+    """Split a comma/newline separated string into cleaned items."""
+    return [item.strip() for item in raw.replace("\n", ",").split(",") if item.strip()]
+
+
+def _mask_secret(value: str) -> str:
+    """Mask a secret so only a hint of it reaches the terminal."""
+    value = (value or "").strip()
+    if not value:
+        return "(not set)"
+    if len(value) <= 8:
+        return "…" + value[-2:]
+    return f"{value[:2]}…{value[-4:]}"
+
+
+def _mask_key_list(keys: list[str]) -> str:
+    """Summarise a list of API keys without printing any in the clear."""
+    usable = [k for k in keys if k and k.strip()]
+    if not usable:
+        return "(none)"
+    return f"{_mask_secret(usable[0])} ({len(usable)} key{'s' if len(usable) != 1 else ''})"
+
+
+def _prompt_text_value(screen: Console, label: str, current: str) -> str:
+    """Prompt for a string value, keeping the current value on blank input."""
+    raw = Prompt.ask(label, default=current, console=screen).strip()
+    if raw == "!clear":
+        return ""
+    return current if raw == "" else raw
+
+
+def _prompt_choice_value(screen: Console, label: str, choices: list[str], current: str) -> str:
+    """Prompt for a choice value with a stable default."""
+    default = current if current in choices else choices[0]
+    return Prompt.ask(label, choices=choices, default=default, console=screen).strip()
+
+
+def _prompt_bool_value(screen: Console, label: str, current: bool) -> bool:
+    """Prompt for a boolean value."""
+    return Confirm.ask(label, default=current, console=screen)
+
+
+def _prompt_int_value(screen: Console, label: str, current: int) -> int:
+    """Prompt for an integer value, keeping the current value on blank input."""
+    while True:
+        raw = Prompt.ask(label, default=str(current), console=screen).strip()
+        if not raw:
+            return current
+        try:
+            return int(raw)
+        except ValueError:
+            screen.print(f"[{C_ERROR}]Enter a whole number.[/]")
+
+
+def _prompt_float_value(screen: Console, label: str, current: float) -> float:
+    """Prompt for a float value, keeping the current value on blank input."""
+    while True:
+        raw = Prompt.ask(label, default=str(current), console=screen).strip()
+        if not raw:
+            return current
+        try:
+            return float(raw)
+        except ValueError:
+            screen.print(f"[{C_ERROR}]Enter a number.[/]")
+
+
+def _prompt_list_value(screen: Console, label: str, current: list[str]) -> list[str]:
+    """Prompt for a comma-separated list value."""
+    raw = Prompt.ask(label, default=", ".join(current), console=screen).strip()
+    if raw == "!clear":
+        return []
+    if not raw:
+        return current
+    return _split_csv_items(raw)
+
+
+def _prompt_env_value(
+    screen: Console, label: str, current: dict[str, str] | None
+) -> dict[str, str]:
+    """Prompt for key=value pairs separated by commas."""
+    current_text = ", ".join(f"{k}={v}" for k, v in sorted((current or {}).items()))
+    raw = Prompt.ask(label, default=current_text, console=screen).strip()
+    if raw == "!clear":
+        return {}
+    if not raw:
+        return current or {}
+
+    result: dict[str, str] = {}
+    for item in _split_csv_items(raw):
+        if "=" not in item:
+            raise ValueError("Environment entries must look like KEY=value")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("Environment keys cannot be blank")
+        result[key] = value.strip()
+    return result
+
+
+def _render_config_summary(screen: Console, config) -> None:
+    """Render a compact summary of the editable config sections."""
+    llm = Table(title="LLM", box=box.ROUNDED, border_style=C_BORDER_SUBTLE)
+    llm.add_column("Field", style=f"bold {C_PRIMARY}")
+    llm.add_column("Value", style=C_TEXT)
+    llm.add_row("Provider", config.llm.provider)
+    llm.add_row("Model", config.llm.model)
+    llm.add_row("Base URL", config.llm.base_url)
+    llm.add_row("Auth mode", config.llm.auth_mode)
+    llm.add_row("API key", _mask_secret(config.llm.api_key))
+    llm.add_row("API keys", _mask_key_list(config.llm.api_keys))
+    llm.add_row("ChatGPT auto-proxy", "yes" if config.llm.chatgpt_auto_proxy else "no")
+    llm.add_row("OAuth token URL", config.llm.oauth_token_url or "(login-managed)")
+    llm.add_row("OAuth client id", config.llm.oauth_client_id or "(login-managed)")
+    llm.add_row("Reasoning", config.llm.reasoning_effort)
+
+    session = Table(title="Session", box=box.ROUNDED, border_style=C_BORDER_SUBTLE)
+    session.add_column("Field", style=f"bold {C_SECONDARY}")
+    session.add_column("Value", style=C_TEXT)
+    session.add_row("Output dir", str(config.session.output_dir))
+    session.add_row("Engine", config.session.engine)
+    session.add_row("Max rounds", str(config.session.max_rounds))
+    session.add_row("Report format", config.session.report_format)
+    session.add_row("PoC language", config.session.poc_language)
+    session.add_row("Language", config.session.language)
+    session.add_row("Show thinking", "yes" if config.session.show_thinking else "no")
+    session.add_row("Persistent cycles", str(config.session.persistent_max_cycles))
+
+    safety = Table(title="Safety", box=box.ROUNDED, border_style=C_BORDER_SUBTLE)
+    safety.add_column("Field", style=f"bold {C_ACCENT}")
+    safety.add_column("Value", style=C_TEXT)
+    safety.add_row("Python execute", "yes" if config.safety.enable_python_execute else "no")
+    safety.add_row("Restricted", "yes" if config.safety.python_execute_restricted else "no")
+    safety.add_row("Mode", config.safety.python_execute_mode)
+    safety.add_row("Parallel tools", "yes" if config.safety.tool_parallel else "no")
+
+    recon = Table(title="Recon", box=box.ROUNDED, border_style=C_BORDER_SUBTLE)
+    recon.add_column("Field", style=f"bold {C_PRIMARY}")
+    recon.add_column("Value", style=C_TEXT)
+    recon.add_row("FOFA email", config.recon.fofa_email or "(not set)")
+    recon.add_row("FOFA key", _mask_secret(config.recon.fofa_key))
+    recon.add_row("Hunter key", _mask_secret(config.recon.hunter_key))
+    recon.add_row("Quake key", _mask_secret(config.recon.quake_key))
+    recon.add_row("ZoomEye key", _mask_secret(config.recon.zoomeye_key))
+    recon.add_row("Shodan key", _mask_secret(config.recon.shodan_key))
+    recon.add_row("0.zone key", _mask_secret(config.recon.zerozone_key))
+    recon.add_row("Max concurrency", str(config.recon.max_concurrency))
+
+    mcp = Table(title="MCP Servers", box=box.ROUNDED, border_style=C_BORDER_SUBTLE)
+    mcp.add_column("Name", style=f"bold {C_PRIMARY}")
+    mcp.add_column("Status", style=C_TEXT)
+    mcp.add_column("Transport", style=C_MUTED)
+    for name, server in config.mcp.servers.items():
+        transport = server.transport
+        if transport.type == "stdio":
+            details = " ".join(
+                part for part in [transport.command or "", " ".join(transport.args or [])] if part
+            ).strip()
+            summary = f"stdio {details}".strip()
+        else:
+            summary = f"{transport.type} {transport.url or ''}".strip()
+        status = "enabled" if server.enabled else "disabled"
+        if name in BUILTIN_MCP_SERVERS:
+            status += ", builtin"
+        mcp.add_row(name, status, summary)
+
+    screen.print(
+        Panel(
+            Group(llm, session, safety, recon, mcp),
+            title="Config Draft",
+            border_style=C_BORDER,
+            box=box.ROUNDED,
+        )
+    )
+
+
+def _edit_llm_config(screen: Console, config):
+    """Edit LLM configuration fields in-place."""
+    screen.print(Panel("Edit LLM settings", border_style=C_BORDER_SUBTLE, box=box.ROUNDED))
+    providers = [item["provider"] for item in list_providers()]
+    provider = _prompt_choice_value(screen, "Provider", providers, config.llm.provider)
+    if provider != config.llm.provider:
+        config = apply_provider_preset(config, provider)
+
+    config.llm.base_url = _prompt_text_value(screen, "Base URL", config.llm.base_url)
+    config.llm.model = _prompt_text_value(screen, "Model", config.llm.model)
+    config.llm.auth_mode = _prompt_choice_value(
+        screen, "Auth mode", ["static", "oauth"], config.llm.auth_mode
+    )
+    config.llm.api_keys = _prompt_list_value(
+        screen,
+        "API keys (comma-separated, !clear to empty)",
+        config.llm.api_keys,
+    )
+    config.llm.api_key = _prompt_text_value(
+        screen,
+        "Single API key fallback (!clear to empty)",
+        config.llm.api_key,
+    )
+    config.llm.chatgpt_auto_proxy = _prompt_bool_value(
+        screen, "ChatGPT auto-proxy", config.llm.chatgpt_auto_proxy
+    )
+    config.llm.max_tokens = _prompt_int_value(screen, "Max tokens", config.llm.max_tokens)
+    config.llm.max_context_tokens = _prompt_int_value(
+        screen, "Max context tokens", config.llm.max_context_tokens
+    )
+    config.llm.temperature = _prompt_float_value(screen, "Temperature", config.llm.temperature)
+    config.llm.reasoning_effort = _prompt_text_value(
+        screen, "Reasoning effort", config.llm.reasoning_effort
+    )
+    screen.print(
+        f"[{C_MUTED}]OAuth endpoints are managed by `vulnclaw login` and are not edited here.[/]"
+    )
+    return config
+
+
+def _edit_session_config(screen: Console, config):
+    """Edit the commonly-tuned session fields in-place.
+
+    Deep engine/reflexion/plugin knobs are left to `vulnclaw config set`.
+    """
+    screen.print(Panel("Edit session settings", border_style=C_BORDER_SUBTLE, box=box.ROUNDED))
+    config.session.output_dir = Path(
+        _prompt_text_value(screen, "Output directory", str(config.session.output_dir))
+    )
+    config.session.auto_save = _prompt_bool_value(screen, "Auto save", config.session.auto_save)
+    config.session.report_format = _prompt_choice_value(
+        screen, "Report format", ["markdown", "html"], config.session.report_format
+    )
+    config.session.poc_language = _prompt_choice_value(
+        screen, "PoC language", ["python", "bash"], config.session.poc_language
+    )
+    config.session.engine = _prompt_choice_value(
+        screen, "Autonomous engine", ["solve", "rounds"], config.session.engine
+    )
+    config.session.max_rounds = _prompt_int_value(screen, "Max rounds", config.session.max_rounds)
+    config.session.show_thinking = _prompt_bool_value(
+        screen, "Show thinking", config.session.show_thinking
+    )
+    config.session.persistent_rounds_per_cycle = _prompt_int_value(
+        screen, "Persistent rounds per cycle", config.session.persistent_rounds_per_cycle
+    )
+    config.session.persistent_max_cycles = _prompt_int_value(
+        screen, "Persistent max cycles", config.session.persistent_max_cycles
+    )
+    config.session.persistent_auto_report = _prompt_bool_value(
+        screen, "Persistent auto report", config.session.persistent_auto_report
+    )
+    config.session.language = _prompt_choice_value(
+        screen, "Language", ["auto", "en", "zh"], config.session.language
+    )
+    return config
+
+
+def _edit_safety_config(screen: Console, config):
+    """Edit safety configuration fields in-place."""
+    screen.print(Panel("Edit safety settings", border_style=C_BORDER_SUBTLE, box=box.ROUNDED))
+    config.safety.enable_python_execute = _prompt_bool_value(
+        screen, "Enable python execute", config.safety.enable_python_execute
+    )
+    config.safety.python_execute_restricted = _prompt_bool_value(
+        screen, "Python execute restricted", config.safety.python_execute_restricted
+    )
+    config.safety.python_execute_mode = _prompt_choice_value(
+        screen,
+        "Python execute mode",
+        ["safe", "lab", "trusted-local"],
+        config.safety.python_execute_mode,
+    )
+    config.safety.python_execute_max_lines = _prompt_int_value(
+        screen, "Python execute max lines", config.safety.python_execute_max_lines
+    )
+    config.safety.python_execute_show_warning = _prompt_bool_value(
+        screen, "Show python execute warning", config.safety.python_execute_show_warning
+    )
+    config.safety.python_execute_max_output_chars = _prompt_int_value(
+        screen,
+        "Python execute max output chars",
+        config.safety.python_execute_max_output_chars,
+    )
+    config.safety.python_execute_audit_enabled = _prompt_bool_value(
+        screen, "Python execute audit enabled", config.safety.python_execute_audit_enabled
+    )
+    config.safety.tool_parallel = _prompt_bool_value(
+        screen, "Parallel tool calls", config.safety.tool_parallel
+    )
+    config.safety.tool_max_concurrent = _prompt_int_value(
+        screen, "Max concurrent tools", config.safety.tool_max_concurrent
+    )
+    return config
+
+
+def _edit_recon_config(screen: Console, config):
+    """Edit recon / space-mapping configuration fields in-place."""
+    screen.print(Panel("Edit recon settings", border_style=C_BORDER_SUBTLE, box=box.ROUNDED))
+    config.recon.fofa_email = _prompt_text_value(
+        screen, "FOFA email", config.recon.fofa_email
+    )
+    config.recon.fofa_key = _prompt_text_value(
+        screen, "FOFA key (!clear to empty)", config.recon.fofa_key
+    )
+    config.recon.hunter_key = _prompt_text_value(
+        screen, "Hunter key (!clear to empty)", config.recon.hunter_key
+    )
+    config.recon.quake_key = _prompt_text_value(
+        screen, "Quake key (!clear to empty)", config.recon.quake_key
+    )
+    config.recon.zoomeye_key = _prompt_text_value(
+        screen, "ZoomEye key (!clear to empty)", config.recon.zoomeye_key
+    )
+    config.recon.shodan_key = _prompt_text_value(
+        screen, "Shodan key (!clear to empty)", config.recon.shodan_key
+    )
+    config.recon.zerozone_key = _prompt_text_value(
+        screen, "0.zone key (!clear to empty)", config.recon.zerozone_key
+    )
+    config.recon.http_timeout = _prompt_float_value(
+        screen, "HTTP timeout (s)", config.recon.http_timeout
+    )
+    config.recon.max_concurrency = _prompt_int_value(
+        screen, "Max concurrency", config.recon.max_concurrency
+    )
+    config.recon.space_size = _prompt_int_value(
+        screen, "Space-mapping result size", config.recon.space_size
+    )
+    config.recon.dir_wordlist_path = _prompt_text_value(
+        screen, "Directory wordlist path (!clear to empty)", config.recon.dir_wordlist_path
+    )
+    config.recon.dir_max_requests = _prompt_int_value(
+        screen, "Directory enumeration max requests", config.recon.dir_max_requests
+    )
+    config.recon.js_max_files = _prompt_int_value(
+        screen, "Max JS files per js_recon", config.recon.js_max_files
+    )
+    return config
+
+
+def _prompt_mcp_transport(screen: Console, transport: MCPTransportConfig) -> MCPTransportConfig:
+    """Edit transport settings for an MCP server."""
+    transport.type = _prompt_choice_value(
+        screen, "Transport type", ["stdio", "sse", "streamable-http"], transport.type
+    )
+    transport.command = _prompt_text_value(screen, "Transport command", transport.command or "")
+    transport.args = _prompt_list_value(
+        screen,
+        "Transport args (comma-separated, !clear to empty)",
+        transport.args or [],
+    )
+    transport.url = _prompt_text_value(screen, "Transport URL", transport.url or "")
+    transport.env = _prompt_env_value(
+        screen, "Transport env / headers (KEY=value, !clear to empty)", transport.env
+    )
+    transport.startup_timeout = _prompt_int_value(
+        screen, "Transport startup timeout", transport.startup_timeout
+    )
+    transport.tool_timeout = _prompt_int_value(
+        screen, "Transport tool timeout", transport.tool_timeout
+    )
+    return transport
+
+
+def _prompt_mcp_server(
+    screen: Console, config, *, server: MCPServerConfig | None = None
+) -> tuple[str, MCPServerConfig]:
+    """Create or edit a single MCP server definition."""
+    is_new = server is None
+    current_name = server.name if server else ""
+    while True:
+        if is_new:
+            name = _prompt_text_value(screen, "Server name", current_name)
+            if not name:
+                screen.print(f"[{C_ERROR}]Server name cannot be blank.[/]")
+                continue
+            if name in config.mcp.servers:
+                screen.print(f"[{C_ERROR}]Server '{name}' already exists.[/]")
+                continue
+        else:
+            name = current_name
+        break
+
+    current = server or MCPServerConfig(
+        name=name,
+        enabled=True,
+        priority=1,
+        transport=MCPTransportConfig(type="stdio"),
+    )
+    current.name = name
+    current.enabled = _prompt_bool_value(screen, f"Enabled [{name}]", current.enabled)
+    current.priority = _prompt_int_value(screen, f"Priority [{name}]", current.priority)
+    current.description = _prompt_text_value(screen, f"Description [{name}]", current.description)
+    current.transport = _prompt_mcp_transport(screen, current.transport)
+    return name, current
+
+
+def _edit_mcp_config(screen: Console, config):
+    """Edit MCP server configuration."""
+    while True:
+        screen.print(Panel("Edit MCP servers", border_style=C_BORDER_SUBTLE, box=box.ROUNDED))
+        table = Table(box=box.SIMPLE, border_style=C_BORDER_SUBTLE)
+        table.add_column("Server", style=f"bold {C_PRIMARY}")
+        table.add_column("Enabled", style=C_TEXT)
+        table.add_column("Priority", style=C_TEXT)
+        table.add_column("Transport", style=C_MUTED)
+        for name, server in config.mcp.servers.items():
+            marker = "builtin" if name in BUILTIN_MCP_SERVERS else "custom"
+            table.add_row(
+                name,
+                "yes" if server.enabled else "no",
+                str(server.priority),
+                f"{server.transport.type} / {marker}",
+            )
+        screen.print(table)
+
+        action = Prompt.ask(
+            "Action",
+            choices=["add", "edit", "delete", "back"],
+            default="back",
+            console=screen,
+        ).strip()
+
+        if action == "back":
+            return config
+        if action == "add":
+            name, server = _prompt_mcp_server(screen, config)
+            config.mcp.servers[name] = server
+            continue
+        if action == "edit":
+            if not config.mcp.servers:
+                screen.print(f"[{C_WARNING}]No MCP servers to edit.[/]")
+                continue
+            name = Prompt.ask(
+                "Server to edit",
+                choices=list(config.mcp.servers.keys()),
+                default=next(iter(config.mcp.servers)),
+                console=screen,
+            ).strip()
+            current = config.mcp.servers[name]
+            _, server = _prompt_mcp_server(screen, config, server=current)
+            config.mcp.servers[name] = server
+            continue
+        if action == "delete":
+            if not config.mcp.servers:
+                screen.print(f"[{C_WARNING}]No MCP servers to delete.[/]")
+                continue
+            name = Prompt.ask(
+                "Server to delete",
+                choices=list(config.mcp.servers.keys()),
+                default=next(iter(config.mcp.servers)),
+                console=screen,
+            ).strip()
+            if name in BUILTIN_MCP_SERVERS:
+                screen.print(
+                    f"[{C_WARNING}]Built-in servers are seeded defaults and cannot be deleted here.[/]"
+                )
+                continue
+            if Confirm.ask(f"Delete MCP server '{name}'?", default=False, console=screen):
+                config.mcp.servers.pop(name, None)
+            continue
+
+
+def run_config_tui() -> None:
+    """Run the interactive config editor."""
+    screen = Console()
+    config = load_config()
+
+    while True:
+        screen.print()
+        screen.print(Panel("VulnClaw Config", border_style=C_BORDER, box=box.ROUNDED))
+        _render_config_summary(screen, config)
+        action = Prompt.ask(
+            "Section",
+            choices=["llm", "session", "safety", "recon", "mcp", "save", "quit"],
+            default="save",
+            console=screen,
+        ).strip()
+
+        if action == "llm":
+            config = _edit_llm_config(screen, config)
+        elif action == "session":
+            config = _edit_session_config(screen, config)
+        elif action == "safety":
+            config = _edit_safety_config(screen, config)
+        elif action == "recon":
+            config = _edit_recon_config(screen, config)
+        elif action == "mcp":
+            config = _edit_mcp_config(screen, config)
+        elif action == "save":
+            save_config(config)
+            screen.print(Panel("Config saved.", border_style=C_SUCCESS, box=box.ROUNDED))
+            return
+        elif action == "quit":
+            screen.print(Panel("Discarded changes.", border_style=C_WARNING, box=box.ROUNDED))
+            return

--- a/vulnclaw/cli/tui.py
+++ b/vulnclaw/cli/tui.py
@@ -738,6 +738,22 @@ def _resolve_repl_command(name: str) -> str:
     return key if key in REPL_COMMANDS else ""
 
 
+def skill_display_description(skill: dict[str, Any]) -> str:
+    """Localized description for a skill's palette / help entry.
+
+    Skill frontmatter descriptions are authored in Chinese. When a localized
+    override exists in the i18n catalog for the active language (key
+    ``skill.<name>.description``, e.g. the English strings in ``en.json``),
+    prefer it; otherwise fall back to the frontmatter description.
+    """
+    name = skill.get("name", "")
+    key = f"skill.{name}.description"
+    localized = _(key)
+    if localized and localized != key:
+        return localized
+    return skill.get("description", "") or f"{skill.get('type', 'skill')} skill"
+
+
 def list_skill_palette_entries(prefix: str = "") -> list[tuple[str, str]]:
     """Return palette entries for available skills only (no built-in commands).
 
@@ -749,7 +765,7 @@ def list_skill_palette_entries(prefix: str = "") -> list[tuple[str, str]]:
         name = skill["name"]
         if normalized and not name.lower().startswith(normalized):
             continue
-        description = skill.get("description", "") or f"{skill.get('type', 'skill')} skill"
+        description = skill_display_description(skill)
         refs = skill.get("references", "0")
         entries.append((name, f"Skill · {description} · {refs} refs"))
     return entries
@@ -1027,7 +1043,7 @@ def render_slash_skill_help(skill: dict[str, Any]) -> str:
     refs = skill.get("references", [])
     lines = [
         f"/{skill['name']} skill",
-        skill.get("description", "") or "No description available.",
+        skill_display_description(skill) or "No description available.",
         f"Format: {skill.get('format', 'unknown')}",
     ]
     if refs:

--- a/vulnclaw/cli/tui.py
+++ b/vulnclaw/cli/tui.py
@@ -33,6 +33,13 @@ from vulnclaw.config.settings import (
     save_config,
 )
 from vulnclaw.i18n import _, init_i18n
+from vulnclaw.skills.flag_skills import (
+    apply_flag_skill_to_tui_state,
+    complete_flag_skills,
+    find_flag_skill,
+    parse_flag_skill_command,
+    render_flag_skill_compact,
+)
 from vulnclaw.target_state.store import get_target_state_preview, list_target_snapshots
 
 # ── opencode-inspired colour palette ──
@@ -435,19 +442,35 @@ def _run_pt_tui(session: dict[str, Any]) -> Optional[str]:
 
     session["_palette_idx"] = 0
 
-    def _palette_visible() -> bool:
+    def _palette_context() -> tuple[str, str] | None:
         text = input_buffer.text
-        if not text.startswith("/"):
-            return False
-        word = text.lstrip("/")
-        if " " in word:
-            return False
-        return True
+        if text.startswith("/."):
+            word = text[2:]
+            if " " in word:
+                return None
+            return "flag", word
+        if text.startswith("/"):
+            word = text.lstrip("/")
+            if " " in word:
+                return None
+            return "slash", word
+        return None
+
+    def _palette_visible() -> bool:
+        return _palette_context() is not None
 
     def _palette_filtered() -> list[tuple[str, str]]:
-        word = input_buffer.text.lstrip("/")
-        return [(cmd, desc) for cmd, desc in SLASH_COMMANDS.items()
-                if cmd.startswith(word)]
+        context = _palette_context()
+        if context is None:
+            return []
+        kind, word = context
+        if kind == "flag":
+            return [(skill.name, skill.summary) for skill in complete_flag_skills(word)]
+        return [(cmd, desc) for cmd, desc in SLASH_COMMANDS.items() if cmd.startswith(word)]
+
+    def _palette_prefix() -> str:
+        context = _palette_context()
+        return "/." if context and context[0] == "flag" else "/"
 
     def _palette_content() -> list[tuple[str, str]]:
         items = _palette_filtered()
@@ -462,10 +485,10 @@ def _run_pt_tui(session: dict[str, Any]) -> Optional[str]:
         for i, (cmd, desc) in enumerate(items):
             prefix = "▸" if i == sel else " "
             if i == sel:
-                result.append((f"fg:{C_PRIMARY} bold bg:#2a2a2a", f" {prefix} /{cmd:<12}"))
+                result.append((f"fg:{C_PRIMARY} bold bg:#2a2a2a", f" {prefix} {_palette_prefix()}{cmd:<12}"))
                 result.append((f"fg:{C_MUTED} bg:#2a2a2a", f" {desc}\n"))
             else:
-                result.append((f"fg:{C_PRIMARY} bold bg:#1e1e1e", f" {prefix} /{cmd:<12}"))
+                result.append((f"fg:{C_PRIMARY} bold bg:#1e1e1e", f" {prefix} {_palette_prefix()}{cmd:<12}"))
                 result.append((f"fg:{C_MUTED} bg:#1e1e1e", f" {desc}\n"))
         result.append((f"fg:{C_BORDER} bg:#1e1e1e", "╰" + "─" * box_inner + "╯"))
         return result
@@ -476,7 +499,7 @@ def _run_pt_tui(session: dict[str, Any]) -> Optional[str]:
         items = _palette_filtered()
         if items:
             sel = session["_palette_idx"] % len(items)
-            input_buffer.text = "/" + items[sel][0]
+            input_buffer.text = _palette_prefix() + items[sel][0]
             input_buffer.cursor_position = len(input_buffer.text)
 
     body = HSplit([
@@ -692,6 +715,23 @@ def _build_slash_completer() -> Any:
             if not text.startswith("/"):
                 return
 
+            if text.startswith("/."):
+                word = text[2:]
+                if " " in word:
+                    return
+                for skill in complete_flag_skills(word):
+                    start_position = -len(word) if word else 0
+                    yield Completion(
+                        skill.name,
+                        start_position=start_position,
+                        display=[
+                            (f"fg:{C_PRIMARY} bold", f"/.{skill.name}"),
+                            ("", "  "),
+                            (f"fg:{C_MUTED}", skill.summary),
+                        ],
+                    )
+                return
+
             word = text.lstrip("/")
 
             if not word:
@@ -719,6 +759,10 @@ def _build_slash_completer() -> Any:
 
 
 def _dispatch_slash(text: str, session: dict[str, Any]) -> None:
+    if text.startswith("/."):
+        _dispatch_flag_skill(text, session)
+        return
+
     parts = text.lstrip("/").strip().split(maxsplit=1)
     cmd = parts[0].lower()
     args = parts[1] if len(parts) > 1 else ""
@@ -737,6 +781,22 @@ def _register_handler(cmd: str):
         _SLASH_HANDLERS[cmd] = fn
         return fn
     return deco
+
+
+def _dispatch_flag_skill(text: str, session: dict[str, Any]) -> None:
+    command = parse_flag_skill_command(text)
+    skill = find_flag_skill(command.query)
+    if skill is None:
+        session["_message"] = f"Unknown flag skill: /.{command.query}"
+        return
+
+    if command.value or skill.tui_action in {"resume_true", "resume_false"}:
+        result = apply_flag_skill_to_tui_state(skill, command.value, session["state"])
+        if result.applied or result.error:
+            session["_message"] = result.message
+            return
+
+    _set_prompt_message(session, render_flag_skill_compact(skill))
 
 
 @_register_handler("quit")

--- a/vulnclaw/cli/tui.py
+++ b/vulnclaw/cli/tui.py
@@ -39,13 +39,16 @@ from vulnclaw.config.settings import (
     save_config,
 )
 from vulnclaw.i18n import _, init_i18n
+from vulnclaw.skills.dispatcher import SkillDispatcher
 from vulnclaw.skills.flag_skills import (
     apply_flag_skill_to_tui_state,
     complete_flag_skills,
     find_flag_skill,
     parse_flag_skill_command,
+    render_flag_skill,
     render_flag_skill_compact,
 )
+from vulnclaw.skills.loader import load_skill_by_name
 from vulnclaw.target_state.store import get_target_state_preview, list_target_snapshots
 
 # ── opencode-inspired colour palette ──
@@ -472,7 +475,7 @@ def _run_pt_tui(session: dict[str, Any]) -> Optional[str]:
         kind, word = context
         if kind == "flag":
             return [(skill.name, skill.summary) for skill in complete_flag_skills(word)]
-        return [(cmd, desc) for cmd, desc in SLASH_COMMANDS.items() if cmd.startswith(word)]
+        return build_slash_palette_entries(word)
 
     def _palette_prefix() -> str:
         context = _palette_context()
@@ -709,6 +712,36 @@ def _build_slash_commands() -> dict[str, str]:
 SLASH_COMMANDS: dict[str, str] = _build_slash_commands()
 
 
+def list_skill_palette_entries(prefix: str = "") -> list[tuple[str, str]]:
+    """Return palette entries for available skills only (no built-in commands).
+
+    Used by the classic REPL, whose ``/`` menu lists skills exclusively.
+    """
+    normalized = prefix.strip().lower()
+    entries: list[tuple[str, str]] = []
+    for skill in SkillDispatcher().list_all_skills():
+        name = skill["name"]
+        if normalized and not name.lower().startswith(normalized):
+            continue
+        description = skill.get("description", "") or f"{skill.get('type', 'skill')} skill"
+        refs = skill.get("references", "0")
+        entries.append((name, f"Skill · {description} · {refs} refs"))
+    return entries
+
+
+def build_slash_palette_entries(prefix: str = "") -> list[tuple[str, str]]:
+    """Return command-palette entries for built-in commands and available skills."""
+    normalized = prefix.strip().lower()
+    entries: list[tuple[str, str]] = list_skill_palette_entries(prefix)
+
+    for cmd, desc in SLASH_COMMANDS.items():
+        if normalized and not cmd.startswith(normalized):
+            continue
+        entries.append((cmd, desc))
+
+    return entries
+
+
 def _build_slash_completer() -> Any:
     from prompt_toolkit.completion import Completer, Completion
 
@@ -741,7 +774,7 @@ def _build_slash_completer() -> Any:
             word = text.lstrip("/")
 
             if not word:
-                for cmd, desc in SLASH_COMMANDS.items():
+                for cmd, desc in build_slash_palette_entries():
                     yield Completion(
                         cmd,
                         start_position=0,
@@ -753,15 +786,130 @@ def _build_slash_completer() -> Any:
             typed_cmd = parts[0]
 
             if len(parts) == 1 and not text.endswith(" "):
-                for cmd, desc in SLASH_COMMANDS.items():
-                    if cmd.startswith(typed_cmd):
-                        yield Completion(
-                            cmd,
-                            start_position=-len(typed_cmd),
-                            display=[(f"fg:{C_PRIMARY} bold", f"/{cmd}"), ("", "  "), (f"fg:{C_MUTED}", desc)],
-                        )
+                for cmd, desc in build_slash_palette_entries(typed_cmd):
+                    yield Completion(
+                        cmd,
+                        start_position=-len(typed_cmd),
+                        display=[(f"fg:{C_PRIMARY} bold", f"/{cmd}"), ("", "  "), (f"fg:{C_MUTED}", desc)],
+                    )
 
     return _SlashCompleter()
+
+
+def build_repl_slash_completer() -> Any:
+    """Completer for the classic REPL: ``/`` lists skills, ``/.`` lists flag skills.
+
+    Unlike the Textual palette, the classic REPL's ``/`` menu never offers the
+    Textual TUI's slash commands (``/mode`` etc.) — those have no handler here.
+    """
+    from prompt_toolkit.completion import Completer, Completion
+
+    class _ReplSlashCompleter(Completer):
+        def get_completions(self, document, _complete_event):
+            text = document.text_before_cursor
+            if not text.startswith("/"):
+                return
+
+            if text.startswith("/."):
+                word = text[2:]
+                if " " in word:
+                    return
+                for skill in complete_flag_skills(word):
+                    start_position = -len(word) if word else 0
+                    yield Completion(
+                        skill.name,
+                        start_position=start_position,
+                        display=[
+                            (f"fg:{C_PRIMARY} bold", f"/.{skill.name}"),
+                            ("", "  "),
+                            (f"fg:{C_MUTED}", skill.summary),
+                        ],
+                    )
+                return
+
+            word = text[1:]
+            if " " in word:
+                # A skill is already chosen; the rest is free-text task input.
+                return
+            for name, desc in list_skill_palette_entries(word):
+                start_position = -len(word) if word else 0
+                yield Completion(
+                    name,
+                    start_position=start_position,
+                    display=[
+                        (f"fg:{C_PRIMARY} bold", f"/{name}"),
+                        ("", "  "),
+                        (f"fg:{C_MUTED}", desc),
+                    ],
+                )
+
+    return _ReplSlashCompleter()
+
+
+@dataclass
+class ReplSlashResult:
+    """Outcome of dispatching a ``/`` line in the classic REPL.
+
+    ``kind`` is one of:
+    - ``"run"``     — feed ``text`` to the agent as a natural-language prompt.
+    - ``"message"`` — print ``text`` and keep looping.
+    - ``"target"``  — set the REPL target to ``value`` (restore behaviour), then loop.
+    """
+
+    kind: Literal["run", "message", "target"]
+    text: str = ""
+    value: str = ""
+
+
+def dispatch_repl_slash(text: str) -> ReplSlashResult:
+    """Resolve a ``/`` or ``/.`` line into an intent for the classic REPL.
+
+    Pure: performs no I/O and mutates no state, so the loop stays in control of
+    printing and target restoration. See :class:`ReplSlashResult`.
+    """
+    stripped = text.strip()
+
+    if stripped.startswith("/."):
+        return _dispatch_repl_flag_skill(stripped)
+
+    body = stripped[1:].strip()
+    if not body:
+        return ReplSlashResult("message", "Type a skill name after '/', e.g. /recon <task>.")
+
+    parts = body.split(maxsplit=1)
+    name = parts[0]
+    task = parts[1].strip() if len(parts) > 1 else ""
+
+    skill = load_skill_by_name(name)
+    if skill is None:
+        return ReplSlashResult("message", f"Unknown skill: /{name}")
+
+    if task:
+        return ReplSlashResult("run", f"Use VulnClaw skill {skill['name']}. {task}")
+
+    return ReplSlashResult("message", render_slash_skill_help(skill))
+
+
+def _dispatch_repl_flag_skill(text: str) -> ReplSlashResult:
+    """Light (B1) flag-skill wiring for the classic REPL.
+
+    Only ``--target`` and ``--resume``/``--no-resume`` change REPL state; every
+    other flag skill is rendered as guidance, since the classic REPL keeps no
+    persistent mode/scope to apply them to.
+    """
+    command = parse_flag_skill_command(text)
+    skill = find_flag_skill(command.query)
+    if skill is None:
+        return ReplSlashResult("message", f"Unknown flag skill: /.{command.query}")
+
+    if skill.tui_action == "target":
+        if not command.value:
+            return ReplSlashResult("message", f"{skill.canonical} needs a host value, e.g. /.target example.com")
+        return ReplSlashResult("target", value=command.value)
+
+    # Everything else (mode/scope/action flags, resume, and guidance-only flags)
+    # has no persistent home in the classic REPL, so we render it as guidance.
+    return ReplSlashResult("message", render_flag_skill(skill))
 
 
 def _dispatch_slash(text: str, session: dict[str, Any]) -> None:
@@ -775,7 +923,7 @@ def _dispatch_slash(text: str, session: dict[str, Any]) -> None:
     handler = _SLASH_HANDLERS.get(cmd)
     if handler:
         handler(session, args)
-    else:
+    elif not dispatch_skill_slash_command(cmd, args, session):
         session["_message"] = f"Unknown command: /{cmd}"
 
 
@@ -803,6 +951,43 @@ def _dispatch_flag_skill(text: str, session: dict[str, Any]) -> None:
             return
 
     _set_prompt_message(session, render_flag_skill_compact(skill))
+
+def dispatch_skill_slash_command(cmd: str, args: str, session: dict[str, Any]) -> bool:
+    """Dispatch `/skill-name [task text]` commands from the TUI."""
+    skill = load_skill_by_name(cmd)
+    if skill is None:
+        return False
+
+    if args:
+        state: TuiState = session["state"]
+        if not state.target.strip():
+            session["_message"] = _("tui.please_set_target")
+            return True
+        prompt = f"Use VulnClaw skill {skill['name']}. {args.strip()}"
+        session["_nl_text"] = prompt
+        session["_nl_history"] = prompt
+        session["_action"] = "launch"
+        return True
+
+    _set_prompt_message(session, render_slash_skill_help(skill))
+    return True
+
+
+def render_slash_skill_help(skill: dict[str, Any]) -> str:
+    """Render compact help for a selected slash skill."""
+    refs = skill.get("references", [])
+    lines = [
+        f"/{skill['name']} skill",
+        skill.get("description", "") or "No description available.",
+        f"Format: {skill.get('format', 'unknown')}",
+    ]
+    if refs:
+        ref_list = ", ".join(refs[:5])
+        if len(refs) > 5:
+            ref_list += f", ... ({len(refs)} total)"
+        lines.append(f"References: {ref_list}")
+    lines.append(f"Run with this skill: /{skill['name']} <task>")
+    return " | ".join(lines)
 
 
 @_register_handler("quit")

--- a/vulnclaw/cli/tui.py
+++ b/vulnclaw/cli/tui.py
@@ -85,10 +85,11 @@ def rebuild_translations() -> None:
     Call this after init_i18n() with a new language to update all
     module-level globals that were built with _() translations.
     """
-    global MODES, MENU_ITEMS, SLASH_COMMANDS
+    global MODES, MENU_ITEMS, SLASH_COMMANDS, REPL_COMMANDS
     MODES = _build_modes()
     MENU_ITEMS = _build_menu_items()
     SLASH_COMMANDS = _build_slash_commands()
+    REPL_COMMANDS = _build_repl_commands()
 
 
 CheckMode = Literal["quick", "standard", "deep", "continuous"]
@@ -712,6 +713,31 @@ def _build_slash_commands() -> dict[str, str]:
 SLASH_COMMANDS: dict[str, str] = _build_slash_commands()
 
 
+def _build_repl_commands() -> dict[str, str]:
+    """Built-in commands the classic REPL implements itself (not skills).
+
+    These have real handlers in ``_run_repl`` — unlike the wider Textual-TUI
+    ``SLASH_COMMANDS`` set, which the classic REPL cannot dispatch.
+    """
+    return {
+        "config": _("tui.slash_config"),
+        "language": _("tui.slash_lang"),
+    }
+
+
+REPL_COMMANDS: dict[str, str] = _build_repl_commands()
+
+# Short aliases → canonical classic-REPL command name.
+_REPL_COMMAND_ALIASES: dict[str, str] = {"cfg": "config", "lang": "language"}
+
+
+def _resolve_repl_command(name: str) -> str:
+    """Return the canonical REPL command for ``name`` (or an alias), else ``""``."""
+    key = name.strip().lower()
+    key = _REPL_COMMAND_ALIASES.get(key, key)
+    return key if key in REPL_COMMANDS else ""
+
+
 def list_skill_palette_entries(prefix: str = "") -> list[tuple[str, str]]:
     """Return palette entries for available skills only (no built-in commands).
 
@@ -726,6 +752,22 @@ def list_skill_palette_entries(prefix: str = "") -> list[tuple[str, str]]:
         description = skill.get("description", "") or f"{skill.get('type', 'skill')} skill"
         refs = skill.get("references", "0")
         entries.append((name, f"Skill · {description} · {refs} refs"))
+    return entries
+
+
+def list_repl_palette_entries(prefix: str = "") -> list[tuple[str, str]]:
+    """Classic-REPL ``/`` palette: built-in commands first, then skills.
+
+    The Textual TUI's other slash commands (``/mode`` etc.) are still excluded —
+    only the commands the classic REPL actually handles are offered here.
+    """
+    normalized = prefix.strip().lower()
+    entries: list[tuple[str, str]] = []
+    for cmd, desc in REPL_COMMANDS.items():
+        if normalized and not cmd.startswith(normalized):
+            continue
+        entries.append((cmd, f"Command · {desc}"))
+    entries.extend(list_skill_palette_entries(prefix))
     return entries
 
 
@@ -797,10 +839,11 @@ def _build_slash_completer() -> Any:
 
 
 def build_repl_slash_completer() -> Any:
-    """Completer for the classic REPL: ``/`` lists skills, ``/.`` lists flag skills.
+    """Completer for the classic REPL: ``/`` lists commands+skills, ``/.`` flag skills.
 
-    Unlike the Textual palette, the classic REPL's ``/`` menu never offers the
-    Textual TUI's slash commands (``/mode`` etc.) — those have no handler here.
+    The ``/`` menu offers the classic REPL's built-in commands (``/config``,
+    ``/language``) followed by skills. The Textual TUI's other slash commands
+    (``/mode`` etc.) are still excluded — they have no handler here.
     """
     from prompt_toolkit.completion import Completer, Completion
 
@@ -829,9 +872,9 @@ def build_repl_slash_completer() -> Any:
 
             word = text[1:]
             if " " in word:
-                # A skill is already chosen; the rest is free-text task input.
+                # A command/skill is already chosen; the rest is free-text input.
                 return
-            for name, desc in list_skill_palette_entries(word):
+            for name, desc in list_repl_palette_entries(word):
                 start_position = -len(word) if word else 0
                 yield Completion(
                     name,
@@ -854,9 +897,10 @@ class ReplSlashResult:
     - ``"run"``     — feed ``text`` to the agent as a natural-language prompt.
     - ``"message"`` — print ``text`` and keep looping.
     - ``"target"``  — set the REPL target to ``value`` (restore behaviour), then loop.
+    - ``"command"`` — run built-in command ``value`` with arguments ``text``.
     """
 
-    kind: Literal["run", "message", "target"]
+    kind: Literal["run", "message", "target", "command"]
     text: str = ""
     value: str = ""
 
@@ -879,6 +923,11 @@ def dispatch_repl_slash(text: str) -> ReplSlashResult:
     parts = body.split(maxsplit=1)
     name = parts[0]
     task = parts[1].strip() if len(parts) > 1 else ""
+
+    # Built-in REPL commands (/config, /language) take precedence over skills.
+    command = _resolve_repl_command(name)
+    if command:
+        return ReplSlashResult("command", value=command, text=task)
 
     skill = load_skill_by_name(name)
     if skill is None:

--- a/vulnclaw/cli/tui_textual.py
+++ b/vulnclaw/cli/tui_textual.py
@@ -53,6 +53,7 @@ from vulnclaw.config.settings import (
     save_config,
 )
 from vulnclaw.i18n import _, init_i18n
+from vulnclaw.skills.flag_skills import complete_flag_skills, render_flag_skill
 from vulnclaw.target_state.store import get_target_state_preview, list_target_snapshots
 
 # ── Slash dispatch ──
@@ -69,6 +70,10 @@ def _register_handler(cmd: str):
 
 def _dispatch(session: dict[str, Any], text: str) -> str | None:
     """Dispatch slash command. Returns 'quit', 'launch', or None."""
+    if text.startswith("/."):
+        _dispatch_flag_skill(session, text)
+        return None
+
     # [修改] 2026-06-10 Nyaecho - 修复空 parts 导致 IndexError 的问题
     parts = text.lstrip("/").strip().split(maxsplit=1)
     if not parts:
@@ -93,6 +98,22 @@ def _cancel_prompt(session: dict[str, Any]) -> None:
         prompt[3]()
 
 
+def _dispatch_flag_skill(session: dict[str, Any], text: str) -> None:
+    command = _tui.parse_flag_skill_command(text)
+    skill = _tui.find_flag_skill(command.query)
+    if skill is None:
+        session["_message"] = f"Unknown flag skill: /.{command.query}"
+        return
+
+    if command.value or skill.tui_action in {"resume_true", "resume_false"}:
+        result = _tui.apply_flag_skill_to_tui_state(skill, command.value, session["state"])
+        if result.applied or result.error:
+            session["_message"] = result.message
+            return
+
+    _set_prompt(session, "message", render_flag_skill(skill))
+
+
 # ── Command palette widget ──
 
 class CommandPalette(ListView):
@@ -102,21 +123,32 @@ class CommandPalette(ListView):
         kwargs.setdefault("id", "cmd-palette")
         super().__init__(**kwargs)
         self._commands: list[str] = []
+        self._completion_prefix = "/"
 
-    def show_commands(self, prefix: str = "") -> None:
+    def show_commands(
+        self,
+        prefix: str = "",
+        *,
+        entries: list[tuple[str, str]] | None = None,
+        completion_prefix: str = "/",
+    ) -> None:
         for item in self.query_children(ListItem):
             item.remove()
         self._commands.clear()
-        for cmd, desc in _tui.SLASH_COMMANDS.items():
+        self._completion_prefix = completion_prefix
+        source_entries = entries if entries is not None else list(_tui.SLASH_COMMANDS.items())
+        for cmd, desc in source_entries:
             if cmd.startswith(prefix):
                 item = ListItem(Static(
-                    f"[bold {C_PRIMARY}]/{cmd}[/]  [{C_MUTED}]{desc}[/]"
+                    f"[bold {C_PRIMARY}]{completion_prefix}{cmd}[/]  [{C_MUTED}]{desc}[/]"
                 ))
                 self.mount(item)
                 self._commands.append(cmd)
         if self._commands:
             self.add_class("open")
             self.index = 0
+        else:
+            self.remove_class("open")
 
     def hide_palette(self) -> None:
         self.remove_class("open")
@@ -129,6 +161,10 @@ class CommandPalette(ListView):
         if self.index is not None and 0 <= self.index < len(self._commands):
             return self._commands[self.index]
         return None
+
+    @property
+    def completion_prefix(self) -> str:
+        return self._completion_prefix
 
 
 # ── Secondary popup widget ──
@@ -798,7 +834,13 @@ class DashboardScreen(Screen):
             return
         text = event.value or ""
         palette = self.query_one(CommandPalette)
-        if text.startswith("/"):
+        if text.startswith("/."):
+            word = text[2:]
+            if " " not in word:
+                entries = [(skill.name, skill.summary) for skill in complete_flag_skills(word)]
+                palette.show_commands(word, entries=entries, completion_prefix="/.")
+                return
+        elif text.startswith("/"):
             word = text.lstrip("/")
             if " " not in word:
                 palette.show_commands(word)
@@ -813,7 +855,7 @@ class DashboardScreen(Screen):
             cmd = palette.selected
             if cmd:
                 self._completing = True
-                self.query_one("#cmd-input").value = "/" + cmd + " "
+                self.query_one("#cmd-input").value = palette.completion_prefix + cmd + " "
                 self.query_one("#cmd-input").action_end()
                 self._completing = False
             palette.hide_palette()
@@ -872,7 +914,7 @@ class DashboardScreen(Screen):
             cmd = p.selected
             if cmd:
                 self._completing = True
-                self.query_one("#cmd-input").value = "/" + cmd + " "
+                self.query_one("#cmd-input").value = p.completion_prefix + cmd + " "
                 self.query_one("#cmd-input").action_end()
                 self._completing = False
             p.hide_palette()

--- a/vulnclaw/cli/tui_textual.py
+++ b/vulnclaw/cli/tui_textual.py
@@ -83,6 +83,8 @@ def _dispatch(session: dict[str, Any], text: str) -> str | None:
     handler = _SLASH_HANDLERS.get(cmd)
     if handler:
         return handler(session, args)
+    if _tui.dispatch_skill_slash_command(cmd, args, session):
+        return session.get("_action")
     return None
 
 
@@ -843,7 +845,11 @@ class DashboardScreen(Screen):
         elif text.startswith("/"):
             word = text.lstrip("/")
             if " " not in word:
-                palette.show_commands(word)
+                palette.show_commands(
+                    word,
+                    entries=_tui.build_slash_palette_entries(),
+                    completion_prefix="/",
+                )
                 return
         palette.hide_palette()
 

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -107,6 +107,11 @@ class LLMConfig(BaseModel):
         description="LLM provider name (openai/minimax/deepseek/zhipu/moonshot/qwen/siliconflow/doubao/baichuan/stepfun/sensetime/yi/custom)",
     )
     api_key: str = Field(default="", description="Static API key for the chosen provider (auth_mode=static)")
+    api_keys: list[str] = Field(
+        default_factory=list,
+        description="Optional list of API keys to fail over between when one is "
+        "rate-limited, out of quota, or invalid. Overrides api_key when non-empty.",
+    )
     auth_mode: str = Field(
         default="static",
         description="Credential mode: static (api_key) or oauth (browser sign-in via `vulnclaw login`).",
@@ -141,6 +146,20 @@ class LLMConfig(BaseModel):
     reasoning_effort: str = Field(
         default="high", description="Reasoning effort level (OpenAI o-series only)"
     )
+
+    def key_pool(self) -> list[str]:
+        """Return the ordered, de-blanked list of usable static API keys.
+
+        Prefers ``api_keys`` when it has any non-empty entry; otherwise falls
+        back to the single ``api_key``. Whitespace-only entries are dropped.
+        """
+        candidates = self.api_keys or ([self.api_key] if self.api_key else [])
+        return [k.strip() for k in candidates if k and k.strip()]
+
+    def primary_key(self) -> str:
+        """Return the first usable static API key, or an empty string if none."""
+        pool = self.key_pool()
+        return pool[0] if pool else ""
 
 
 class MCPTransportConfig(BaseModel):
@@ -270,6 +289,27 @@ class SessionConfig(BaseModel):
     )
     show_thinking: bool = Field(
         default=False, description="Show LLM thinking/reasoning output (default: off)"
+    )
+    repl_parallel_enabled: bool = Field(
+        default=True,
+        description="Use bounded child-agent fan-out by default for REPL auto-mode "
+        "(legacy 'rounds' engine only; the 'solve' engine uses solve_max_parallel)",
+    )
+    repl_parallel_agents: int = Field(
+        default=3,
+        description="Default child-agent count for REPL auto-mode fan-out",
+    )
+    repl_parallel_depth: int = Field(
+        default=1,
+        description="Default child-agent discovery depth for REPL auto-mode fan-out",
+    )
+    repl_parallel_worker_rounds: int = Field(
+        default=3,
+        description="Max rounds per REPL parallel worker",
+    )
+    repl_parallel_surface_limit: int = Field(
+        default=20,
+        description="Maximum discovered surfaces considered by REPL parallel auto-mode",
     )
     # Dead-loop detection
     stale_rounds_threshold: int = Field(

--- a/vulnclaw/config/settings.py
+++ b/vulnclaw/config/settings.py
@@ -136,6 +136,12 @@ def set_config_value(key: str, value: str) -> None:
                 value = float(value)
             elif annotation is bool:
                 value = value.lower() in ("true", "1", "yes")
+            elif getattr(annotation, "__origin__", None) is list:
+                # Accept a list as-is, or split a comma/newline-separated string.
+                if isinstance(value, str):
+                    value = [p.strip() for p in value.replace("\n", ",").split(",") if p.strip()]
+                else:
+                    value = list(value)
         setattr(obj, field_name, value)
     save_config(config)
 
@@ -199,6 +205,10 @@ def _overlay_env(config: VulnClawConfig) -> VulnClawConfig:
     # ── LLM ──────────────────────────────────────────────────────────
     if v := os.environ.get("VULNCLAW_LLM_API_KEY"):
         config.llm.api_key = v
+    if v := os.environ.get("VULNCLAW_LLM_API_KEYS"):
+        keys = [k.strip() for k in v.split(",") if k.strip()]
+        if keys:
+            config.llm.api_keys = keys
     if v := os.environ.get("VULNCLAW_LLM_BASE_URL"):
         config.llm.base_url = v
     if v := os.environ.get("VULNCLAW_LLM_MODEL"):
@@ -233,6 +243,20 @@ def _overlay_env(config: VulnClawConfig) -> VulnClawConfig:
             config.session.max_rounds = int(v)
     if v := os.environ.get("VULNCLAW_SESSION_SHOW_THINKING"):
         config.session.show_thinking = v.lower() in ("1", "true", "yes", "on")
+    if v := os.environ.get("VULNCLAW_SESSION_REPL_PARALLEL_ENABLED"):
+        config.session.repl_parallel_enabled = v.lower() in ("1", "true", "yes", "on")
+    if v := os.environ.get("VULNCLAW_SESSION_REPL_PARALLEL_AGENTS"):
+        with suppress(ValueError):
+            config.session.repl_parallel_agents = int(v)
+    if v := os.environ.get("VULNCLAW_SESSION_REPL_PARALLEL_DEPTH"):
+        with suppress(ValueError):
+            config.session.repl_parallel_depth = int(v)
+    if v := os.environ.get("VULNCLAW_SESSION_REPL_PARALLEL_WORKER_ROUNDS"):
+        with suppress(ValueError):
+            config.session.repl_parallel_worker_rounds = int(v)
+    if v := os.environ.get("VULNCLAW_SESSION_REPL_PARALLEL_SURFACE_LIMIT"):
+        with suppress(ValueError):
+            config.session.repl_parallel_surface_limit = int(v)
     if v := os.environ.get("VULNCLAW_SESSION_STALE_ROUNDS_THRESHOLD"):
         with suppress(ValueError):
             config.session.stale_rounds_threshold = int(v)
@@ -306,6 +330,8 @@ def _strip_defaults(raw: dict) -> None:
     # Keep it simple — just strip known default values
     if raw.get("llm", {}).get("api_key") == "":
         raw["llm"].pop("api_key", None)
+    if raw.get("llm", {}).get("api_keys") == []:
+        raw["llm"].pop("api_keys", None)
     # Don't strip base_url/model if provider is set — they may be provider-specific
     # Only strip if still at OpenAI defaults
     if raw.get("llm", {}).get("provider") == "openai":

--- a/vulnclaw/config/token_provider.py
+++ b/vulnclaw/config/token_provider.py
@@ -372,11 +372,15 @@ def _resolve_oauth_token(llm: Any) -> str:
 def resolve_llm_token(llm: Any) -> str:
     """Return the effective bearer token / API key for the configured auth mode.
 
-    ``static`` returns ``llm.api_key`` (possibly empty, preserving legacy
-    behaviour); ``oauth`` returns a valid access token, refreshing if needed.
+    ``static`` returns the primary key from ``llm.api_keys``/``llm.api_key``
+    (possibly empty, preserving legacy behaviour); ``oauth`` returns a valid
+    access token, refreshing if needed.
     """
     mode = str(_get(llm, "auth_mode") or "static").strip().lower()
     if mode in ("", "static"):
+        primary_key = getattr(llm, "primary_key", None)
+        if callable(primary_key):
+            return str(primary_key() or "")
         return str(_get(llm, "api_key") or "")
     if mode == "oauth":
         return _resolve_oauth_token(llm)
@@ -386,12 +390,15 @@ def resolve_llm_token(llm: Any) -> str:
 def has_llm_credentials(llm: Any) -> bool:
     """Whether usable credentials are configured, without minting a token.
 
-    ``static`` requires a non-empty ``api_key``; ``oauth`` requires stored
-    tokens. This is a cheap pre-flight check — it does NOT validate that the
-    credential actually works.
+    ``static`` requires a non-empty ``api_key``/``api_keys``; ``oauth``
+    requires stored tokens. This is a cheap pre-flight check — it does NOT
+    validate that the credential actually works.
     """
     mode = str(_get(llm, "auth_mode") or "static").strip().lower()
     if mode in ("", "static"):
+        primary_key = getattr(llm, "primary_key", None)
+        if callable(primary_key):
+            return bool(primary_key())
         return bool(_get(llm, "api_key"))
     if mode == "oauth":
         bundle = load_oauth_tokens()

--- a/vulnclaw/i18n/en.json
+++ b/vulnclaw/i18n/en.json
@@ -34,7 +34,6 @@
   "cli.init.step_api_key": "  2. Set API key: [bold]vulnclaw config set llm.api_key <your-key>[/]",
   "cli.init.step_cli": "  3. Start CLI: [bold]vulnclaw[/]",
   "cli.init.step_tui": "  4. Open TUI: [bold]vulnclaw tui[/]",
-
   "help.title": "VulnClaw Help",
   "help.commands": "Built-in Commands",
   "help.target": "[cyan]target <host>[/]      Set the active target",
@@ -63,20 +62,17 @@
   "help.example_vuln": "[dim]Look for vulnerabilities[/]",
   "help.example_exploit": "[dim]Try to exploit CVE-202X-XXXX[/]",
   "help.example_report": "[dim]Generate a pentest report[/]",
-
   "status.title": "Current Status",
   "status.target": "Target: [bold]{target}[/]",
   "status.phase": "Phase: [bold]{phase}[/]",
   "status.mcp_services": "MCP Services: [bold]{count}[/]",
   "status.tools": "Available Tools: [bold]{count}[/]",
   "status.thinking": "Thinking: {state}",
-
   "auto_pentest.title": "Autonomous Pentest Result",
   "auto_pentest.finished": "[*] Autonomous pentest finished",
   "auto_pentest.rounds": "    Total rounds: {rounds}",
   "auto_pentest.steps": "    Steps executed: {steps}",
   "auto_pentest.findings": "    Findings: {findings}",
-
   "persistent.title": "Persistent Pentest",
   "persistent.target": "Target: [bold]{target}[/]",
   "persistent.rounds": "Rounds per cycle: [bold]{rounds}[/]",
@@ -102,7 +98,6 @@
   "persistent.finished_summary": "\n[+] Persistent pentest finished: {cycles} cycles, {findings} findings",
   "cli.partial_report": "[+] Partial report: {path}",
   "cli.pentest_finished": "\n[+] Pentest finished with {findings} findings",
-
   "tui.title": "VulnClaw TUI Workbench",
   "tui.desc": "Terminal graphical entry for authorized security testing: Confirm target and boundaries before starting.",
   "tui.mode_quick": "Quick Scan",
@@ -226,7 +221,6 @@
   "tui.report_generated": "Report Generated",
   "tui.slash_hint": "Commands: /target /mode /scope /start /run /continue ...",
   "tui.read_error_short": "Read failed",
-
   "tui.slash_target": "Set authorized target URL / domain / IP",
   "tui.slash_mode": "Select check mode (quick / standard / deep / continuous)",
   "tui.slash_scope": "Configure test scope boundaries",
@@ -237,7 +231,6 @@
   "tui.slash_diag": "Run environment diagnostic",
   "tui.slash_config": "Configure LLM provider / model / API key",
   "tui.slash_quit": "Exit TUI",
-
   "tui.prompt_target": "Target URL / domain / IP:",
   "tui.prompt_select_mode": "Select mode:",
   "tui.prompt_only_host": "Only Test Host",
@@ -251,7 +244,6 @@
   "tui.prompt_select_provider": "Select Provider (current: {provider}):",
   "tui.prompt_enter_model": "Model (current: {model}):",
   "tui.prompt_enter_apikey": "API Key ({status}, enter to keep):",
-
   "tui.error_invalid_port": "Port must be a number between 1-65535",
   "tui.no_previous_execution": "No previous execution to continue",
   "tui.execution_interrupted": "Execution interrupted (Esc). Type /continue to resume.",
@@ -275,5 +267,27 @@
   "tui.prompt_enter_model_fallback": "Failed to fetch models, enter model name manually (current: {model}):",
   "tui.fetching_models": "Fetching model list...",
   "tui.fetch_models_failed": "Failed to fetch model list",
-  "tui.no_models_available": "No models available from this provider"
+  "tui.no_models_available": "No models available from this provider",
+  "skill.exploitation.description": "Exploitation workflow — build PoCs to verify and exploit discovered vulnerabilities",
+  "skill.pentest-flow.description": "End-to-end pentest orchestration — from recon through report generation",
+  "skill.post-exploitation.description": "Post-exploitation workflow — internal recon and lateral movement",
+  "skill.recon.description": "Reconnaissance workflow — passive and active recon",
+  "skill.reporting.description": "Reporting workflow — generate structured pentest reports and PoCs",
+  "skill.vuln-discovery.description": "Vulnerability discovery — scan for vulnerabilities based on recon findings",
+  "skill.waf-bypass.description": "WAF bypass techniques — assorted methods for evading WAFs",
+  "skill.ai-mcp-security.description": "AI & MCP security assessment — prompt injection, tool abuse, MCP trust boundaries, agent privilege escape, data leakage, model risk, GAARM risk matrix",
+  "skill.android-pentest.description": "Android app pentest — APK analysis, hooking, automated testing, runtime driving, signature recovery, traffic capture",
+  "skill.client-reverse.description": "Client reversing & Burp replay — signature recovery, decryption, request-chain tracing, and stable replay for authorized Android app, browser JS, and desktop client testing",
+  "skill.crypto-toolkit.description": "Encoding & crypto toolkit — base64/URL/hex/HTML-entity codecs, MD5/SHA hashing, AES/DES/RSA, JWT parsing, Caesar/ROT13, rail-fence/Vigenère, Unicode escapes, Morse, and more",
+  "skill.ctf-crypto.description": "CTF cryptography attacks — RSA (low-exponent/common-modulus/Wiener/Coppersmith), AES (padding oracle/ECB byte-flip/GCM nonce reuse), ECC, LFSR/LCG/PRNG, classical ciphers, LWE lattice attacks",
+  "skill.ctf-misc.description": "CTF misc knowledge — Python/Bash jail escapes, encoding-chain identification & decoding, QR/audio/image stego, game-VM reversing, CTFd API navigation, Linux privesc",
+  "skill.ctf-web.description": "CTF web attacks — PHP loose-comparison bypass, command-injection space bypass, eval echo tricks, SSTI chains, deserialization chains, PHP code-audit checklist, common flag locations",
+  "skill.cve-triage.description": "CVE lookup and triage — map discovered services/versions to known CVEs, score by CVSS/exploitability, and prioritize what to verify first",
+  "skill.intranet-pentest-advanced.description": "Advanced intranet pentest — lateral movement, credential theft, privilege escalation, persistence, tunneling/proxying, AD attacks, ADCS abuse, Exchange/SharePoint attacks",
+  "skill.osint-recon.description": "OSINT reconnaissance — four-dimension collection model (server → website → domain → people); the people dimension triggers conditionally",
+  "skill.pentest-tools.description": "Pentest tool cheatsheet — codecs, reverse shells, red-team tooling, exploitation, password attacks, intranet tools, credential theft, privesc, tunneling, system commands, recon, domain attacks, web & Windows tools",
+  "skill.rapid-checklist.description": "Rapid pentest checklist & payloads — payload families, bypass reminders, verification order, and quick test cards for when the direction is already known",
+  "skill.secknowledge-skill.description": "Web + AI security testing knowledge base — WooYun 88,636 cases + Xianzhi L1–L4 methodology + GAARM 150 risks + OWASP",
+  "skill.web-pentest.description": "Web application pentest — full workflow covering tech-stack fingerprinting, directory enumeration, auth testing, input validation, and logic flaws",
+  "skill.web-security-advanced.description": "Advanced web security testing — injection families, protocol security, auth & logic flaws, file & deployment security, and the modern web attack surface, with full playbooks"
 }

--- a/vulnclaw/intel/__init__.py
+++ b/vulnclaw/intel/__init__.py
@@ -1,0 +1,5 @@
+"""VulnClaw intelligence modules ported from HackBot (CVE, OSINT, topology,
+compliance, findings, remediation).
+
+Exposed to the agent as builtin tools via :mod:`vulnclaw.intel.tools`.
+"""

--- a/vulnclaw/intel/attack.py
+++ b/vulnclaw/intel/attack.py
@@ -1,0 +1,1072 @@
+"""
+VulnClaw MITRE ATT&CK Mapping Engine
+=====================================
+Maps agent actions, tool usage, and security findings to MITRE ATT&CK
+techniques and tactics.  Generates ATT&CK Navigator layer JSON for
+visualization at https://mitre-attack.github.io/attack-navigator/.
+
+Features:
+  - Map findings to ATT&CK techniques via keyword rules
+  - Map tool execution history to techniques
+  - Generate ATT&CK Navigator layer JSON
+  - Formatted Markdown reports
+  - Statistics and coverage analysis
+
+Reference: https://attack.mitre.org/
+
+Developed by Yashab Alam
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from vulnclaw import __version__
+
+# ── ATT&CK Data Models ──────────────────────────────────────────────────────
+
+@dataclass
+class Tactic:
+    """A MITRE ATT&CK tactic (column in the matrix)."""
+    id: str            # e.g. "TA0043"
+    name: str          # e.g. "Reconnaissance"
+    short_name: str    # e.g. "reconnaissance" (Navigator key)
+    description: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "short_name": self.short_name,
+            "description": self.description,
+        }
+
+
+@dataclass
+class Technique:
+    """A MITRE ATT&CK technique."""
+    id: str            # e.g. "T1046"
+    name: str          # e.g. "Network Service Scanning"
+    tactic_ids: List[str] = field(default_factory=list)  # parent tactic IDs
+    description: str = ""
+    is_subtechnique: bool = False
+    parent_id: str = ""
+    url: str = ""
+
+    def __post_init__(self):
+        if not self.url:
+            tid = self.id.replace(".", "/")
+            self.url = f"https://attack.mitre.org/techniques/{tid}/"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "tactic_ids": self.tactic_ids,
+            "description": self.description,
+            "is_subtechnique": self.is_subtechnique,
+            "parent_id": self.parent_id,
+            "url": self.url,
+        }
+
+
+@dataclass
+class TechniqueMapping:
+    """A mapping from a finding/tool action to an ATT&CK technique."""
+    technique: Technique
+    source: str = ""       # "finding" | "tool" | "manual"
+    source_name: str = ""  # finding title or tool name
+    confidence: str = "medium"  # "high" | "medium" | "low"
+    notes: str = ""
+    severity: str = ""      # from the finding, if applicable
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "technique": self.technique.to_dict(),
+            "source": self.source,
+            "source_name": self.source_name,
+            "confidence": self.confidence,
+            "notes": self.notes,
+            "severity": self.severity,
+        }
+
+
+@dataclass
+class AttackReport:
+    """Complete ATT&CK mapping report."""
+    mappings: List[TechniqueMapping] = field(default_factory=list)
+    target: str = ""
+    total_findings: int = 0
+    total_tools: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        by_tactic: Dict[str, List[Dict]] = {}
+        unique_techniques: Set[str] = set()
+
+        for m in self.mappings:
+            unique_techniques.add(m.technique.id)
+            for tac_id in m.technique.tactic_ids:
+                tactic_name = TACTIC_MAP.get(tac_id, Tactic(tac_id, tac_id, tac_id)).name
+                by_tactic.setdefault(tactic_name, []).append(m.to_dict())
+
+        return {
+            "target": self.target,
+            "total_findings": self.total_findings,
+            "total_tools": self.total_tools,
+            "total_mappings": len(self.mappings),
+            "unique_techniques": len(unique_techniques),
+            "tactics_covered": len(by_tactic),
+            "total_tactics": len(TACTICS),
+            "by_tactic": by_tactic,
+        }
+
+
+# ── ATT&CK Tactics ──────────────────────────────────────────────────────────
+# Full Enterprise ATT&CK tactic list (v15)
+
+TACTICS: List[Tactic] = [
+    Tactic("TA0043", "Reconnaissance", "reconnaissance",
+           "Gathering information to plan future operations."),
+    Tactic("TA0042", "Resource Development", "resource-development",
+           "Establishing resources to support operations."),
+    Tactic("TA0001", "Initial Access", "initial-access",
+           "Trying to get into your network."),
+    Tactic("TA0002", "Execution", "execution",
+           "Trying to run malicious code."),
+    Tactic("TA0003", "Persistence", "persistence",
+           "Trying to maintain their foothold."),
+    Tactic("TA0004", "Privilege Escalation", "privilege-escalation",
+           "Trying to gain higher-level permissions."),
+    Tactic("TA0005", "Defense Evasion", "defense-evasion",
+           "Trying to avoid being detected."),
+    Tactic("TA0006", "Credential Access", "credential-access",
+           "Trying to steal account names and passwords."),
+    Tactic("TA0007", "Discovery", "discovery",
+           "Trying to figure out your environment."),
+    Tactic("TA0008", "Lateral Movement", "lateral-movement",
+           "Trying to move through your environment."),
+    Tactic("TA0009", "Collection", "collection",
+           "Trying to gather data of interest."),
+    Tactic("TA0011", "Command and Control", "command-and-control",
+           "Trying to communicate with compromised systems."),
+    Tactic("TA0010", "Exfiltration", "exfiltration",
+           "Trying to steal data."),
+    Tactic("TA0040", "Impact", "impact",
+           "Trying to manipulate, interrupt, or destroy data and systems."),
+]
+
+# Quick lookup: tactic_id → Tactic
+TACTIC_MAP: Dict[str, Tactic] = {t.id: t for t in TACTICS}
+TACTIC_NAME_MAP: Dict[str, Tactic] = {t.name: t for t in TACTICS}
+
+
+# ── ATT&CK Techniques (curated subset relevant to pentesting) ───────────────
+# Each technique includes the tactic IDs it maps to.
+
+TECHNIQUES: List[Technique] = [
+    # -- Reconnaissance --
+    Technique("T1595", "Active Scanning", ["TA0043"],
+              "Scanning infrastructure to gather information."),
+    Technique("T1595.001", "Scanning IP Blocks", ["TA0043"],
+              "Scanning IP blocks to gather victim network information.",
+              is_subtechnique=True, parent_id="T1595"),
+    Technique("T1595.002", "Vulnerability Scanning", ["TA0043"],
+              "Scanning systems for vulnerabilities.",
+              is_subtechnique=True, parent_id="T1595"),
+    Technique("T1592", "Gather Victim Host Information", ["TA0043"],
+              "Gathering information about victim hosts."),
+    Technique("T1592.002", "Software", ["TA0043"],
+              "Gathering information about victim host software.",
+              is_subtechnique=True, parent_id="T1592"),
+    Technique("T1590", "Gather Victim Network Information", ["TA0043"],
+              "Gathering information about victim networks."),
+    Technique("T1590.004", "Network Topology", ["TA0043"],
+              "Gathering victim network topology information.",
+              is_subtechnique=True, parent_id="T1590"),
+    Technique("T1590.005", "IP Addresses", ["TA0043"],
+              "Gathering victim IP address information.",
+              is_subtechnique=True, parent_id="T1590"),
+    Technique("T1593", "Search Open Websites/Domains", ["TA0043"],
+              "Searching freely available websites and domains."),
+    Technique("T1596", "Search Open Technical Databases", ["TA0043"],
+              "Searching freely available technical databases."),
+    Technique("T1589", "Gather Victim Identity Information", ["TA0043"],
+              "Gathering identity information."),
+    Technique("T1591", "Gather Victim Org Information", ["TA0043"],
+              "Gathering organization information."),
+    Technique("T1597", "Search Closed Sources", ["TA0043"],
+              "Searching closed sources for victim information."),
+
+    # -- Initial Access --
+    Technique("T1190", "Exploit Public-Facing Application", ["TA0001"],
+              "Exploiting vulnerabilities in internet-facing applications."),
+    Technique("T1133", "External Remote Services", ["TA0001", "TA0003"],
+              "Leveraging external-facing remote services."),
+    Technique("T1078", "Valid Accounts", ["TA0001", "TA0003", "TA0004", "TA0005"],
+              "Using legitimate credentials to gain access."),
+    Technique("T1189", "Drive-by Compromise", ["TA0001"],
+              "Gaining access through a user visiting a website."),
+    Technique("T1566", "Phishing", ["TA0001"],
+              "Sending phishing messages to gain access."),
+
+    # -- Execution --
+    Technique("T1059", "Command and Scripting Interpreter", ["TA0002"],
+              "Abusing command and script interpreters to execute commands."),
+    Technique("T1059.001", "PowerShell", ["TA0002"],
+              "Abusing PowerShell for execution.",
+              is_subtechnique=True, parent_id="T1059"),
+    Technique("T1059.003", "Windows Command Shell", ["TA0002"],
+              "Abusing cmd.exe for execution.",
+              is_subtechnique=True, parent_id="T1059"),
+    Technique("T1059.004", "Unix Shell", ["TA0002"],
+              "Abusing Unix shell for execution.",
+              is_subtechnique=True, parent_id="T1059"),
+    Technique("T1203", "Exploitation for Client Execution", ["TA0002"],
+              "Exploiting software vulnerabilities for code execution."),
+
+    # -- Persistence --
+    Technique("T1505", "Server Software Component", ["TA0003"],
+              "Abusing server software to establish persistence."),
+    Technique("T1505.003", "Web Shell", ["TA0003"],
+              "Placing a web shell on a web server.",
+              is_subtechnique=True, parent_id="T1505"),
+    Technique("T1136", "Create Account", ["TA0003"],
+              "Creating accounts for persistence."),
+    Technique("T1098", "Account Manipulation", ["TA0003", "TA0004"],
+              "Manipulating accounts to maintain or escalate access."),
+    Technique("T1053", "Scheduled Task/Job", ["TA0002", "TA0003", "TA0004"],
+              "Abusing task scheduling for execution or persistence."),
+
+    # -- Privilege Escalation --
+    Technique("T1068", "Exploitation for Privilege Escalation", ["TA0004"],
+              "Exploiting software vulnerabilities to escalate privileges."),
+    Technique("T1548", "Abuse Elevation Control Mechanism", ["TA0004", "TA0005"],
+              "Circumventing elevated access controls."),
+    Technique("T1548.001", "Setuid and Setgid", ["TA0004", "TA0005"],
+              "Abusing setuid/setgid bits for privilege escalation.",
+              is_subtechnique=True, parent_id="T1548"),
+    Technique("T1548.003", "Sudo and Sudo Caching", ["TA0004", "TA0005"],
+              "Abusing sudo for privilege escalation.",
+              is_subtechnique=True, parent_id="T1548"),
+
+    # -- Defense Evasion --
+    Technique("T1070", "Indicator Removal", ["TA0005"],
+              "Deleting or modifying artifacts such as logs."),
+    Technique("T1027", "Obfuscated Files or Information", ["TA0005"],
+              "Attempting to make payloads difficult to discover or analyze."),
+    Technique("T1562", "Impair Defenses", ["TA0005"],
+              "Disabling or modifying security tools."),
+    Technique("T1562.001", "Disable or Modify Tools", ["TA0005"],
+              "Disabling security software.",
+              is_subtechnique=True, parent_id="T1562"),
+
+    # -- Credential Access --
+    Technique("T1110", "Brute Force", ["TA0006"],
+              "Trying many passwords or keys to discover valid credentials."),
+    Technique("T1110.001", "Password Guessing", ["TA0006"],
+              "Guessing passwords for user accounts.",
+              is_subtechnique=True, parent_id="T1110"),
+    Technique("T1110.003", "Password Spraying", ["TA0006"],
+              "Using a single password against many accounts.",
+              is_subtechnique=True, parent_id="T1110"),
+    Technique("T1110.004", "Credential Stuffing", ["TA0006"],
+              "Using breached credential pairs.",
+              is_subtechnique=True, parent_id="T1110"),
+    Technique("T1555", "Credentials from Password Stores", ["TA0006"],
+              "Searching password stores for credentials."),
+    Technique("T1552", "Unsecured Credentials", ["TA0006"],
+              "Searching for insecurely stored credentials."),
+    Technique("T1552.001", "Credentials In Files", ["TA0006"],
+              "Searching local file systems for credentials.",
+              is_subtechnique=True, parent_id="T1552"),
+    Technique("T1557", "Adversary-in-the-Middle", ["TA0006", "TA0009"],
+              "Positioning between two targets to intercept traffic."),
+    Technique("T1040", "Network Sniffing", ["TA0006", "TA0007"],
+              "Sniffing network traffic for information."),
+    Technique("T1003", "OS Credential Dumping", ["TA0006"],
+              "Dumping credentials from the operating system."),
+    Technique("T1212", "Exploitation for Credential Access", ["TA0006"],
+              "Exploiting software vulnerabilities to collect credentials."),
+
+    # -- Discovery --
+    Technique("T1046", "Network Service Discovery", ["TA0007"],
+              "Enumerating services running on remote hosts."),
+    Technique("T1018", "Remote System Discovery", ["TA0007"],
+              "Discovering remote systems on a network."),
+    Technique("T1082", "System Information Discovery", ["TA0007"],
+              "Getting detailed information about the operating system and hardware."),
+    Technique("T1083", "File and Directory Discovery", ["TA0007"],
+              "Enumerating files and directories."),
+    Technique("T1087", "Account Discovery", ["TA0007"],
+              "Getting a listing of accounts on a system or domain."),
+    Technique("T1016", "System Network Configuration Discovery", ["TA0007"],
+              "Looking at network configuration and settings."),
+    Technique("T1049", "System Network Connections Discovery", ["TA0007"],
+              "Getting network connections to and from the compromised system."),
+    Technique("T1069", "Permission Groups Discovery", ["TA0007"],
+              "Enumerating permission groups."),
+    Technique("T1518", "Software Discovery", ["TA0007"],
+              "Enumerating installed software."),
+    Technique("T1580", "Cloud Infrastructure Discovery", ["TA0007"],
+              "Discovering cloud infrastructure."),
+    Technique("T1135", "Network Share Discovery", ["TA0007"],
+              "Looking for shared drives and folders."),
+    Technique("T1047", "Windows Management Instrumentation", ["TA0002"],
+              "Using WMI to execute commands."),
+
+    # -- Lateral Movement --
+    Technique("T1021", "Remote Services", ["TA0008"],
+              "Using remote services to move laterally."),
+    Technique("T1021.001", "Remote Desktop Protocol", ["TA0008"],
+              "Using RDP to move laterally.",
+              is_subtechnique=True, parent_id="T1021"),
+    Technique("T1021.004", "SSH", ["TA0008"],
+              "Using SSH to move laterally.",
+              is_subtechnique=True, parent_id="T1021"),
+    Technique("T1210", "Exploitation of Remote Services", ["TA0008"],
+              "Exploiting remote services for lateral movement."),
+
+    # -- Collection --
+    Technique("T1005", "Data from Local System", ["TA0009"],
+              "Searching local system sources for data."),
+    Technique("T1039", "Data from Network Shared Drive", ["TA0009"],
+              "Searching network shares for data."),
+    Technique("T1114", "Email Collection", ["TA0009"],
+              "Collecting email data."),
+    Technique("T1213", "Data from Information Repositories", ["TA0009"],
+              "Mining data from information repositories."),
+
+    # -- Command and Control --
+    Technique("T1071", "Application Layer Protocol", ["TA0011"],
+              "Using application layer protocols for C2 communication."),
+    Technique("T1105", "Ingress Tool Transfer", ["TA0011"],
+              "Transferring tools from external systems."),
+    Technique("T1572", "Protocol Tunneling", ["TA0011"],
+              "Tunneling network communications using a protocol."),
+    Technique("T1573", "Encrypted Channel", ["TA0011"],
+              "Using encrypted channels for C2."),
+
+    # -- Exfiltration --
+    Technique("T1048", "Exfiltration Over Alternative Protocol", ["TA0010"],
+              "Transferring data via a non-C2 protocol."),
+    Technique("T1567", "Exfiltration Over Web Service", ["TA0010"],
+              "Exfiltrating data to a web service."),
+
+    # -- Impact --
+    Technique("T1499", "Endpoint Denial of Service", ["TA0040"],
+              "Performing denial of service to degrade availability."),
+    Technique("T1499.002", "Service Exhaustion Flood", ["TA0040"],
+              "Performing a DoS via resource exhaustion.",
+              is_subtechnique=True, parent_id="T1499"),
+    Technique("T1485", "Data Destruction", ["TA0040"],
+              "Destroying data and files on specific systems."),
+    Technique("T1486", "Data Encrypted for Impact", ["TA0040"],
+              "Encrypting data on target systems (ransomware)."),
+    Technique("T1491", "Defacement", ["TA0040"],
+              "Modifying visual content internally or externally."),
+    Technique("T1531", "Account Access Removal", ["TA0040"],
+              "Removing access to accounts."),
+]
+
+# Quick lookups
+TECHNIQUE_MAP: Dict[str, Technique] = {t.id: t for t in TECHNIQUES}
+
+
+# ── Tool → Technique Mapping ────────────────────────────────────────────────
+# Maps VulnClaw's allowed tools to the ATT&CK techniques they implement.
+# Each tool maps to [(technique_id, confidence, notes)].
+
+TOOL_TECHNIQUE_MAP: Dict[str, List[Tuple[str, str, str]]] = {
+    "nmap": [
+        ("T1046",    "high",   "Network service discovery / port scanning"),
+        ("T1595.001","high",   "Active scanning of IP blocks"),
+        ("T1592.002","medium", "OS and service version fingerprinting"),
+        ("T1082",    "medium", "System information via service banners"),
+    ],
+    "masscan": [
+        ("T1595.001","high",   "High-speed IP block scanning"),
+        ("T1046",    "high",   "Network service discovery"),
+    ],
+    "nikto": [
+        ("T1595.002","high",   "Web server vulnerability scanning"),
+        ("T1190",    "medium", "Testing for exploitable web vulnerabilities"),
+    ],
+    "nuclei": [
+        ("T1595.002","high",   "Template-based vulnerability scanning"),
+        ("T1190",    "medium", "Testing for exploitable vulnerabilities"),
+    ],
+    "sqlmap": [
+        ("T1190",    "high",   "SQL injection exploitation"),
+        ("T1059",    "high",   "Command execution via SQL injection"),
+        ("T1005",    "medium", "Data extraction via SQL injection"),
+    ],
+    "gobuster": [
+        ("T1083",    "high",   "Directory/file brute-force enumeration"),
+        ("T1595",    "medium", "Active scanning for hidden content"),
+    ],
+    "dirb": [
+        ("T1083",    "high",   "Directory brute-force enumeration"),
+        ("T1595",    "medium", "Active scanning for hidden directories"),
+    ],
+    "ffuf": [
+        ("T1083",    "high",   "Fuzzing for files and directories"),
+        ("T1595",    "medium", "Active content discovery"),
+    ],
+    "wfuzz": [
+        ("T1083",    "high",   "Web fuzzing for parameters and paths"),
+        ("T1190",    "medium", "Parameter injection testing"),
+    ],
+    "subfinder": [
+        ("T1590",    "high",   "Subdomain enumeration"),
+        ("T1593",    "high",   "Passive subdomain discovery"),
+    ],
+    "amass": [
+        ("T1590",    "high",   "Network mapping and subdomain discovery"),
+        ("T1593",    "high",   "Active and passive reconnaissance"),
+        ("T1596",    "medium", "Searching technical databases"),
+    ],
+    "httpx": [
+        ("T1595",    "medium", "HTTP probing and fingerprinting"),
+        ("T1592.002","medium", "Web technology fingerprinting"),
+    ],
+    "whatweb": [
+        ("T1592.002","high",   "Web technology fingerprinting"),
+        ("T1595",    "medium", "Active web scanning"),
+    ],
+    "hydra": [
+        ("T1110",    "high",   "Network brute-force attacks"),
+        ("T1110.001","high",   "Password guessing"),
+    ],
+    "john": [
+        ("T1110",    "high",   "Offline password cracking"),
+        ("T1003",    "medium", "Credential recovery from hashes"),
+    ],
+    "hashcat": [
+        ("T1110",    "high",   "GPU-accelerated password cracking"),
+        ("T1003",    "medium", "Credential recovery from hashes"),
+    ],
+    "curl": [
+        ("T1071",    "low",    "HTTP request crafting"),
+        ("T1190",    "low",    "Manual web application testing"),
+    ],
+    "wget": [
+        ("T1105",    "medium", "File download / tool transfer"),
+    ],
+    "dig": [
+        ("T1590",    "high",   "DNS information gathering"),
+        ("T1016",    "medium", "Network configuration discovery via DNS"),
+    ],
+    "whois": [
+        ("T1591",    "high",   "Domain/IP owner information gathering"),
+        ("T1596",    "high",   "Searching WHOIS databases"),
+    ],
+    "traceroute": [
+        ("T1590.004","high",   "Network topology mapping"),
+        ("T1016",    "medium", "Network path discovery"),
+    ],
+    "ping": [
+        ("T1018",    "medium", "Host discovery via ICMP"),
+    ],
+    "netcat": [
+        ("T1046",    "medium", "Banner grabbing / service probing"),
+        ("T1071",    "medium", "Network communication"),
+    ],
+    "openssl": [
+        ("T1573",    "low",    "SSL/TLS inspection and testing"),
+    ],
+    "testssl": [
+        ("T1595.002","high",   "TLS/SSL vulnerability scanning"),
+    ],
+    "sslscan": [
+        ("T1595.002","high",   "SSL/TLS configuration scanning"),
+    ],
+    "ssh": [
+        ("T1021.004","medium", "SSH remote access"),
+    ],
+}
+
+
+# ── Finding → Technique Rules ────────────────────────────────────────────────
+# Each rule: (compiled_regex, list_of_(technique_id, confidence), default_notes)
+# Regex matched against finding title + description + evidence (case-insensitive).
+
+def _re(pattern: str) -> re.Pattern:
+    return re.compile(pattern, re.IGNORECASE)
+
+
+_FINDING_RULES: List[Tuple[re.Pattern, List[Tuple[str, str]], str]] = [
+    # SQL Injection
+    (_re(r"sql\s*injection|sqli|blind.?sql|union.?select|sqlmap"),
+     [("T1190", "high"), ("T1059", "medium")],
+     "SQL injection enables application exploitation and command execution"),
+
+    # XSS
+    (_re(r"cross.?site\s*script|xss|reflected\s*xss|stored\s*xss|dom.?xss"),
+     [("T1190", "high"), ("T1189", "medium")],
+     "Cross-site scripting can lead to session hijacking"),
+
+    # Command Injection / RCE
+    (_re(r"command\s*injection|remote\s*code\s*exec|rce|os\s*command|shell\s*injection"),
+     [("T1059", "high"), ("T1190", "high"), ("T1203", "high")],
+     "Command injection enables arbitrary code execution"),
+
+    # File Inclusion / Path Traversal
+    (_re(r"file\s*inclusion|path\s*traversal|directory\s*traversal|lfi|rfi|\.\./"),
+     [("T1083", "high"), ("T1005", "medium")],
+     "Path traversal enables file system access"),
+
+    # Authentication issues
+    (_re(r"default\s*credential|weak\s*password|default.*password|brute.?forc|credential\s*stuff|password\s*spray"),
+     [("T1110", "high"), ("T1078", "high")],
+     "Weak authentication enables unauthorized access"),
+
+    # SSRF
+    (_re(r"ssrf|server.?side\s*request\s*forgery"),
+     [("T1190", "high"), ("T1580", "medium")],
+     "SSRF can enable internal network access"),
+
+    # CSRF
+    (_re(r"csrf|cross.?site\s*request\s*forgery"),
+     [("T1190", "medium")],
+     "CSRF enables unauthorized actions"),
+
+    # Open ports / services
+    (_re(r"open\s*port|exposed\s*service|unnecessary\s*service|unneeded\s*port"),
+     [("T1046", "high"), ("T1133", "medium")],
+     "Open ports increase the attack surface"),
+
+    # SSH issues
+    (_re(r"ssh.*weak|ssh.*vuln|weak\s*ssh|ssh.*password\s*auth|ssh.*root\s*login"),
+     [("T1021.004", "high"), ("T1078", "medium")],
+     "Weak SSH configuration enables remote access"),
+
+    # RDP issues
+    (_re(r"rdp.*exposed|rdp.*weak|remote\s*desktop.*vuln"),
+     [("T1021.001", "high"), ("T1133", "high")],
+     "Exposed RDP enables lateral movement"),
+
+    # SSL/TLS issues
+    (_re(r"ssl|tls|certificate|cipher.*weak|heartbleed|poodle|beast|drown"),
+     [("T1557", "medium"), ("T1040", "low")],
+     "Weak encryption enables traffic interception"),
+
+    # Information disclosure
+    (_re(r"information\s*disclos|info.*leak|server\s*header|version\s*disclos|banner\s*grab|stack\s*trace|error\s*message.*detail|debug.*mode"),
+     [("T1592.002", "medium"), ("T1082", "medium")],
+     "Information disclosure aids reconnaissance"),
+
+    # Directory listing
+    (_re(r"directory\s*listing|index\s*of|dir.*listing.*enabled"),
+     [("T1083", "high"), ("T1213", "medium")],
+     "Directory listing exposes file structure"),
+
+    # Subdomain / DNS
+    (_re(r"subdomain|dns.*zone.*transfer|dns.*enum|axfr"),
+     [("T1590", "high"), ("T1596", "medium")],
+     "DNS enumeration reveals infrastructure"),
+
+    # Web shell / backdoor
+    (_re(r"web.?shell|backdoor|persist.*shell|reverse.*shell"),
+     [("T1505.003", "high"), ("T1059.004", "high")],
+     "Web shells provide persistent access"),
+
+    # Privilege escalation
+    (_re(r"privil.*escal|priv.*esc|setuid|suid|sudo.*vuln|root.*access|local.*root"),
+     [("T1068", "high"), ("T1548", "high")],
+     "Privilege escalation grants elevated access"),
+
+    # Misconfiguration
+    (_re(r"misconfig|security.*header.*missing|cors.*misconfig|csp.*missing|hsts.*missing|x-frame|clickjack"),
+     [("T1190", "medium")],
+     "Misconfigurations weaken security posture"),
+
+    # DoS
+    (_re(r"denial.?of.?service|dos|ddos|slow.?loris|resource\s*exhaust"),
+     [("T1499", "high"), ("T1499.002", "medium")],
+     "DoS vulnerabilities impact availability"),
+
+    # LDAP
+    (_re(r"ldap.*injection|ldap.*enum|active\s*directory"),
+     [("T1087", "medium"), ("T1069", "medium")],
+     "LDAP issues enable directory enumeration"),
+
+    # SMB / Network shares
+    (_re(r"smb.*vuln|smb.*enum|network\s*share|null\s*session|eternalblue|ms17"),
+     [("T1135", "high"), ("T1210", "high"), ("T1039", "medium")],
+     "SMB vulnerabilities enable lateral movement"),
+
+    # SNMP
+    (_re(r"snmp.*community|snmp.*public|snmp.*enum"),
+     [("T1082", "medium"), ("T1046", "medium")],
+     "SNMP misconfigurations expose system information"),
+
+    # Phishing
+    (_re(r"phish|spear.*phish|social\s*engineer"),
+     [("T1566", "high")],
+     "Phishing enables initial access"),
+
+    # Credential in files
+    (_re(r"credential.*file|password.*file|\.env.*exposed|config.*password|hardcoded.*password|api.?key.*exposed"),
+     [("T1552.001", "high"), ("T1552", "high")],
+     "Credentials in files enable unauthorized access"),
+
+    # Data exfiltration
+    (_re(r"data.*exfil|data.*leak|sensitive.*data.*exposed|pii.*exposed"),
+     [("T1048", "medium"), ("T1567", "medium")],
+     "Data exposure enables exfiltration"),
+
+    # Ransomware / encryption
+    (_re(r"ransomware|encrypt.*impact|data.*destroy"),
+     [("T1486", "high"), ("T1485", "high")],
+     "Ransomware encrypts data for impact"),
+
+    # Account issues
+    (_re(r"account.*lockout.*missing|no.*lockout|session.*fixation|session.*hijack"),
+     [("T1078", "medium"), ("T1110", "medium")],
+     "Account weaknesses enable unauthorized access"),
+
+    # Log / monitoring
+    (_re(r"no.*logging|logging.*disabled|audit.*missing|monitor.*missing"),
+     [("T1070", "medium"), ("T1562", "medium")],
+     "Missing logging aids defense evasion"),
+
+    # Cloud
+    (_re(r"s3.*bucket|cloud.*misconfig|azure.*exposed|gcp.*public|aws.*public"),
+     [("T1580", "high"), ("T1190", "medium")],
+     "Cloud misconfigurations expose resources"),
+]
+
+
+# ── Navigator Layer Schema ───────────────────────────────────────────────────
+
+# ATT&CK Navigator layer version 4.5
+_NAVIGATOR_VERSION = "4.5"
+_ATTACK_VERSION = "15"
+_NAV_DOMAIN = "enterprise-attack"
+
+
+def _build_navigator_layer(
+    mappings: List[TechniqueMapping],
+    name: str = "VulnClaw Assessment",
+    description: str = "",
+) -> Dict[str, Any]:
+    """Build an ATT&CK Navigator layer JSON from technique mappings.
+
+    The output can be loaded at:
+      https://mitre-attack.github.io/attack-navigator/
+
+    Scoring:
+      - high confidence → score 4 (red)
+      - medium confidence → score 3 (orange)
+      - low confidence → score 2 (yellow)
+    Severity overlay:
+      - Critical → score +1
+      - High → score +0.5
+    """
+    # Aggregate best score per technique
+    tech_scores: Dict[str, float] = {}
+    tech_comments: Dict[str, List[str]] = {}
+
+    confidence_score = {"high": 4, "medium": 3, "low": 2}
+    severity_bonus = {"Critical": 1.0, "High": 0.5, "Medium": 0, "Low": 0, "Info": 0}
+
+    for m in mappings:
+        tid = m.technique.id
+        base = confidence_score.get(m.confidence, 2)
+        bonus = severity_bonus.get(m.severity, 0)
+        score = base + bonus
+
+        tech_scores[tid] = max(tech_scores.get(tid, 0), score)
+
+        comment = f"[{m.source}] {m.source_name}"
+        if m.notes:
+            comment += f" — {m.notes}"
+        tech_comments.setdefault(tid, []).append(comment)
+
+    # Build technique entries
+    techniques = []
+    for tid, score in tech_scores.items():
+        tech = TECHNIQUE_MAP.get(tid)
+        if not tech:
+            continue
+
+        # Tactic references
+        tactic_refs = []
+        for tac_id in tech.tactic_ids:
+            tac = TACTIC_MAP.get(tac_id)
+            if tac:
+                tactic_refs.append({"tacticName": tac.short_name.replace("-", " ")})
+
+        entry: Dict[str, Any] = {
+            "techniqueID": tid,
+            "score": score,
+            "comment": "\n".join(tech_comments.get(tid, [])),
+            "enabled": True,
+            "showSubtechniques": tech.is_subtechnique,
+        }
+        if tactic_refs:
+            entry["tactic"] = tactic_refs[0]["tacticName"]  # primary tactic
+
+        techniques.append(entry)
+
+    # Gradient: green(0) → yellow(2) → orange(3) → red(5)
+    layer = {
+        "name": name,
+        "versions": {
+            "attack": _ATTACK_VERSION,
+            "navigator": _NAVIGATOR_VERSION,
+            "layer": "4.5",
+        },
+        "domain": _NAV_DOMAIN,
+        "description": description or f"Generated by VulnClaw v{__version__}",
+        "filters": {"platforms": ["Linux", "macOS", "Windows", "Network"]},
+        "sorting": 3,  # Sort by score descending
+        "layout": {
+            "layout": "side",
+            "aggregateFunction": "max",
+            "showID": True,
+            "showName": True,
+            "showAggregateScores": True,
+            "countUnscored": False,
+        },
+        "hideDisabled": False,
+        "techniques": techniques,
+        "gradient": {
+            "colors": ["#a1d99b", "#fee08b", "#fdae61", "#f46d43", "#d73027"],
+            "minValue": 0,
+            "maxValue": 5,
+        },
+        "legendItems": [
+            {"label": "Not observed", "color": "#a1d99b"},
+            {"label": "Low confidence", "color": "#fee08b"},
+            {"label": "Medium confidence", "color": "#fdae61"},
+            {"label": "High confidence", "color": "#f46d43"},
+            {"label": "Critical finding", "color": "#d73027"},
+        ],
+        "metadata": [
+            {"name": "generator", "value": f"VulnClaw v{__version__}"},
+            {"name": "generated_at", "value": time.strftime("%Y-%m-%d %H:%M:%S")},
+        ],
+        "showTacticRowBackground": True,
+        "tacticRowBackground": "#205b8f",
+        "selectTechniquesAcrossTactics": True,
+        "selectSubtechniquesWithParent": True,
+    }
+
+    return layer
+
+
+# ── ATT&CK Mapper Class ─────────────────────────────────────────────────────
+
+class AttackMapper:
+    """Maps VulnClaw findings and tool usage to MITRE ATT&CK techniques.
+
+    Usage::
+
+        mapper = AttackMapper()
+        report = mapper.map_findings(findings_dicts, target="192.168.1.1")
+        report = mapper.map_tools(tool_history, report)
+        layer_json = mapper.generate_navigator_layer(report)
+        markdown = AttackMapper.format_report(report)
+    """
+
+    def __init__(self):
+        pass
+
+    def map_findings(
+        self,
+        findings: List[Dict[str, Any]],
+        target: str = "",
+        tool_history: Optional[List[Dict[str, Any]]] = None,
+    ) -> AttackReport:
+        """Map findings and tool history to ATT&CK techniques.
+
+        Args:
+            findings: List of finding dicts (from Finding.to_dict())
+            target: Assessment target
+            tool_history: Optional list of tool execution dicts
+
+        Returns:
+            AttackReport with all mappings
+        """
+        report = AttackReport(target=target, total_findings=len(findings))
+
+        seen: Set[str] = set()  # Deduplicate: "source:technique_id:source_name"
+
+        # Map findings
+        for finding in findings:
+            text = " ".join([
+                finding.get("title", ""),
+                finding.get("description", ""),
+                finding.get("evidence", ""),
+                finding.get("recommendation", ""),
+            ]).strip()
+
+            if not text:
+                continue
+
+            severity = finding.get("severity", "Info")
+
+            for pattern, tech_list, notes in _FINDING_RULES:
+                if pattern.search(text):
+                    for tech_id, confidence in tech_list:
+                        technique = TECHNIQUE_MAP.get(tech_id)
+                        if not technique:
+                            continue
+
+                        dedup_key = f"finding:{tech_id}:{finding.get('title', '')}"
+                        if dedup_key in seen:
+                            continue
+                        seen.add(dedup_key)
+
+                        report.mappings.append(TechniqueMapping(
+                            technique=technique,
+                            source="finding",
+                            source_name=finding.get("title", "Unknown"),
+                            confidence=confidence,
+                            notes=notes,
+                            severity=severity,
+                        ))
+
+        # Map tool history
+        if tool_history:
+            report.total_tools = len(tool_history)
+            for entry in tool_history:
+                tool_name = entry.get("tool", "").lower()
+                if tool_name not in TOOL_TECHNIQUE_MAP:
+                    continue
+
+                for tech_id, confidence, notes in TOOL_TECHNIQUE_MAP[tool_name]:
+                    technique = TECHNIQUE_MAP.get(tech_id)
+                    if not technique:
+                        continue
+
+                    dedup_key = f"tool:{tech_id}:{tool_name}"
+                    if dedup_key in seen:
+                        continue
+                    seen.add(dedup_key)
+
+                    report.mappings.append(TechniqueMapping(
+                        technique=technique,
+                        source="tool",
+                        source_name=tool_name,
+                        confidence=confidence,
+                        notes=notes,
+                    ))
+
+        return report
+
+    def generate_navigator_layer(
+        self,
+        report: AttackReport,
+        name: str = "",
+        description: str = "",
+    ) -> Dict[str, Any]:
+        """Generate an ATT&CK Navigator layer JSON from a report.
+
+        Args:
+            report: The ATT&CK mapping report
+            name: Layer name (default: "VulnClaw: <target>")
+            description: Layer description
+
+        Returns:
+            Navigator layer JSON as dict
+        """
+        if not name:
+            name = f"VulnClaw: {report.target}" if report.target else "VulnClaw Assessment"
+        if not description:
+            description = (
+                f"Assessment of {report.target} — "
+                f"{len(report.mappings)} technique mappings from "
+                f"{report.total_findings} findings and {report.total_tools} tool executions"
+            )
+        return _build_navigator_layer(report.mappings, name=name, description=description)
+
+    def generate_navigator_json(
+        self,
+        report: AttackReport,
+        name: str = "",
+        description: str = "",
+    ) -> str:
+        """Generate an ATT&CK Navigator layer as a JSON string."""
+        layer = self.generate_navigator_layer(report, name, description)
+        return json.dumps(layer, indent=2)
+
+    # ── Static helpers ───────────────────────────────────────────────────
+
+    @staticmethod
+    def list_tactics() -> List[Dict[str, str]]:
+        """List all ATT&CK tactics."""
+        return [t.to_dict() for t in TACTICS]
+
+    @staticmethod
+    def list_techniques(tactic_id: str = "") -> List[Dict[str, Any]]:
+        """List techniques, optionally filtered by tactic."""
+        if tactic_id:
+            return [
+                t.to_dict() for t in TECHNIQUES
+                if tactic_id in t.tactic_ids
+            ]
+        return [t.to_dict() for t in TECHNIQUES]
+
+    @staticmethod
+    def get_technique(technique_id: str) -> Optional[Dict[str, Any]]:
+        """Get a technique by ID."""
+        tech = TECHNIQUE_MAP.get(technique_id)
+        return tech.to_dict() if tech else None
+
+    @staticmethod
+    def get_tool_techniques(tool_name: str) -> List[Dict[str, Any]]:
+        """Get ATT&CK techniques mapped to a specific tool."""
+        mappings = TOOL_TECHNIQUE_MAP.get(tool_name.lower(), [])
+        result = []
+        for tech_id, confidence, notes in mappings:
+            tech = TECHNIQUE_MAP.get(tech_id)
+            if tech:
+                result.append({
+                    "technique": tech.to_dict(),
+                    "confidence": confidence,
+                    "notes": notes,
+                })
+        return result
+
+    @staticmethod
+    def format_report(report: AttackReport) -> str:
+        """Format an ATT&CK report as Markdown."""
+        data = report.to_dict()
+        lines = [
+            "# MITRE ATT&CK Mapping\n",
+            f"**Target:** {data['target'] or 'N/A'}",
+            f"**Findings analysed:** {data['total_findings']}",
+            f"**Tool executions:** {data['total_tools']}",
+            f"**Technique mappings:** {data['total_mappings']}",
+            f"**Unique techniques:** {data['unique_techniques']}",
+            f"**Tactics covered:** {data['tactics_covered']}/{data['total_tactics']}",
+            "",
+        ]
+
+        # Coverage bar
+        covered = data["tactics_covered"]
+        total = data["total_tactics"]
+        bar_filled = int((covered / max(total, 1)) * 20)
+        bar = "█" * bar_filled + "░" * (20 - bar_filled)
+        lines.append(f"**Coverage:** [{bar}] {covered}/{total} tactics\n")
+
+        # By tactic
+        for tactic in TACTICS:
+            tactic_mappings = data["by_tactic"].get(tactic.name, [])
+            if not tactic_mappings:
+                continue
+
+            lines.append(f"\n## {tactic.name} ({tactic.id})\n")
+            lines.append(f"*{tactic.description}*\n")
+
+            seen_techs: Set[str] = set()
+            for m in tactic_mappings:
+                tech = m["technique"]
+                if tech["id"] in seen_techs:
+                    continue
+                seen_techs.add(tech["id"])
+
+                conf_icon = {"high": "🔴", "medium": "🟠", "low": "🟡"}.get(
+                    m["confidence"], "⚪"
+                )
+                sev_str = f" [{m['severity']}]" if m["severity"] else ""
+                source_icon = "🔍" if m["source"] == "finding" else "🔧"
+
+                lines.append(
+                    f"- {conf_icon} **{tech['id']}** — {tech['name']}"
+                    f"{sev_str} ({source_icon} {m['source_name']})"
+                )
+                if m["notes"]:
+                    lines.append(f"  *{m['notes']}*")
+
+            lines.append("")
+
+        # Legend
+        lines.extend([
+            "\n---",
+            "**Confidence:** 🔴 High | 🟠 Medium | 🟡 Low",
+            "**Source:** 🔍 Finding | 🔧 Tool",
+            f"\n*Generated by VulnClaw v{__version__}*",
+        ])
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def format_summary(report: AttackReport) -> str:
+        """Format a short summary of the ATT&CK mapping."""
+        data = report.to_dict()
+        tactics = list(data["by_tactic"].keys())
+
+        lines = [
+            f"📊 **ATT&CK Coverage:** {data['unique_techniques']} techniques, "
+            f"{data['tactics_covered']}/{data['total_tactics']} tactics",
+        ]
+        if tactics:
+            lines.append(f"**Tactics:** {', '.join(tactics)}")
+
+        # Count by confidence
+        conf_counts: Dict[str, int] = {"high": 0, "medium": 0, "low": 0}
+        for m in report.mappings:
+            conf_counts[m.confidence] = conf_counts.get(m.confidence, 0) + 1
+
+        parts = []
+        if conf_counts["high"]:
+            parts.append(f"🔴 {conf_counts['high']} high")
+        if conf_counts["medium"]:
+            parts.append(f"🟠 {conf_counts['medium']} medium")
+        if conf_counts["low"]:
+            parts.append(f"🟡 {conf_counts['low']} low")
+        if parts:
+            lines.append(f"**Confidence:** {' | '.join(parts)}")
+
+        return "\n".join(lines)
+
+
+# ── Agent tool ───────────────────────────────────────────────────────────────
+
+
+def _findings_from_agent(agent: Any) -> List[Dict[str, Any]]:
+    session = getattr(agent, "session_state", None)
+    findings = getattr(session, "findings", None) or []
+    out: List[Dict[str, Any]] = []
+    for f in findings:
+        if isinstance(f, dict):
+            out.append(f)
+        elif hasattr(f, "model_dump"):
+            out.append(f.model_dump())
+    return out
+
+
+async def attack_map_tool(agent: Any, args: Dict[str, Any]) -> str:
+    """Agent tool: map findings (and optional tool usage) to MITRE ATT&CK.
+
+    Returns a markdown technique/tactic report, or an ATT&CK Navigator layer JSON
+    when ``format`` is "navigator"/"json". Read-only/offline.
+    """
+    findings = args.get("findings")
+    if not isinstance(findings, list) or not findings:
+        findings = _findings_from_agent(agent)
+    tool_history = args.get("tool_history")
+    if not isinstance(tool_history, list):
+        tool_history = None
+    if not findings and not tool_history:
+        return (
+            "[attack_map] No findings/tool history to map. Pass a 'findings' array "
+            "(or 'tool_history'), or run after findings exist."
+        )
+
+    target = str(args.get("target", "") or "")
+    fmt = str(args.get("format", "markdown") or "markdown").lower()
+    mapper = AttackMapper()
+    report = mapper.map_findings(findings or [], target=target, tool_history=tool_history)
+    if not report.mappings:
+        return "[attack_map] No ATT&CK techniques matched the provided findings/tools."
+    if fmt in ("navigator", "json", "layer"):
+        return mapper.generate_navigator_json(report)
+    return AttackMapper.format_report(report)

--- a/vulnclaw/intel/compliance.py
+++ b/vulnclaw/intel/compliance.py
@@ -1,0 +1,413 @@
+"""Compliance mapping engine for VulnClaw.
+
+Ported from HackBot (``hackbot/core/compliance.py``). Maps security findings to
+control frameworks via a keyword-rule database:
+
+  * PCI DSS v4.0
+  * NIST SP 800-53 Rev 5
+  * OWASP Top 10 (2021)
+  * ISO 27001:2022
+
+Pure/offline. Exposed as the read-only ``compliance_map`` tool, which maps either
+explicitly-passed findings or the agent's current ``session_state`` findings.
+
+Note: MITRE ATT&CK mapping lives in HackBot's separate ``attack.py`` and is not
+part of this port; it is tracked as a follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class Framework(str, Enum):
+    PCI_DSS = "PCI DSS v4.0"
+    NIST_800_53 = "NIST 800-53 Rev 5"
+    OWASP_TOP_10 = "OWASP Top 10 (2021)"
+    ISO_27001 = "ISO 27001:2022"
+
+
+@dataclass
+class Control:
+    framework: str
+    control_id: str
+    title: str
+    description: str = ""
+    family: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "framework": self.framework,
+            "control_id": self.control_id,
+            "title": self.title,
+            "description": self.description,
+            "family": self.family,
+        }
+
+
+@dataclass
+class ControlMapping:
+    control: Control
+    status: str = "fail"  # fail | warn | pass | not_tested
+    notes: str = ""
+    finding_title: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "control": self.control.to_dict(),
+            "status": self.status,
+            "notes": self.notes,
+            "finding_title": self.finding_title,
+        }
+
+
+@dataclass
+class ComplianceReport:
+    frameworks: list[str] = field(default_factory=list)
+    mappings: list[ControlMapping] = field(default_factory=list)
+    target: str = ""
+    total_findings: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        by_framework: dict[str, list[dict]] = {}
+        for m in self.mappings:
+            by_framework.setdefault(m.control.framework, []).append(m.to_dict())
+        summary: dict[str, dict[str, int]] = {}
+        for fw, maps in by_framework.items():
+            counts = {"fail": 0, "warn": 0, "pass": 0, "not_tested": 0}
+            for m in maps:
+                counts[m["status"]] = counts.get(m["status"], 0) + 1
+            summary[fw] = counts
+        return {
+            "target": self.target,
+            "total_findings": self.total_findings,
+            "frameworks": self.frameworks,
+            "summary": summary,
+            "mappings": by_framework,
+        }
+
+
+def _re(pattern: str) -> re.Pattern:
+    return re.compile(pattern, re.IGNORECASE)
+
+
+# ── Control databases ────────────────────────────────────────────────────────
+
+PCI_DSS_CONTROLS: list[Control] = [
+    Control(Framework.PCI_DSS.value, "1.2.1", "Network security controls", "Install and maintain network security controls.", "Network Security"),
+    Control(Framework.PCI_DSS.value, "1.3.1", "Inbound traffic restriction", "Restrict inbound traffic to only that which is necessary.", "Network Security"),
+    Control(Framework.PCI_DSS.value, "1.3.2", "Outbound traffic restriction", "Restrict outbound traffic to only that which is necessary.", "Network Security"),
+    Control(Framework.PCI_DSS.value, "2.2.1", "System hardening standards", "Develop configuration standards for all system components.", "Secure Configuration"),
+    Control(Framework.PCI_DSS.value, "2.2.7", "Encrypt non-console admin access", "Encrypt all non-console administrative access using strong cryptography.", "Secure Configuration"),
+    Control(Framework.PCI_DSS.value, "4.2.1", "Strong cryptography for transmission", "Strong cryptography is used during transmission of PAN.", "Encryption"),
+    Control(Framework.PCI_DSS.value, "4.2.2", "PAN secured with strong crypto", "PAN is secured with strong cryptography whenever sent via end-user messaging.", "Encryption"),
+    Control(Framework.PCI_DSS.value, "6.2.4", "Secure coding practices", "Software engineering techniques prevent or mitigate common software attacks.", "Secure Development"),
+    Control(Framework.PCI_DSS.value, "6.3.1", "Vulnerability identification", "Security vulnerabilities are identified and managed.", "Vulnerability Management"),
+    Control(Framework.PCI_DSS.value, "6.3.3", "Patch management", "Critical security patches are installed within one month of release.", "Vulnerability Management"),
+    Control(Framework.PCI_DSS.value, "6.4.1", "Web app attack protection", "Public-facing web applications are protected against attacks.", "Secure Development"),
+    Control(Framework.PCI_DSS.value, "6.4.2", "WAF for web applications", "Public-facing web applications use an automated technical solution to detect and prevent web-based attacks.", "Secure Development"),
+    Control(Framework.PCI_DSS.value, "7.2.1", "Access control system", "An access control system(s) is implemented for systems components.", "Access Control"),
+    Control(Framework.PCI_DSS.value, "7.2.2", "Appropriate user access", "Access is assigned based on job classification and function.", "Access Control"),
+    Control(Framework.PCI_DSS.value, "8.3.1", "Strong authentication", "All user access to system components is authenticated by at least one factor.", "Authentication"),
+    Control(Framework.PCI_DSS.value, "8.3.6", "Password complexity", "Passwords/passphrases meet minimum complexity requirements.", "Authentication"),
+    Control(Framework.PCI_DSS.value, "8.3.9", "Password rotation", "Passwords/passphrases are changed at least once every 90 days.", "Authentication"),
+    Control(Framework.PCI_DSS.value, "10.2.1", "Audit logging", "Audit logs are enabled and active for all system components.", "Logging & Monitoring"),
+    Control(Framework.PCI_DSS.value, "10.4.1", "Audit log review", "Audit logs are reviewed at least once daily.", "Logging & Monitoring"),
+    Control(Framework.PCI_DSS.value, "11.3.1", "Vulnerability scanning", "Internal vulnerability scans performed at least quarterly.", "Security Testing"),
+    Control(Framework.PCI_DSS.value, "11.4.1", "Penetration testing", "External and internal penetration testing performed at least annually.", "Security Testing"),
+    Control(Framework.PCI_DSS.value, "12.3.1", "Risk assessment", "Risk assessment is performed at least annually.", "Information Security Policy"),
+]
+
+NIST_CONTROLS: list[Control] = [
+    Control(Framework.NIST_800_53.value, "AC-2", "Account Management", "Manage system accounts, including establishing, activating, modifying, reviewing, disabling, and removing accounts.", "Access Control"),
+    Control(Framework.NIST_800_53.value, "AC-3", "Access Enforcement", "Enforce approved authorizations for logical access.", "Access Control"),
+    Control(Framework.NIST_800_53.value, "AC-7", "Unsuccessful Logon Attempts", "Limit consecutive invalid logon attempts.", "Access Control"),
+    Control(Framework.NIST_800_53.value, "AC-17", "Remote Access", "Establish and document usage restrictions for remote access.", "Access Control"),
+    Control(Framework.NIST_800_53.value, "AU-2", "Event Logging", "Identify events that the system is capable of logging.", "Audit and Accountability"),
+    Control(Framework.NIST_800_53.value, "AU-6", "Audit Record Review", "Review and analyze system audit records.", "Audit and Accountability"),
+    Control(Framework.NIST_800_53.value, "CA-8", "Penetration Testing", "Conduct penetration testing on systems and networks.", "Assessment, Authorization, and Monitoring"),
+    Control(Framework.NIST_800_53.value, "CM-6", "Configuration Settings", "Establish and document mandatory configuration settings.", "Configuration Management"),
+    Control(Framework.NIST_800_53.value, "CM-7", "Least Functionality", "Configure the system to provide only essential capabilities.", "Configuration Management"),
+    Control(Framework.NIST_800_53.value, "IA-2", "Identification and Authentication", "Uniquely identify and authenticate organizational users.", "Identification and Authentication"),
+    Control(Framework.NIST_800_53.value, "IA-5", "Authenticator Management", "Manage system authenticators (passwords, tokens, biometrics, PKI).", "Identification and Authentication"),
+    Control(Framework.NIST_800_53.value, "IR-4", "Incident Handling", "Implement an incident handling capability.", "Incident Response"),
+    Control(Framework.NIST_800_53.value, "RA-5", "Vulnerability Monitoring and Scanning", "Monitor and scan for vulnerabilities in the system.", "Risk Assessment"),
+    Control(Framework.NIST_800_53.value, "SC-7", "Boundary Protection", "Monitor and control communications at the external managed interfaces.", "System and Communications Protection"),
+    Control(Framework.NIST_800_53.value, "SC-8", "Transmission Confidentiality and Integrity", "Protect the confidentiality and integrity of transmitted information.", "System and Communications Protection"),
+    Control(Framework.NIST_800_53.value, "SC-12", "Cryptographic Key Establishment and Management", "Establish and manage cryptographic keys.", "System and Communications Protection"),
+    Control(Framework.NIST_800_53.value, "SC-13", "Cryptographic Protection", "Implement cryptographic mechanisms to prevent unauthorized disclosure.", "System and Communications Protection"),
+    Control(Framework.NIST_800_53.value, "SC-28", "Protection of Information at Rest", "Protect the confidentiality and integrity of information at rest.", "System and Communications Protection"),
+    Control(Framework.NIST_800_53.value, "SI-2", "Flaw Remediation", "Identify, report, and correct system flaws.", "System and Information Integrity"),
+    Control(Framework.NIST_800_53.value, "SI-3", "Malicious Code Protection", "Implement malicious code protection mechanisms.", "System and Information Integrity"),
+    Control(Framework.NIST_800_53.value, "SI-4", "System Monitoring", "Monitor the system to detect attacks and indicators of potential attacks.", "System and Information Integrity"),
+    Control(Framework.NIST_800_53.value, "SI-10", "Information Input Validation", "Check the validity of information inputs.", "System and Information Integrity"),
+]
+
+OWASP_CONTROLS: list[Control] = [
+    Control(Framework.OWASP_TOP_10.value, "A01:2021", "Broken Access Control", "Access control enforces policy such that users cannot act outside their intended permissions.", "Access Control"),
+    Control(Framework.OWASP_TOP_10.value, "A02:2021", "Cryptographic Failures", "Failures related to cryptography (or lack thereof) that lead to exposure of sensitive data.", "Cryptography"),
+    Control(Framework.OWASP_TOP_10.value, "A03:2021", "Injection", "SQL, NoSQL, OS, LDAP injection — untrusted data sent to an interpreter.", "Injection"),
+    Control(Framework.OWASP_TOP_10.value, "A04:2021", "Insecure Design", "Risks related to design and architectural flaws.", "Design"),
+    Control(Framework.OWASP_TOP_10.value, "A05:2021", "Security Misconfiguration", "Missing or improper security hardening across the application stack.", "Configuration"),
+    Control(Framework.OWASP_TOP_10.value, "A06:2021", "Vulnerable and Outdated Components", "Using components with known vulnerabilities.", "Components"),
+    Control(Framework.OWASP_TOP_10.value, "A07:2021", "Identification and Authentication Failures", "Confirmation of the user's identity, authentication, and session management.", "Authentication"),
+    Control(Framework.OWASP_TOP_10.value, "A08:2021", "Software and Data Integrity Failures", "Code and infrastructure that does not protect against integrity violations.", "Integrity"),
+    Control(Framework.OWASP_TOP_10.value, "A09:2021", "Security Logging and Monitoring Failures", "Insufficient logging, detection, monitoring, and active response.", "Logging"),
+    Control(Framework.OWASP_TOP_10.value, "A10:2021", "Server-Side Request Forgery (SSRF)", "SSRF flaws occur when a web application fetches a remote resource without validating the user-supplied URL.", "SSRF"),
+]
+
+ISO_CONTROLS: list[Control] = [
+    Control(Framework.ISO_27001.value, "A.5.1", "Policies for information security", "Management direction for information security shall be established.", "Organizational Controls"),
+    Control(Framework.ISO_27001.value, "A.5.15", "Access control", "Rules to control physical and logical access to information shall be established.", "Organizational Controls"),
+    Control(Framework.ISO_27001.value, "A.5.23", "Information security for use of cloud services", "Processes for acquisition and management of cloud services shall be established.", "Organizational Controls"),
+    Control(Framework.ISO_27001.value, "A.5.36", "Compliance with policies and standards", "Compliance with the organization's information security policy shall be reviewed.", "Organizational Controls"),
+    Control(Framework.ISO_27001.value, "A.6.8", "Information security event reporting", "Personnel shall report observed or suspected information security events.", "People Controls"),
+    Control(Framework.ISO_27001.value, "A.7.1", "Physical security perimeters", "Security perimeters shall be defined and used to protect areas with sensitive information.", "Physical Controls"),
+    Control(Framework.ISO_27001.value, "A.8.1", "User endpoint devices", "Information stored on, processed by, or accessible via user endpoint devices shall be protected.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.5", "Secure authentication", "Secure authentication technologies and procedures shall be established.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.7", "Protection against malware", "Protection against malware shall be implemented.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.8", "Management of technical vulnerabilities", "Information about technical vulnerabilities shall be obtained, evaluated, and addressed.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.9", "Configuration management", "Configurations, including security configurations, shall be established.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.10", "Information deletion", "Information stored in systems and devices shall be deleted when no longer required.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.12", "Data leakage prevention", "Data leakage prevention measures shall be applied.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.15", "Logging", "Logs that record activities, exceptions, faults and other relevant events shall be produced and stored.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.20", "Networks security", "Networks and network devices shall be secured, managed and controlled.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.21", "Security of network services", "Security mechanisms, service levels and requirements of network services shall be identified.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.24", "Use of cryptography", "Rules for the effective use of cryptography shall be defined and implemented.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.25", "Secure development life cycle", "Rules for the secure development of software and systems shall be established.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.26", "Application security requirements", "Information security requirements shall be identified when developing or acquiring applications.", "Technological Controls"),
+    Control(Framework.ISO_27001.value, "A.8.28", "Secure coding", "Secure coding principles shall be applied to software development.", "Technological Controls"),
+]
+
+# (regex, [(framework_key, control_id), ...], default_status)
+_RULES: list[tuple[re.Pattern, list[tuple[str, str]], str]] = [
+    (_re(r"sql.?inject|sqli|union.?select|blind.?inject"), [("pci", "6.2.4"), ("pci", "6.4.1"), ("nist", "SI-10"), ("nist", "SI-2"), ("owasp", "A03:2021"), ("iso", "A.8.28"), ("iso", "A.8.26")], "fail"),
+    (_re(r"cross.?site.?script|xss|reflected.?script|stored.?xss|dom.?xss"), [("pci", "6.2.4"), ("pci", "6.4.1"), ("pci", "6.4.2"), ("nist", "SI-10"), ("owasp", "A03:2021"), ("iso", "A.8.28")], "fail"),
+    (_re(r"command.?inject|os.?inject|rce|remote.?code.?exec"), [("pci", "6.2.4"), ("nist", "SI-10"), ("nist", "SI-2"), ("owasp", "A03:2021"), ("iso", "A.8.28")], "fail"),
+    (_re(r"ssrf|server.?side.?request"), [("pci", "6.2.4"), ("nist", "SI-10"), ("nist", "SC-7"), ("owasp", "A10:2021"), ("iso", "A.8.20")], "fail"),
+    (_re(r"broken.?access|unauthorized|idor|privilege.?escalat|insecure.?direct.?object|access.?control"), [("pci", "7.2.1"), ("pci", "7.2.2"), ("nist", "AC-3"), ("nist", "AC-2"), ("owasp", "A01:2021"), ("iso", "A.5.15")], "fail"),
+    (_re(r"brute.?force|weak.?password|default.?cred|credential|login.?bypass|password.?policy|auth.?bypass|authentication.?fail"), [("pci", "8.3.1"), ("pci", "8.3.6"), ("pci", "8.3.9"), ("nist", "IA-2"), ("nist", "IA-5"), ("nist", "AC-7"), ("owasp", "A07:2021"), ("iso", "A.8.5")], "fail"),
+    (_re(r"ssl|tls|cert|cipher|crypto|cleartext|plaintext.?transmit|http(?!s)|weak.?encrypt|expired.?cert"), [("pci", "4.2.1"), ("pci", "2.2.7"), ("nist", "SC-8"), ("nist", "SC-12"), ("nist", "SC-13"), ("owasp", "A02:2021"), ("iso", "A.8.24")], "fail"),
+    (_re(r"outdated|eol|end.?of.?life|known.?vuln|cve-\d|unpatched|obsolete|version"), [("pci", "6.3.1"), ("pci", "6.3.3"), ("nist", "SI-2"), ("nist", "RA-5"), ("owasp", "A06:2021"), ("iso", "A.8.8")], "fail"),
+    (_re(r"mis.?config|default.?config|directory.?list|open.?port|information.?disclos|server.?header|debug.?mode|verbose.?error|stack.?trace"), [("pci", "2.2.1"), ("nist", "CM-6"), ("nist", "CM-7"), ("owasp", "A05:2021"), ("iso", "A.8.9")], "fail"),
+    (_re(r"no.?log|missing.?log|insufficient.?log|audit|monitoring.?fail"), [("pci", "10.2.1"), ("pci", "10.4.1"), ("nist", "AU-2"), ("nist", "AU-6"), ("nist", "SI-4"), ("owasp", "A09:2021"), ("iso", "A.8.15")], "fail"),
+    (_re(r"firewall|open.?port|network.?segm|exposed.?service|unnecessary.?port|ingress|egress"), [("pci", "1.2.1"), ("pci", "1.3.1"), ("pci", "1.3.2"), ("nist", "SC-7"), ("owasp", "A05:2021"), ("iso", "A.8.20"), ("iso", "A.8.21")], "warn"),
+    (_re(r"data.?leak|sensitive.?data|expos|personal.?data|pii|pan|card.?number|ssn"), [("pci", "4.2.2"), ("nist", "SC-28"), ("owasp", "A02:2021"), ("iso", "A.8.10"), ("iso", "A.8.12")], "fail"),
+    (_re(r"malware|trojan|backdoor|web.?shell|integrity|supply.?chain|tamper"), [("nist", "SI-3"), ("owasp", "A08:2021"), ("iso", "A.8.7")], "fail"),
+    (_re(r"insecure.?design|architecture|threat.?model|security.?by.?design"), [("owasp", "A04:2021"), ("iso", "A.8.25"), ("iso", "A.8.26")], "warn"),
+    (_re(r"ssh|remote.?access|rdp|telnet|vnc"), [("pci", "2.2.7"), ("nist", "AC-17"), ("iso", "A.8.20")], "warn"),
+]
+
+_FRAMEWORK_MAP: dict[str, dict[str, Control]] = {
+    "pci": {c.control_id: c for c in PCI_DSS_CONTROLS},
+    "nist": {c.control_id: c for c in NIST_CONTROLS},
+    "owasp": {c.control_id: c for c in OWASP_CONTROLS},
+    "iso": {c.control_id: c for c in ISO_CONTROLS},
+}
+
+ALL_FRAMEWORKS: dict[str, Framework] = {
+    "pci": Framework.PCI_DSS,
+    "nist": Framework.NIST_800_53,
+    "owasp": Framework.OWASP_TOP_10,
+    "iso": Framework.ISO_27001,
+}
+
+_FRAMEWORK_ALIASES = {
+    "pcidss": "pci", "pci": "pci", "pcidssv4": "pci", "pciv4": "pci",
+    "nist": "nist", "nist80053": "nist", "nist800": "nist", "sp80053": "nist",
+    "owasp": "owasp", "owasptop10": "owasp", "owasp2021": "owasp", "top10": "owasp",
+    "iso": "iso", "iso27001": "iso", "iso27k": "iso", "27001": "iso",
+}
+
+
+def normalize_frameworks(frameworks: Optional[list[str]]) -> list[str]:
+    """Normalize framework names/aliases to internal keys; default to all four."""
+    if not frameworks:
+        return ["pci", "nist", "owasp", "iso"]
+    normalized = []
+    for fw in frameworks:
+        key = fw.lower().replace(" ", "").replace("-", "").replace("_", "")
+        normalized.append(_FRAMEWORK_ALIASES.get(key, key))
+    # de-dupe, preserve order
+    seen: set[str] = set()
+    return [k for k in normalized if k in ALL_FRAMEWORKS and not (k in seen or seen.add(k))]
+
+
+def _finding_text(finding: dict[str, Any]) -> str:
+    return " ".join(
+        str(finding.get(k, "") or "")
+        for k in ("title", "vuln_type", "description", "evidence", "recommendation", "remediation")
+    )
+
+
+def _status_for_severity(severity: str, default_status: str) -> str:
+    sev = (severity or "Info").lower()
+    if sev in ("critical", "high"):
+        return "fail"
+    if sev == "medium":
+        return default_status
+    return "warn"
+
+
+def map_findings(
+    findings: list[dict[str, Any]],
+    *,
+    frameworks: Optional[list[str]] = None,
+    target: str = "",
+) -> ComplianceReport:
+    """Map a list of finding dicts to compliance controls."""
+    fw_keys = normalize_frameworks(frameworks)
+    report = ComplianceReport(
+        frameworks=[ALL_FRAMEWORKS[f].value for f in fw_keys],
+        target=target,
+        total_findings=len(findings),
+    )
+    seen: set[str] = set()
+    for finding in findings:
+        text = _finding_text(finding)
+        title = str(finding.get("title", "") or "")
+        severity = str(finding.get("severity", "Info") or "Info")
+        for pattern, control_refs, default_status in _RULES:
+            if not pattern.search(text):
+                continue
+            status = _status_for_severity(severity, default_status)
+            for fw_key, ctrl_id in control_refs:
+                if fw_key not in fw_keys:
+                    continue
+                ctrl = _FRAMEWORK_MAP.get(fw_key, {}).get(ctrl_id)
+                if not ctrl:
+                    continue
+                dedup_key = f"{ctrl.framework}:{ctrl.control_id}:{title}"
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                report.mappings.append(
+                    ControlMapping(
+                        control=ctrl,
+                        status=status,
+                        notes=f"Finding '{title}' ({severity}) indicates a gap in {ctrl.control_id}.",
+                        finding_title=title,
+                    )
+                )
+    return report
+
+
+def get_framework_controls(framework: str) -> list[Control]:
+    key = framework.lower().replace(" ", "").replace("-", "").replace("_", "")
+    key = _FRAMEWORK_ALIASES.get(key, key)
+    return list(_FRAMEWORK_MAP.get(key, {}).values())
+
+
+def list_frameworks() -> list[dict[str, Any]]:
+    return [
+        {"key": "pci", "name": Framework.PCI_DSS.value, "controls": len(PCI_DSS_CONTROLS)},
+        {"key": "nist", "name": Framework.NIST_800_53.value, "controls": len(NIST_CONTROLS)},
+        {"key": "owasp", "name": Framework.OWASP_TOP_10.value, "controls": len(OWASP_CONTROLS)},
+        {"key": "iso", "name": Framework.ISO_27001.value, "controls": len(ISO_CONTROLS)},
+    ]
+
+
+def format_report(report: ComplianceReport) -> str:
+    lines = [
+        "# Compliance Mapping Report",
+        "",
+        f"**Target:** {report.target or 'N/A'}",
+        f"**Findings Analyzed:** {report.total_findings}",
+        f"**Frameworks:** {', '.join(report.frameworks)}",
+        "",
+    ]
+    data = report.to_dict()
+
+    lines.append("## Executive Summary\n")
+    lines.append("| Framework | Fail | Warn | Pass | Not Tested |")
+    lines.append("|-----------|------|------|------|------------|")
+    for fw, counts in data.get("summary", {}).items():
+        lines.append(
+            f"| {fw} | {counts.get('fail', 0)} | {counts.get('warn', 0)} | "
+            f"{counts.get('pass', 0)} | {counts.get('not_tested', 0)} |"
+        )
+    lines.append("")
+
+    for fw, mappings in data.get("mappings", {}).items():
+        lines.append(f"## {fw}\n")
+        lines.append("| Status | Control | Title | Finding |")
+        lines.append("|--------|---------|-------|---------|")
+        for m in mappings:
+            ctrl = m["control"]
+            icon = {
+                "fail": "FAIL",
+                "warn": "WARN",
+                "pass": "PASS",
+                "not_tested": "N/T",
+            }.get(m["status"], m["status"])
+            lines.append(
+                f"| {icon} | {ctrl['control_id']} | {ctrl['title']} | {m.get('finding_title', '')} |"
+            )
+        lines.append("")
+
+    lines.append("## Gap Analysis\n")
+    fail_count = sum(1 for m in report.mappings if m.status == "fail")
+    warn_count = sum(1 for m in report.mappings if m.status == "warn")
+    total = len(report.mappings)
+    if total == 0:
+        lines.append("No compliance gaps identified from the current findings.\n")
+    else:
+        pct_fail = (fail_count / total * 100) if total else 0
+        lines.append(f"- **{fail_count}** controls failing ({pct_fail:.0f}% of mapped controls)")
+        lines.append(f"- **{warn_count}** controls with warnings")
+        lines.append(f"- **{total}** total control mappings from {report.total_findings} findings")
+        lines.append("")
+        family_fails: dict[str, int] = {}
+        for m in report.mappings:
+            if m.status == "fail":
+                family_fails[m.control.family] = family_fails.get(m.control.family, 0) + 1
+        if family_fails:
+            lines.append("### Top Failing Control Families\n")
+            for fam, count in sorted(family_fails.items(), key=lambda x: -x[1])[:10]:
+                lines.append(f"- **{fam}**: {count} failing control(s)")
+            lines.append("")
+    return "\n".join(lines)
+
+
+# ── Tool handler ─────────────────────────────────────────────────────────────
+
+
+def _findings_from_agent(agent: Any) -> list[dict[str, Any]]:
+    """Best-effort extraction of finding dicts from the agent's session state."""
+    session = getattr(agent, "session_state", None)
+    findings = getattr(session, "findings", None) or []
+    out: list[dict[str, Any]] = []
+    for f in findings:
+        if isinstance(f, dict):
+            out.append(f)
+        elif hasattr(f, "model_dump"):
+            out.append(f.model_dump())
+        else:
+            out.append({k: getattr(f, k, "") for k in ("title", "severity", "vuln_type", "description", "evidence", "remediation")})
+    return out
+
+
+async def compliance_map_tool(agent: Any, args: dict[str, Any]) -> str:
+    """Agent tool: map findings to PCI/NIST/OWASP/ISO controls.
+
+    Uses the ``findings`` argument when provided, otherwise the agent's current
+    session findings.
+    """
+    findings = args.get("findings")
+    if not isinstance(findings, list) or not findings:
+        findings = _findings_from_agent(agent)
+    if not findings:
+        return (
+            "[compliance_map] No findings to map. Pass a 'findings' array "
+            "(title/severity/description/evidence) or run after findings exist."
+        )
+
+    frameworks = args.get("frameworks") if isinstance(args.get("frameworks"), list) else None
+    target = str(args.get("target", "") or "")
+    report = map_findings(findings, frameworks=frameworks, target=target)
+    if not report.mappings:
+        return "[compliance_map] No control mappings matched the provided findings."
+    return format_report(report)

--- a/vulnclaw/intel/cve.py
+++ b/vulnclaw/intel/cve.py
@@ -1,0 +1,364 @@
+"""CVE / exploit intelligence for VulnClaw.
+
+Ported from HackBot (``hackbot/core/cve.py``) and rewritten for VulnClaw's
+async, httpx-based stack. Queries NVD (keyless, or with an API key for higher
+rate limits) and optionally discovers exploit PoC repositories on GitHub.
+
+Exposed to the agent as the read-only ``cve_lookup`` tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Optional
+
+import httpx
+
+NVD_API_BASE = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+GITHUB_EXPLOIT_SEARCH = "https://api.github.com/search/repositories"
+
+_CVE_ID_RE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
+
+# NVD allows ~5 req/30s without an API key, ~50 req/30s with one.
+_NVD_RATE_LIMIT_NO_KEY = 6.5
+_NVD_RATE_LIMIT_WITH_KEY = 0.6
+_rate_lock = asyncio.Lock()
+_last_nvd_request = 0.0
+
+
+# ── Data model ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class CVEEntry:
+    """Single CVE record."""
+
+    cve_id: str
+    description: str
+    severity: str = "Unknown"
+    cvss_score: float = 0.0
+    cvss_vector: str = ""
+    published: str = ""
+    modified: str = ""
+    references: list[str] = field(default_factory=list)
+    cpe_matches: list[str] = field(default_factory=list)
+    weaknesses: list[str] = field(default_factory=list)
+    exploits: list[dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cve_id": self.cve_id,
+            "description": self.description,
+            "severity": self.severity,
+            "cvss_score": self.cvss_score,
+            "cvss_vector": self.cvss_vector,
+            "published": self.published,
+            "modified": self.modified,
+            "references": self.references,
+            "cpe_matches": self.cpe_matches,
+            "weaknesses": self.weaknesses,
+            "exploits": list(self.exploits),
+        }
+
+    @property
+    def severity_label(self) -> str:
+        if self.cvss_score >= 9.0:
+            return "Critical"
+        if self.cvss_score >= 7.0:
+            return "High"
+        if self.cvss_score >= 4.0:
+            return "Medium"
+        if self.cvss_score > 0:
+            return "Low"
+        return "Info"
+
+
+# ── NVD parsing ──────────────────────────────────────────────────────────────
+
+
+def _parse_nvd_item(item: dict[str, Any]) -> CVEEntry:
+    """Parse a single NVD CVE item into a CVEEntry."""
+    cve_data = item.get("cve", {})
+    cve_id = cve_data.get("id", "")
+
+    descriptions = cve_data.get("descriptions", [])
+    desc = ""
+    for d in descriptions:
+        if d.get("lang") == "en":
+            desc = d.get("value", "")
+            break
+    if not desc and descriptions:
+        desc = descriptions[0].get("value", "")
+
+    metrics = cve_data.get("metrics", {})
+    cvss_score = 0.0
+    cvss_vector = ""
+    severity = "Unknown"
+    for version in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+        metric_list = metrics.get(version, [])
+        if metric_list:
+            primary = metric_list[0]
+            cvss_data = primary.get("cvssData", {})
+            cvss_score = cvss_data.get("baseScore", 0.0)
+            cvss_vector = cvss_data.get("vectorString", "")
+            severity = primary.get("baseSeverity", cvss_data.get("baseSeverity", "Unknown"))
+            break
+
+    published = (cve_data.get("published", "") or "")[:10]
+    modified = (cve_data.get("lastModified", "") or "")[:10]
+
+    refs = [ref.get("url", "") for ref in cve_data.get("references", []) if ref.get("url")]
+
+    cpe_matches = []
+    for config in cve_data.get("configurations", []):
+        for node in config.get("nodes", []):
+            for match in node.get("cpeMatch", []):
+                criteria = match.get("criteria", "")
+                if criteria:
+                    cpe_matches.append(criteria)
+
+    weaknesses = []
+    for w in cve_data.get("weaknesses", []):
+        for wd in w.get("description", []):
+            val = wd.get("value", "")
+            if val and val not in ("NVD-CWE-Other", "NVD-CWE-noinfo"):
+                weaknesses.append(val)
+
+    return CVEEntry(
+        cve_id=cve_id,
+        description=desc,
+        severity=severity,
+        cvss_score=cvss_score,
+        cvss_vector=cvss_vector,
+        published=published,
+        modified=modified,
+        references=refs[:10],
+        cpe_matches=cpe_matches[:20],
+        weaknesses=weaknesses,
+    )
+
+
+# ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    headers = {
+        "User-Agent": "VulnClaw/0.3 CVE-Lookup",
+        "Accept": "application/json",
+    }
+    if api_key:
+        headers["apiKey"] = api_key
+    return headers
+
+
+@contextlib.asynccontextmanager
+async def _client_ctx(
+    client: Optional[httpx.AsyncClient], timeout: float, api_key: str
+) -> AsyncIterator[httpx.AsyncClient]:
+    """Yield the caller's client, or a short-lived one closed on exit."""
+    if client is not None:
+        yield client
+        return
+    async with httpx.AsyncClient(timeout=timeout, headers=_headers(api_key)) as owned:
+        yield owned
+
+
+async def _nvd_rate_limit(has_key: bool) -> None:
+    global _last_nvd_request
+    async with _rate_lock:
+        limit = _NVD_RATE_LIMIT_WITH_KEY if has_key else _NVD_RATE_LIMIT_NO_KEY
+        elapsed = time.monotonic() - _last_nvd_request
+        if 0 < elapsed < limit:
+            await asyncio.sleep(limit - elapsed)
+        _last_nvd_request = time.monotonic()
+
+
+# ── Queries ──────────────────────────────────────────────────────────────────
+
+
+async def search_cve(
+    keyword: str,
+    *,
+    max_results: int = 20,
+    severity: str = "",
+    api_key: str = "",
+    timeout: float = 20.0,
+    client: Optional[httpx.AsyncClient] = None,
+    rate_limit: bool = True,
+) -> list[CVEEntry]:
+    """Search NVD for CVEs matching a keyword, sorted by CVSS descending."""
+    keyword = keyword.strip()
+    if not keyword:
+        return []
+    max_results = min(max_results, 50)
+
+    params: dict[str, Any] = {"keywordSearch": keyword, "resultsPerPage": max_results}
+    sev = severity.upper()
+    if sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW"):
+        params["cvssV3Severity"] = sev
+
+    if rate_limit:
+        await _nvd_rate_limit(bool(api_key))
+
+    try:
+        async with _client_ctx(client, timeout, api_key) as c:
+            resp = await c.get(NVD_API_BASE, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return []
+
+    results = [_parse_nvd_item(item) for item in data.get("vulnerabilities", [])]
+    results.sort(key=lambda e: e.cvss_score, reverse=True)
+    return results
+
+
+async def lookup_cve_id(
+    cve_id: str,
+    *,
+    api_key: str = "",
+    timeout: float = 20.0,
+    client: Optional[httpx.AsyncClient] = None,
+    rate_limit: bool = True,
+    with_exploits: bool = True,
+) -> Optional[CVEEntry]:
+    """Look up a specific CVE by ID (e.g. CVE-2021-44228)."""
+    cve_id = cve_id.strip().upper()
+    if not _CVE_ID_RE.match(cve_id):
+        return None
+
+    if rate_limit:
+        await _nvd_rate_limit(bool(api_key))
+
+    try:
+        async with _client_ctx(client, timeout, api_key) as c:
+            resp = await c.get(NVD_API_BASE, params={"cveId": cve_id})
+            resp.raise_for_status()
+            data = resp.json()
+            vulns = data.get("vulnerabilities", [])
+            if not vulns:
+                return None
+            entry = _parse_nvd_item(vulns[0])
+            if with_exploits:
+                entry.exploits = await search_exploits(cve_id, client=c, timeout=timeout)
+            return entry
+    except (httpx.HTTPError, ValueError):
+        return None
+
+
+async def search_exploits(
+    query: str,
+    *,
+    max_results: int = 5,
+    timeout: float = 20.0,
+    client: Optional[httpx.AsyncClient] = None,
+) -> list[dict[str, str]]:
+    """Best-effort GitHub search for exploit / PoC repositories."""
+    exploits: list[dict[str, str]] = []
+    try:
+        async with _client_ctx(client, timeout, "") as c:
+            resp = await c.get(
+                GITHUB_EXPLOIT_SEARCH,
+                params={
+                    "q": f"{query} exploit OR poc OR vulnerability",
+                    "sort": "stars",
+                    "order": "desc",
+                    "per_page": min(max_results, 20),
+                },
+            )
+            if resp.status_code != 200:
+                return []
+            data = resp.json()
+            for repo in data.get("items", [])[:max_results]:
+                exploits.append(
+                    {
+                        "title": repo.get("full_name", ""),
+                        "source": "GitHub",
+                        "url": repo.get("html_url", ""),
+                        "description": (repo.get("description") or "")[:200],
+                        "stars": str(repo.get("stargazers_count", 0)),
+                        "language": repo.get("language") or "",
+                    }
+                )
+    except (httpx.HTTPError, ValueError):
+        return []
+    return exploits
+
+
+# ── Formatting ───────────────────────────────────────────────────────────────
+
+
+def format_cve_report(cves: list[CVEEntry], title: str = "CVE Results") -> str:
+    """Format CVEs as a markdown report (table + detail for top entries)."""
+    if not cves:
+        return f"## {title}\n\nNo CVEs found."
+
+    lines = [f"## {title}\n", f"**{len(cves)} vulnerabilities found**\n"]
+    lines.append("| CVE ID | CVSS | Severity | Description |")
+    lines.append("|--------|------|----------|-------------|")
+    for cve in cves:
+        desc = cve.description[:100] + "..." if len(cve.description) > 100 else cve.description
+        desc = desc.replace("|", "\\|").replace("\n", " ")
+        lines.append(f"| {cve.cve_id} | {cve.cvss_score} | {cve.severity_label} | {desc} |")
+    lines.append("")
+
+    for cve in cves[:5]:
+        lines.append(f"### {cve.cve_id} — CVSS {cve.cvss_score} ({cve.severity_label})")
+        lines.append(f"\n{cve.description}\n")
+        if cve.weaknesses:
+            lines.append(f"**Weaknesses:** {', '.join(cve.weaknesses)}")
+        if cve.published:
+            lines.append(f"**Published:** {cve.published}")
+        if cve.references:
+            lines.append("\n**References:**")
+            for ref in cve.references[:5]:
+                lines.append(f"- {ref}")
+        if cve.exploits:
+            lines.append("\n**Known exploit / PoC repositories:**")
+            for exp in cve.exploits:
+                stars = f" ⭐ {exp['stars']}" if exp.get("stars") else ""
+                lines.append(f"- [{exp['title']}]({exp['url']}){stars}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── Tool handler ─────────────────────────────────────────────────────────────
+
+
+def _resolve_nvd_key(agent: Any) -> str:
+    """Resolve an NVD API key from agent config, else the NVD_API_KEY env var."""
+    cfg = getattr(agent, "config", None)
+    intel = getattr(cfg, "intel", None)
+    key = getattr(intel, "nvd_api_key", "") if intel is not None else ""
+    return (key or os.environ.get("NVD_API_KEY", "") or "").strip()
+
+
+async def cve_lookup_tool(agent: Any, args: dict[str, Any]) -> str:
+    """Agent tool: look up CVEs by keyword or CVE-ID against NVD."""
+    query = str(args.get("query", "") or "").strip()
+    if not query:
+        return "[cve_lookup] error: 'query' is required (a keyword or a CVE-ID)."
+    try:
+        limit = int(args.get("limit", 5) or 5)
+    except (TypeError, ValueError):
+        limit = 5
+    limit = max(1, min(limit, 50))
+
+    api_key = _resolve_nvd_key(agent)
+
+    if _CVE_ID_RE.match(query.upper()):
+        entry = await lookup_cve_id(query, api_key=api_key)
+        if entry is None:
+            return f"[cve_lookup] No NVD record found for {query.upper()}."
+        return format_cve_report([entry], title=f"CVE detail: {query.upper()}")
+
+    entries = await search_cve(query, max_results=limit, api_key=api_key)
+    if not entries:
+        return f"[cve_lookup] No CVEs found for '{query}'."
+    return format_cve_report(entries, title=f"CVE search: {query}")

--- a/vulnclaw/intel/findings.py
+++ b/vulnclaw/intel/findings.py
@@ -1,0 +1,342 @@
+"""Findings risk scoring & assessment diff for VulnClaw.
+
+Ports the *logic* of HackBot's ``vulndb.py`` (risk scoring) and ``diff_report.py``
+(assessment diff) — but with no second database. Everything operates on plain
+VulnClaw finding dicts and ``target_state`` snapshot dicts, so the canonical
+store stays the single source of truth (spec §5.2).
+
+Exposes two read-only tools:
+  * ``findings_report`` — risk score, severity breakdown, top risks, optional
+    compliance-control coverage for the current/given findings.
+  * ``findings_diff`` — new / fixed / persistent findings between two finding
+    sets (e.g. a baseline snapshot vs the current assessment).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from vulnclaw.intel.compliance import map_findings
+
+SEVERITY_WEIGHTS = {
+    "critical": 10.0,
+    "high": 7.5,
+    "medium": 5.0,
+    "low": 2.5,
+    "info": 0.5,
+}
+_SEVERITY_ORDER = ["Critical", "High", "Medium", "Low", "Info"]
+_REJECTED_STATES = {"rejected", "fixed", "closed"}
+MATCH_THRESHOLD = 0.65
+
+
+# ── Severity / risk ──────────────────────────────────────────────────────────
+
+
+def _norm_sev(severity: str) -> str:
+    return (severity or "info").strip().lower()
+
+
+def _canonical_sev(severity: str) -> str:
+    norm = _norm_sev(severity)
+    for s in _SEVERITY_ORDER:
+        if s.lower() == norm:
+            return s
+    return "Info"
+
+
+def _is_open(finding: dict[str, Any]) -> bool:
+    status = str(finding.get("lifecycle_status", finding.get("status", "")) or "").lower()
+    return status not in _REJECTED_STATES
+
+
+def finding_risk(finding: dict[str, Any]) -> float:
+    """Risk weight for one finding: CVSS base score if present (>0), else the
+    severity weight."""
+    cvss = finding.get("cvss_score")
+    try:
+        if cvss is not None and float(cvss) > 0:
+            return float(cvss)
+    except (TypeError, ValueError):
+        pass
+    return SEVERITY_WEIGHTS.get(_norm_sev(str(finding.get("severity", "Info"))), 0.5)
+
+
+@dataclass
+class RiskScore:
+    total: float = 0.0
+    open_count: int = 0
+    counts: dict[str, int] = field(default_factory=lambda: {s: 0 for s in _SEVERITY_ORDER})
+
+    @property
+    def band(self) -> str:
+        for s in _SEVERITY_ORDER:
+            if self.counts.get(s, 0) > 0:
+                return s
+        return "Info"
+
+
+def score_findings(findings: list[dict[str, Any]], *, open_only: bool = True) -> RiskScore:
+    """Aggregate a risk score + severity breakdown over findings."""
+    score = RiskScore()
+    for f in findings:
+        if open_only and not _is_open(f):
+            continue
+        score.counts[_canonical_sev(str(f.get("severity", "Info")))] += 1
+        score.open_count += 1
+        score.total += finding_risk(f)
+    score.total = round(score.total, 1)
+    return score
+
+
+# ── Compliance annotation ────────────────────────────────────────────────────
+
+
+def annotate_compliance(
+    finding: dict[str, Any], *, frameworks: Optional[list[str]] = None
+) -> dict[str, Any]:
+    """Return a copy of the finding with a 'compliance' list of matched controls
+    (framework + control_id). Reuses the compliance keyword-rule engine."""
+    report = map_findings([finding], frameworks=frameworks)
+    controls = [
+        {"framework": m.control.framework, "control_id": m.control.control_id, "status": m.status}
+        for m in report.mappings
+    ]
+    annotated = dict(finding)
+    annotated["compliance"] = controls
+    return annotated
+
+
+# ── Diff engine ──────────────────────────────────────────────────────────────
+
+
+def _normalize(text: str) -> str:
+    return (text or "").strip().lower()
+
+
+def _finding_fingerprint(finding: dict[str, Any]) -> str:
+    title = _normalize(str(finding.get("title", "")))
+    desc = _normalize(str(finding.get("description", "")))[:80]
+    tool = _normalize(str(finding.get("tool", finding.get("vuln_type", ""))))
+    return f"{title}|{desc}|{tool}"
+
+
+def _similarity(fp1: str, fp2: str) -> float:
+    p1, p2 = fp1.split("|"), fp2.split("|")
+    if p1[0] and p1[0] == p2[0]:
+        return 1.0
+    t1, t2 = set(p1[0].split()), set(p2[0].split())
+    if not t1 or not t2:
+        return 0.0
+    union = t1 | t2
+    jaccard = len(t1 & t2) / len(union) if union else 0.0
+    if p1[2] and p1[2] == p2[2]:
+        jaccard = min(1.0, jaccard + 0.15)
+    return jaccard
+
+
+def _match_findings(
+    old: list[dict[str, Any]], new: list[dict[str, Any]]
+) -> tuple[list[tuple[dict, dict]], list[dict], list[dict]]:
+    old_fps = [(_finding_fingerprint(f), f) for f in old]
+    new_fps = [(_finding_fingerprint(f), f) for f in new]
+    scores: list[tuple[float, int, int]] = []
+    for i, (fp_old, _) in enumerate(old_fps):
+        for j, (fp_new, _) in enumerate(new_fps):
+            sim = _similarity(fp_old, fp_new)
+            if sim >= MATCH_THRESHOLD:
+                scores.append((sim, i, j))
+    scores.sort(key=lambda x: x[0], reverse=True)
+    used_old: set[int] = set()
+    used_new: set[int] = set()
+    pairs: list[tuple[dict, dict]] = []
+    for _sim, i, j in scores:
+        if i in used_old or j in used_new:
+            continue
+        pairs.append((old_fps[i][1], new_fps[j][1]))
+        used_old.add(i)
+        used_new.add(j)
+    unmatched_old = [old_fps[i][1] for i in range(len(old_fps)) if i not in used_old]
+    unmatched_new = [new_fps[j][1] for j in range(len(new_fps)) if j not in used_new]
+    return pairs, unmatched_old, unmatched_new
+
+
+@dataclass
+class DiffEntry:
+    title: str
+    severity: str
+    status: str  # new | fixed | persistent
+    old_severity: str = ""
+
+
+@dataclass
+class DiffReport:
+    target: str = ""
+    new: list[DiffEntry] = field(default_factory=list)
+    fixed: list[DiffEntry] = field(default_factory=list)
+    persistent: list[DiffEntry] = field(default_factory=list)
+
+    @property
+    def regressions(self) -> list[DiffEntry]:
+        """Persistent findings whose severity increased."""
+        out = []
+        for e in self.persistent:
+            if e.old_severity and _SEVERITY_ORDER.index(
+                _canonical_sev(e.severity)
+            ) < _SEVERITY_ORDER.index(_canonical_sev(e.old_severity)):
+                out.append(e)
+        return out
+
+
+def _as_findings(state: Any) -> list[dict[str, Any]]:
+    if isinstance(state, dict):
+        return state.get("findings", []) or []
+    if isinstance(state, list):
+        return state
+    return []
+
+
+def diff_assessments(old_state: Any, new_state: Any, *, target: str = "") -> DiffReport:
+    """Compare two assessments (target_state snapshot dicts or finding lists)."""
+    old = _as_findings(old_state)
+    new = _as_findings(new_state)
+    pairs, unmatched_old, unmatched_new = _match_findings(old, new)
+
+    if not target and isinstance(new_state, dict):
+        target = new_state.get("target", "")
+    report = DiffReport(target=target)
+
+    for old_f, new_f in pairs:
+        old_sev = str(old_f.get("severity", "Info"))
+        new_sev = str(new_f.get("severity", "Info"))
+        report.persistent.append(
+            DiffEntry(
+                title=str(new_f.get("title", "")),
+                severity=new_sev,
+                status="persistent",
+                old_severity=old_sev if old_sev != new_sev else "",
+            )
+        )
+    for f in unmatched_old:
+        report.fixed.append(
+            DiffEntry(title=str(f.get("title", "")), severity=str(f.get("severity", "Info")), status="fixed")
+        )
+    for f in unmatched_new:
+        report.new.append(
+            DiffEntry(title=str(f.get("title", "")), severity=str(f.get("severity", "Info")), status="new")
+        )
+    return report
+
+
+# ── Formatting ───────────────────────────────────────────────────────────────
+
+
+def format_risk_report(
+    findings: list[dict[str, Any]], score: RiskScore, *, with_compliance: bool = False
+) -> str:
+    lines = ["# Findings Risk Summary\n"]
+    lines.append(f"**Open findings:** {score.open_count}  ·  **Risk score:** {score.total}  ·  **Top band:** {score.band}\n")
+    lines.append("| Severity | Count |")
+    lines.append("|----------|-------|")
+    for s in _SEVERITY_ORDER:
+        lines.append(f"| {s} | {score.counts.get(s, 0)} |")
+    lines.append("")
+
+    ranked = sorted(findings, key=finding_risk, reverse=True)
+    open_ranked = [f for f in ranked if _is_open(f)]
+    if open_ranked:
+        lines.append("## Top Risks\n")
+        lines.append("| Risk | Severity | Title |")
+        lines.append("|------|----------|-------|")
+        for f in open_ranked[:10]:
+            lines.append(
+                f"| {finding_risk(f):.1f} | {_canonical_sev(str(f.get('severity', 'Info')))} "
+                f"| {str(f.get('title', ''))[:80]} |"
+            )
+        lines.append("")
+
+    if with_compliance:
+        report = map_findings(findings)
+        if report.mappings:
+            by_fw: dict[str, int] = {}
+            for m in report.mappings:
+                by_fw[m.control.framework] = by_fw.get(m.control.framework, 0) + 1
+            lines.append("## Compliance Control Coverage\n")
+            lines.append("| Framework | Mapped controls |")
+            lines.append("|-----------|-----------------|")
+            for fw, n in by_fw.items():
+                lines.append(f"| {fw} | {n} |")
+            lines.append("")
+    return "\n".join(lines)
+
+
+def format_diff(report: DiffReport) -> str:
+    lines = [f"# Assessment Diff: {report.target or 'N/A'}\n"]
+    lines.append(
+        f"**+{len(report.new)} new**  ·  **-{len(report.fixed)} fixed**  ·  "
+        f"**{len(report.persistent)} persistent**"
+    )
+    regs = report.regressions
+    if regs:
+        lines.append(f"  ·  **⚠ {len(regs)} regressions** (severity increased)")
+    lines.append("")
+
+    def _section(title: str, entries: list[DiffEntry], show_change: bool = False) -> None:
+        if not entries:
+            return
+        lines.append(f"## {title} ({len(entries)})\n")
+        lines.append("| Severity | Title |" + (" Change |" if show_change else ""))
+        lines.append("|----------|-------|" + ("--------|" if show_change else ""))
+        for e in entries:
+            row = f"| {e.severity} | {e.title[:80]} |"
+            if show_change:
+                row += f" {e.old_severity + ' → ' + e.severity if e.old_severity else '—'} |"
+            lines.append(row)
+        lines.append("")
+
+    _section("New", report.new)
+    _section("Fixed", report.fixed)
+    _section("Persistent", report.persistent, show_change=True)
+    return "\n".join(lines)
+
+
+# ── Tool handlers ────────────────────────────────────────────────────────────
+
+
+def _findings_from_agent(agent: Any) -> list[dict[str, Any]]:
+    session = getattr(agent, "session_state", None)
+    findings = getattr(session, "findings", None) or []
+    out: list[dict[str, Any]] = []
+    for f in findings:
+        if isinstance(f, dict):
+            out.append(f)
+        elif hasattr(f, "model_dump"):
+            out.append(f.model_dump())
+    return out
+
+
+async def findings_report_tool(agent: Any, args: dict[str, Any]) -> str:
+    """Agent tool: risk-score and summarize findings (session or provided)."""
+    findings = args.get("findings")
+    if not isinstance(findings, list) or not findings:
+        findings = _findings_from_agent(agent)
+    if not findings:
+        return "[findings_report] No findings to score. Pass a 'findings' array or run after findings exist."
+    with_compliance = bool(args.get("with_compliance", False))
+    score = score_findings(findings)
+    return format_risk_report(findings, score, with_compliance=with_compliance)
+
+
+async def findings_diff_tool(agent: Any, args: dict[str, Any]) -> str:
+    """Agent tool: diff a baseline finding set against the current/new one."""
+    baseline = args.get("baseline")
+    current = args.get("current")
+    if not isinstance(current, list) or not current:
+        current = _findings_from_agent(agent)
+    if not isinstance(baseline, list):
+        baseline = []
+    if not baseline and not current:
+        return "[findings_diff] Provide 'baseline' and 'current' finding arrays to diff."
+    report = diff_assessments(baseline, current, target=str(args.get("target", "") or ""))
+    return format_diff(report)

--- a/vulnclaw/intel/osint.py
+++ b/vulnclaw/intel/osint.py
@@ -1,0 +1,705 @@
+"""OSINT reconnaissance for VulnClaw.
+
+Ported from HackBot (``hackbot/core/osint.py``) and rewritten for VulnClaw's
+async stack: HTTP features (Certificate Transparency via crt.sh, RDAP WHOIS,
+tech-stack fingerprinting) use httpx; blocking DNS / socket-WHOIS / TLS calls run
+in worker threads. ``dnspython`` is an optional enhancement (``vulnclaw[osint]``);
+without it DNS resolution falls back to the stdlib socket resolver.
+
+Exposed to the agent as the ``osint_recon`` tool. This is *active* recon (it
+contacts the target and third-party services), so it is classified as ``recon``
+rather than read-only.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+import socket
+import ssl
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+_BROWSER_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+DEFAULT_MODULES = ("subdomains", "dns", "whois", "tech", "emails")
+
+
+# ── Data models ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SubdomainResult:
+    subdomain: str
+    ip: str = ""
+    source: str = ""
+    status: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "subdomain": self.subdomain,
+            "ip": self.ip,
+            "source": self.source,
+            "status": self.status,
+        }
+
+
+@dataclass
+class WHOISResult:
+    domain: str
+    registrar: str = ""
+    creation_date: str = ""
+    expiration_date: str = ""
+    updated_date: str = ""
+    name_servers: list[str] = field(default_factory=list)
+    status: list[str] = field(default_factory=list)
+    emails: list[str] = field(default_factory=list)
+    org: str = ""
+    country: str = ""
+    raw: str = ""
+
+
+@dataclass
+class DNSRecord:
+    record_type: str
+    value: str
+    ttl: int = 0
+
+
+@dataclass
+class TechStackResult:
+    url: str
+    server: str = ""
+    powered_by: str = ""
+    technologies: list[dict[str, str]] = field(default_factory=list)
+    headers: dict[str, str] = field(default_factory=dict)
+    cookies: list[str] = field(default_factory=list)
+    meta_tags: dict[str, str] = field(default_factory=dict)
+    scripts: list[str] = field(default_factory=list)
+    frameworks: list[str] = field(default_factory=list)
+
+
+@dataclass
+class OSINTReport:
+    domain: str
+    subdomains: list[SubdomainResult] = field(default_factory=list)
+    dns_records: list[DNSRecord] = field(default_factory=list)
+    whois: Optional[WHOISResult] = None
+    tech_stack: Optional[TechStackResult] = None
+    emails: list[str] = field(default_factory=list)
+
+
+# ── Fingerprints / wordlists ─────────────────────────────────────────────────
+
+TECH_FINGERPRINTS: dict[str, Any] = {
+    "headers": {
+        "X-Powered-By": {
+            "Express": {"name": "Express.js", "category": "Web Framework"},
+            "PHP": {"name": "PHP", "category": "Language"},
+            "ASP.NET": {"name": "ASP.NET", "category": "Web Framework"},
+            "Next.js": {"name": "Next.js", "category": "Web Framework"},
+            "Servlet": {"name": "Java Servlet", "category": "Web Framework"},
+        },
+        "Server": {
+            "nginx": {"name": "Nginx", "category": "Web Server"},
+            "Apache": {"name": "Apache", "category": "Web Server"},
+            "Microsoft-IIS": {"name": "IIS", "category": "Web Server"},
+            "LiteSpeed": {"name": "LiteSpeed", "category": "Web Server"},
+            "cloudflare": {"name": "Cloudflare", "category": "CDN"},
+            "AmazonS3": {"name": "Amazon S3", "category": "Cloud Storage"},
+            "gunicorn": {"name": "Gunicorn", "category": "Web Server"},
+            "Caddy": {"name": "Caddy", "category": "Web Server"},
+        },
+        "X-AspNet-Version": {"": {"name": "ASP.NET", "category": "Web Framework"}},
+        "X-Drupal-Cache": {"": {"name": "Drupal", "category": "CMS"}},
+    },
+    "cookies": {
+        "PHPSESSID": {"name": "PHP", "category": "Language"},
+        "JSESSIONID": {"name": "Java", "category": "Language"},
+        "ASP.NET_SessionId": {"name": "ASP.NET", "category": "Web Framework"},
+        "csrftoken": {"name": "Django", "category": "Web Framework"},
+        "laravel_session": {"name": "Laravel", "category": "Web Framework"},
+        "wp-settings": {"name": "WordPress", "category": "CMS"},
+        "_rails_": {"name": "Ruby on Rails", "category": "Web Framework"},
+        "connect.sid": {"name": "Express.js", "category": "Web Framework"},
+    },
+    "html": {
+        "wp-content": {"name": "WordPress", "category": "CMS"},
+        "wp-includes": {"name": "WordPress", "category": "CMS"},
+        "Joomla": {"name": "Joomla", "category": "CMS"},
+        "Drupal.settings": {"name": "Drupal", "category": "CMS"},
+        "react": {"name": "React", "category": "JS Framework"},
+        "vue": {"name": "Vue.js", "category": "JS Framework"},
+        "angular": {"name": "Angular", "category": "JS Framework"},
+        "__next": {"name": "Next.js", "category": "Web Framework"},
+        "__nuxt": {"name": "Nuxt.js", "category": "Web Framework"},
+        "gatsby": {"name": "Gatsby", "category": "Static Site Generator"},
+        "shopify": {"name": "Shopify", "category": "E-Commerce"},
+        "jquery": {"name": "jQuery", "category": "JS Library"},
+        "bootstrap": {"name": "Bootstrap", "category": "CSS Framework"},
+        "tailwindcss": {"name": "Tailwind CSS", "category": "CSS Framework"},
+    },
+}
+
+SUBDOMAIN_WORDLIST = [
+    "www", "mail", "remote", "blog", "webmail", "server", "ns1", "ns2",
+    "smtp", "secure", "vpn", "m", "shop", "ftp", "test", "portal", "ns",
+    "support", "dev", "web", "mx", "email", "cloud", "forum", "admin",
+    "store", "cdn", "api", "exchange", "app", "vps", "news", "intranet",
+    "staging", "beta", "demo", "internal", "lab", "stg", "sandbox", "git",
+    "jenkins", "ci", "jira", "confluence", "wiki", "monitor", "grafana",
+    "kibana", "status", "docs", "assets", "static", "media", "img", "files",
+    "backup", "old", "legacy", "proxy", "gateway", "auth", "sso", "login",
+]
+
+COMMON_EMAIL_PREFIXES = [
+    "info", "admin", "contact", "support", "hello", "sales",
+    "security", "abuse", "webmaster", "postmaster", "hr",
+]
+
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_SUBDOMAIN_RE = re.compile(
+    r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
+)
+_SCRIPT_SRC_RE = re.compile(r'<script[^>]+src=["\']([^"\']+)', re.IGNORECASE)
+_META_RE = re.compile(
+    r'<meta\s+(?:name|property)=["\']([^"\']+)["\']\s+content=["\']([^"\']+)',
+    re.IGNORECASE,
+)
+
+
+# ── Utilities ────────────────────────────────────────────────────────────────
+
+
+def clean_domain(domain: str) -> str:
+    domain = domain.strip().lower()
+    for prefix in ("https://", "http://", "www."):
+        if domain.startswith(prefix):
+            domain = domain[len(prefix):]
+    domain = domain.split("/")[0]
+    domain = domain.split(":")[0]
+    return domain
+
+
+def normalize_url(target: str) -> str:
+    target = target.strip()
+    if not target.startswith(("http://", "https://")):
+        target = f"https://{target}"
+    return target
+
+
+def is_valid_subdomain(name: str) -> bool:
+    if not name or len(name) > 253:
+        return False
+    return bool(_SUBDOMAIN_RE.match(name))
+
+
+@contextlib.asynccontextmanager
+async def _client_ctx(
+    client: Optional[httpx.AsyncClient], timeout: float, *, verify: bool = True
+) -> AsyncIterator[httpx.AsyncClient]:
+    if client is not None:
+        yield client
+        return
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        headers={"User-Agent": _BROWSER_UA},
+        follow_redirects=True,
+        verify=verify,
+    ) as owned:
+        yield owned
+
+
+def _resolve_host(hostname: str) -> str:
+    try:
+        return socket.gethostbyname(hostname)
+    except (socket.gaierror, OSError):
+        return ""
+
+
+# ── Subdomain enumeration ────────────────────────────────────────────────────
+
+
+async def crtsh_subdomains(
+    domain: str, *, client: Optional[httpx.AsyncClient] = None, timeout: float = 15.0
+) -> set[str]:
+    """Fetch subdomains from Certificate Transparency logs via crt.sh."""
+    subs: set[str] = set()
+    try:
+        async with _client_ctx(client, timeout) as c:
+            resp = await c.get(f"https://crt.sh/?q=%25.{domain}&output=json")
+            if resp.status_code != 200:
+                return subs
+            data = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return subs
+
+    for entry in data:
+        name = entry.get("name_value", "")
+        for line in name.split("\n"):
+            line = line.strip().lower().lstrip("*.")
+            if (line.endswith(f".{domain}") or line == domain) and is_valid_subdomain(line):
+                subs.add(line)
+    return subs
+
+
+async def enumerate_subdomains(
+    domain: str,
+    *,
+    bruteforce: bool = False,
+    resolve: bool = True,
+    client: Optional[httpx.AsyncClient] = None,
+    timeout: float = 15.0,
+) -> list[SubdomainResult]:
+    """Enumerate subdomains via Certificate Transparency + optional brute force."""
+    domain = clean_domain(domain)
+    found: dict[str, SubdomainResult] = {}
+
+    for sub in await crtsh_subdomains(domain, client=client, timeout=timeout):
+        found.setdefault(sub, SubdomainResult(subdomain=sub, source="crt.sh"))
+
+    if bruteforce:
+        for word in SUBDOMAIN_WORDLIST:
+            sub = f"{word}.{domain}"
+            if sub in found:
+                continue
+            ip = _resolve_host(sub)
+            if ip:
+                found[sub] = SubdomainResult(subdomain=sub, ip=ip, source="brute")
+
+    if resolve:
+        for result in found.values():
+            if not result.ip:
+                result.ip = _resolve_host(result.subdomain)
+
+    return sorted(found.values(), key=lambda s: s.subdomain)
+
+
+# ── DNS records ──────────────────────────────────────────────────────────────
+
+
+def _dnspython_records(domain: str, timeout: float) -> Optional[list[DNSRecord]]:
+    """Resolve records via dnspython, or None if dnspython is unavailable."""
+    try:
+        import dns.exception
+        import dns.resolver
+    except ImportError:
+        return None
+
+    resolver = dns.resolver.Resolver()
+    resolver.timeout = timeout
+    resolver.lifetime = timeout
+    records: list[DNSRecord] = []
+    for rtype in ("A", "AAAA", "MX", "NS", "TXT", "CNAME", "SOA", "SRV"):
+        try:
+            answers = resolver.resolve(domain, rtype)
+        except Exception:
+            continue
+        ttl = answers.rrset.ttl if answers.rrset else 0
+        for rdata in answers:
+            records.append(DNSRecord(record_type=rtype, value=str(rdata), ttl=ttl))
+    return records
+
+
+def _socket_records(domain: str) -> list[DNSRecord]:
+    records: list[DNSRecord] = []
+    try:
+        infos = socket.getaddrinfo(domain, None)
+    except (socket.gaierror, OSError):
+        return records
+    seen: set[tuple[str, str]] = set()
+    for family, _, _, _, sockaddr in infos:
+        ip = sockaddr[0]
+        rtype = "A" if family == socket.AF_INET else "AAAA"
+        if (rtype, ip) not in seen:
+            records.append(DNSRecord(record_type=rtype, value=ip))
+            seen.add((rtype, ip))
+    return records
+
+
+def _dns_records_blocking(domain: str, timeout: float) -> list[DNSRecord]:
+    records = _dnspython_records(domain, timeout)
+    if records is not None:
+        return records
+    return _socket_records(domain)
+
+
+async def get_dns_records(domain: str, *, timeout: float = 15.0) -> list[DNSRecord]:
+    """Retrieve DNS records (dnspython if installed, socket fallback otherwise)."""
+    return _dns_records_blocking(clean_domain(domain), timeout)
+
+
+def _mx_exists_blocking(domain: str) -> bool:
+    try:
+        import dns.resolver
+
+        return len(list(dns.resolver.resolve(domain, "MX"))) > 0
+    except ImportError:
+        pass
+    except Exception:
+        return False
+    try:
+        socket.getaddrinfo(f"mail.{domain}", 25)
+        return True
+    except (socket.gaierror, OSError):
+        return False
+
+
+# ── WHOIS ────────────────────────────────────────────────────────────────────
+
+
+async def rdap_whois(
+    domain: str, *, client: Optional[httpx.AsyncClient] = None, timeout: float = 15.0
+) -> Optional[WHOISResult]:
+    """RDAP lookup (IETF replacement for WHOIS)."""
+    try:
+        async with _client_ctx(client, timeout) as c:
+            resp = await c.get(
+                f"https://rdap.org/domain/{domain}",
+                headers={"Accept": "application/rdap+json"},
+            )
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+
+    result = WHOISResult(domain=domain)
+    for entity in data.get("entities", []):
+        if "registrar" in entity.get("roles", []):
+            vcard = entity.get("vcardArray", [None, []])
+            for item in vcard[1] if len(vcard) > 1 else []:
+                if item and item[0] == "fn":
+                    result.registrar = item[3]
+                    break
+    for event in data.get("events", []):
+        date = (event.get("eventDate", "") or "")[:10]
+        action = event.get("eventAction", "")
+        if action == "registration":
+            result.creation_date = date
+        elif action == "expiration":
+            result.expiration_date = date
+        elif action == "last changed":
+            result.updated_date = date
+    for ns in data.get("nameservers", []):
+        name = ns.get("ldhName", "")
+        if name:
+            result.name_servers.append(name)
+    result.status = data.get("status", [])
+    return result
+
+
+def _socket_whois_blocking(domain: str, timeout: float) -> Optional[WHOISResult]:
+    tld = domain.rsplit(".", 1)[-1]
+    whois_servers = {
+        "com": "whois.verisign-grs.com",
+        "net": "whois.verisign-grs.com",
+        "org": "whois.pir.org",
+        "io": "whois.nic.io",
+        "dev": "whois.nic.google",
+        "app": "whois.nic.google",
+    }
+    server = whois_servers.get(tld, f"whois.nic.{tld}")
+    try:
+        with socket.create_connection((server, 43), timeout=timeout) as sock:
+            sock.sendall(f"{domain}\r\n".encode())
+            chunks = []
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        text = b"".join(chunks).decode("utf-8", errors="replace")
+    except (OSError, socket.error):
+        return None
+
+    result = WHOISResult(domain=domain, raw=text)
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        lower = line.lower()
+        if "registrar:" in lower:
+            result.registrar = line.split(":", 1)[1].strip()
+        elif "creation date:" in lower or "created:" in lower:
+            result.creation_date = line.split(":", 1)[1].strip()[:10]
+        elif "expir" in lower and "date:" in lower:
+            result.expiration_date = line.split(":", 1)[1].strip()[:10]
+        elif "updated date:" in lower:
+            result.updated_date = line.split(":", 1)[1].strip()[:10]
+        elif "name server:" in lower:
+            result.name_servers.append(line.split(":", 1)[1].strip())
+        elif "registrant organization:" in lower:
+            result.org = line.split(":", 1)[1].strip()
+        elif "registrant country:" in lower:
+            result.country = line.split(":", 1)[1].strip()
+    result.emails = sorted(set(_EMAIL_RE.findall(text)))
+    return result
+
+
+async def whois_lookup(
+    domain: str, *, client: Optional[httpx.AsyncClient] = None, timeout: float = 15.0
+) -> Optional[WHOISResult]:
+    """WHOIS via RDAP, falling back to socket WHOIS."""
+    domain = clean_domain(domain)
+    result = await rdap_whois(domain, client=client, timeout=timeout)
+    if result:
+        return result
+    return _socket_whois_blocking(domain, timeout)
+
+
+# ── Email harvesting ─────────────────────────────────────────────────────────
+
+
+async def common_emails(domain: str) -> list[str]:
+    """Generate common-prefix emails when the domain has MX records.
+
+    Note: HackBot's search-engine scraping is intentionally dropped — it was
+    unreliable and ToS-fragile. This yields deterministic, low-noise candidates.
+    """
+    domain = clean_domain(domain)
+    if not _mx_exists_blocking(domain):
+        return []
+    return sorted(f"{prefix}@{domain}" for prefix in COMMON_EMAIL_PREFIXES)
+
+
+# ── Tech stack fingerprinting ────────────────────────────────────────────────
+
+
+def _ssl_issuer_org(hostname: str, timeout: float) -> str:
+    try:
+        ctx = ssl.create_default_context()
+        with socket.create_connection((hostname, 443), timeout=timeout) as raw:
+            with ctx.wrap_socket(raw, server_hostname=hostname) as s:
+                cert = s.getpeercert()
+        if cert:
+            issuer = dict(x[0] for x in cert.get("issuer", []))
+            return issuer.get("organizationName", "")
+    except (OSError, ssl.SSLError):
+        return ""
+    return ""
+
+
+async def fingerprint_tech(
+    target: str,
+    *,
+    client: Optional[httpx.AsyncClient] = None,
+    timeout: float = 15.0,
+    check_ssl: bool = True,
+) -> TechStackResult:
+    """Detect technologies from HTTP headers, cookies, HTML, and TLS issuer."""
+    url = normalize_url(target)
+    result = TechStackResult(url=url)
+    try:
+        async with _client_ctx(client, timeout, verify=False) as c:
+            resp = await c.get(url)
+    except httpx.HTTPError:
+        return result
+
+    result.headers = dict(resp.headers)
+    result.server = resp.headers.get("Server", "")
+    result.powered_by = resp.headers.get("X-Powered-By", "")
+
+    for header_name, patterns in TECH_FINGERPRINTS["headers"].items():
+        header_val = resp.headers.get(header_name, "")
+        if not header_val:
+            continue
+        for pattern, tech in patterns.items():
+            if not pattern or pattern.lower() in header_val.lower():
+                result.technologies.append(
+                    {
+                        "name": tech["name"],
+                        "category": tech["category"],
+                        "evidence": f"Header: {header_name}: {header_val[:100]}",
+                    }
+                )
+
+    for cookie in resp.cookies.jar:
+        name = cookie.name
+        result.cookies.append(name)
+        for pattern, tech in TECH_FINGERPRINTS["cookies"].items():
+            if pattern.lower() in name.lower():
+                result.technologies.append(
+                    {
+                        "name": tech["name"],
+                        "category": tech["category"],
+                        "evidence": f"Cookie: {name}",
+                    }
+                )
+
+    html = resp.text
+    for pattern, tech in TECH_FINGERPRINTS["html"].items():
+        if pattern.lower() in html.lower():
+            result.technologies.append(
+                {
+                    "name": tech["name"],
+                    "category": tech["category"],
+                    "evidence": f"HTML content match: {pattern}",
+                }
+            )
+
+    result.scripts = _SCRIPT_SRC_RE.findall(html)[:20]
+    for name, content in _META_RE.findall(html):
+        result.meta_tags[name] = content[:200]
+        if "generator" in name.lower():
+            result.frameworks.append(content)
+
+    if check_ssl:
+        parsed = urlparse(url)
+        if parsed.scheme == "https" and parsed.hostname:
+            org = _ssl_issuer_org(parsed.hostname, timeout)
+            if org:
+                result.technologies.append(
+                    {
+                        "name": f"SSL: {org}",
+                        "category": "Certificate Authority",
+                        "evidence": f"Certificate issuer: {org}",
+                    }
+                )
+
+    seen: set[str] = set()
+    unique = []
+    for tech in result.technologies:
+        if tech["name"] not in seen:
+            seen.add(tech["name"])
+            unique.append(tech)
+    result.technologies = unique
+    return result
+
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+
+
+async def full_scan(
+    domain: str,
+    *,
+    modules: tuple[str, ...] = DEFAULT_MODULES,
+    bruteforce: bool = False,
+    client: Optional[httpx.AsyncClient] = None,
+    timeout: float = 15.0,
+) -> OSINTReport:
+    """Run a configurable OSINT scan against a domain."""
+    domain = clean_domain(domain)
+    report = OSINTReport(domain=domain)
+    if "subdomains" in modules:
+        report.subdomains = await enumerate_subdomains(
+            domain, bruteforce=bruteforce, client=client, timeout=timeout
+        )
+    if "dns" in modules:
+        report.dns_records = await get_dns_records(domain, timeout=timeout)
+    if "whois" in modules:
+        report.whois = await whois_lookup(domain, client=client, timeout=timeout)
+    if "tech" in modules:
+        report.tech_stack = await fingerprint_tech(domain, client=client, timeout=timeout)
+    if "emails" in modules:
+        report.emails = await common_emails(domain)
+    return report
+
+
+# ── Formatting ───────────────────────────────────────────────────────────────
+
+
+def format_report(report: OSINTReport) -> str:
+    lines = [f"# OSINT Report: {report.domain}\n"]
+
+    lines.append("## Summary\n")
+    lines.append("| Metric | Count |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Subdomains | {len(report.subdomains)} |")
+    lines.append(f"| DNS Records | {len(report.dns_records)} |")
+    lines.append(f"| Emails | {len(report.emails)} |")
+    tech_count = len(report.tech_stack.technologies) if report.tech_stack else 0
+    lines.append(f"| Technologies | {tech_count} |")
+    lines.append("")
+
+    if report.subdomains:
+        lines.append("## Subdomains\n")
+        lines.append("| Subdomain | IP | Source |")
+        lines.append("|-----------|-----|--------|")
+        for s in report.subdomains[:50]:
+            lines.append(f"| {s.subdomain} | {s.ip or '—'} | {s.source} |")
+        if len(report.subdomains) > 50:
+            lines.append(f"\n_...and {len(report.subdomains) - 50} more_")
+        lines.append("")
+
+    if report.dns_records:
+        lines.append("## DNS Records\n")
+        lines.append("| Type | Value | TTL |")
+        lines.append("|------|-------|-----|")
+        for r in report.dns_records:
+            val = r.value[:80] + "..." if len(r.value) > 80 else r.value
+            lines.append(f"| {r.record_type} | {val} | {r.ttl} |")
+        lines.append("")
+
+    if report.whois:
+        w = report.whois
+        lines.append("## WHOIS\n")
+        if w.registrar:
+            lines.append(f"- **Registrar:** {w.registrar}")
+        if w.org:
+            lines.append(f"- **Organization:** {w.org}")
+        if w.country:
+            lines.append(f"- **Country:** {w.country}")
+        if w.creation_date:
+            lines.append(f"- **Created:** {w.creation_date}")
+        if w.expiration_date:
+            lines.append(f"- **Expires:** {w.expiration_date}")
+        if w.name_servers:
+            lines.append(f"- **Name Servers:** {', '.join(w.name_servers)}")
+        if w.emails:
+            lines.append(f"- **Contacts:** {', '.join(w.emails)}")
+        lines.append("")
+
+    if report.tech_stack and report.tech_stack.technologies:
+        ts = report.tech_stack
+        lines.append("## Technology Stack\n")
+        if ts.server:
+            lines.append(f"- **Server:** {ts.server}")
+        if ts.powered_by:
+            lines.append(f"- **Powered By:** {ts.powered_by}")
+        lines.append("")
+        by_category: dict[str, list[dict[str, str]]] = {}
+        for tech in ts.technologies:
+            by_category.setdefault(tech.get("category", "Other"), []).append(tech)
+        for cat, techs in by_category.items():
+            lines.append(f"**{cat}:**")
+            for t in techs:
+                lines.append(f"- {t['name']} _{t.get('evidence', '')}_")
+            lines.append("")
+
+    if report.emails:
+        lines.append("## Email Addresses\n")
+        for email in report.emails:
+            lines.append(f"- {email}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── Tool handler ─────────────────────────────────────────────────────────────
+
+
+async def osint_recon_tool(agent: Any, args: dict[str, Any]) -> str:
+    """Agent tool: run OSINT recon (subdomains/DNS/WHOIS/tech/emails) on a domain."""
+    domain = clean_domain(str(args.get("domain", "") or ""))
+    if not domain or "." not in domain:
+        return "[osint_recon] error: a valid 'domain' is required (e.g. example.com)."
+
+    requested = args.get("modules")
+    if isinstance(requested, list) and requested:
+        modules = tuple(m for m in requested if m in DEFAULT_MODULES)
+        if not modules:
+            modules = DEFAULT_MODULES
+    else:
+        modules = DEFAULT_MODULES
+
+    bruteforce = bool(args.get("bruteforce", False))
+    try:
+        report = await full_scan(domain, modules=modules, bruteforce=bruteforce)
+    except Exception as exc:  # never raise into the agent loop
+        return f"[osint_recon] error during scan of {domain}: {exc}"
+    return format_report(report)

--- a/vulnclaw/intel/remediation.py
+++ b/vulnclaw/intel/remediation.py
@@ -1,0 +1,1655 @@
+"""
+VulnClaw Remediation Engine
+================================
+Ported from HackBot (``hackbot/core/remediation.py``). For each finding,
+auto-generate actionable fix commands, configuration patches, and code
+snippets from a built-in rule knowledge base. Works in two modes:
+
+1. **Rule-based** — instant remediation from a built-in knowledge base of
+   vulnerability patterns (no API key required). This is the path used by the
+   ``remediation_advice`` tool.
+2. **AI-enhanced** — optional; uses a passed-in engine to generate tailored
+   fixes. Not used by the agent tool (the agent itself is the LLM).
+
+Each remediation contains:
+  • One-liner summary of the fix
+  • Shell commands (apt, systemctl, sysctl, iptables, etc.)
+  • Config file patches (nginx, apache, sshd, etc.)
+  • Code snippets (Python, PHP, JS, Java, etc.)
+  • References (CVE links, CIS benchmarks, OWASP pages)
+
+Usage (CLI)::
+
+    /remediate              Remediate all current findings
+    /remediate 2            Remediate finding #2 only
+    /remediate --ai         Force AI-enhanced remediation
+
+Usage (Agent)::
+
+    The agent can call the remediation engine automatically after
+    discovering findings to provide immediate fix guidance.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ── Enums ────────────────────────────────────────────────────────────────────
+
+class RemediationType(str, Enum):
+    """Category of remediation action."""
+    COMMAND = "command"
+    CONFIG = "config"
+    CODE = "code"
+    REFERENCE = "reference"
+
+
+class RemediationPriority(str, Enum):
+    """How urgently the fix should be applied."""
+    IMMEDIATE = "immediate"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    INFORMATIONAL = "informational"
+
+
+# ── Data Models ──────────────────────────────────────────────────────────────
+
+@dataclass
+class RemediationStep:
+    """A single actionable fix step."""
+    type: RemediationType
+    title: str
+    content: str
+    language: str = ""  # bash, python, nginx, apache, yaml, etc.
+    filename: str = ""  # target file path when applicable
+    description: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type.value,
+            "title": self.title,
+            "content": self.content,
+            "language": self.language,
+            "filename": self.filename,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RemediationStep":
+        return cls(
+            type=RemediationType(data.get("type", "reference")),
+            title=data.get("title", ""),
+            content=data.get("content", ""),
+            language=data.get("language", ""),
+            filename=data.get("filename", ""),
+            description=data.get("description", ""),
+        )
+
+
+@dataclass
+class Remediation:
+    """Complete remediation guidance for a single finding."""
+    finding_title: str
+    finding_severity: str
+    summary: str
+    priority: RemediationPriority
+    steps: List[RemediationStep] = field(default_factory=list)
+    references: List[str] = field(default_factory=list)
+    generated_at: float = field(default_factory=time.time)
+    source: str = "rule"  # "rule" or "ai"
+    confidence: float = 1.0  # 0.0-1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "finding_title": self.finding_title,
+            "finding_severity": self.finding_severity,
+            "summary": self.summary,
+            "priority": self.priority.value,
+            "steps": [s.to_dict() for s in self.steps],
+            "references": self.references,
+            "generated_at": self.generated_at,
+            "source": self.source,
+            "confidence": self.confidence,
+            "step_count": len(self.steps),
+            "has_commands": any(s.type == RemediationType.COMMAND for s in self.steps),
+            "has_config": any(s.type == RemediationType.CONFIG for s in self.steps),
+            "has_code": any(s.type == RemediationType.CODE for s in self.steps),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Remediation":
+        return cls(
+            finding_title=data.get("finding_title", ""),
+            finding_severity=data.get("finding_severity", ""),
+            summary=data.get("summary", ""),
+            priority=RemediationPriority(data.get("priority", "medium")),
+            steps=[RemediationStep.from_dict(s) for s in data.get("steps", [])],
+            references=data.get("references", []),
+            generated_at=data.get("generated_at", time.time()),
+            source=data.get("source", "rule"),
+            confidence=data.get("confidence", 1.0),
+        )
+
+    def get_markdown(self) -> str:
+        """Render remediation as markdown."""
+        lines = [f"## 🔧 Remediation: {self.finding_title}\n"]
+        lines.append(f"**Priority:** {self.priority.value.upper()} | "
+                      f"**Severity:** {self.finding_severity} | "
+                      f"**Source:** {self.source}\n")
+        lines.append(f"{self.summary}\n")
+
+        for i, step in enumerate(self.steps, 1):
+            icon = {"command": "💻", "config": "⚙️", "code": "📝", "reference": "📖"}.get(step.type.value, "•")
+            lines.append(f"### {icon} Step {i}: {step.title}\n")
+            if step.description:
+                lines.append(f"{step.description}\n")
+            if step.filename:
+                lines.append(f"**File:** `{step.filename}`\n")
+            lang = step.language or ("bash" if step.type == RemediationType.COMMAND else "")
+            if step.content:
+                lines.append(f"```{lang}\n{step.content}\n```\n")
+
+        if self.references:
+            lines.append("### 📚 References\n")
+            for ref in self.references:
+                lines.append(f"- {ref}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+# ── Severity → Priority Mapping ─────────────────────────────────────────────
+
+_SEVERITY_PRIORITY = {
+    "Critical": RemediationPriority.IMMEDIATE,
+    "High": RemediationPriority.HIGH,
+    "Medium": RemediationPriority.MEDIUM,
+    "Low": RemediationPriority.LOW,
+    "Info": RemediationPriority.INFORMATIONAL,
+}
+
+
+def _severity_to_priority(severity: str) -> RemediationPriority:
+    return _SEVERITY_PRIORITY.get(severity, RemediationPriority.MEDIUM)
+
+
+# ── Rule-Based Remediation Knowledge Base ────────────────────────────────────
+#
+# Each rule is a tuple of:
+#   (pattern, builder_function)
+#
+# `pattern` is compiled into a regex and matched against finding title +
+# description (case-insensitive).  `builder_function` receives the finding
+# dict and the regex match object and returns a Remediation.
+
+_RULES: List[Tuple[str, Callable]] = []
+
+
+def _rule(pattern: str):
+    """Decorator to register a remediation rule."""
+    def decorator(fn: Callable):
+        _RULES.append((pattern, fn))
+        return fn
+    return decorator
+
+
+# ── SQL Injection ────────────────────────────────────────────────────────────
+
+@_rule(r"sql\s*inject|sqli|blind.*inject|union.*inject")
+def _remediate_sqli(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "SQL Injection"),
+        finding_severity=finding.get("severity", "Critical"),
+        summary="Prevent SQL injection by using parameterized queries, input validation, and ORM frameworks.",
+        priority=RemediationPriority.IMMEDIATE,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Use parameterized queries (Python)",
+                language="python",
+                description="Replace string concatenation with parameterized queries.",
+                content="""# VULNERABLE — never do this:
+# cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
+
+# SECURE — use parameterized queries:
+cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+
+# Or use an ORM (SQLAlchemy):
+user = session.query(User).filter(User.id == user_id).first()""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Use parameterized queries (PHP)",
+                language="php",
+                description="Use PDO prepared statements.",
+                content="""<?php
+// VULNERABLE:
+// $stmt = $pdo->query("SELECT * FROM users WHERE id = " . $_GET['id']);
+
+// SECURE — use prepared statements:
+$stmt = $pdo->prepare("SELECT * FROM users WHERE id = :id");
+$stmt->execute(['id' => $_GET['id']]);
+$user = $stmt->fetch();""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Use parameterized queries (Java)",
+                language="java",
+                description="Use PreparedStatement instead of Statement.",
+                content="""// SECURE — PreparedStatement
+PreparedStatement ps = conn.prepareStatement(
+    "SELECT * FROM users WHERE id = ?");
+ps.setInt(1, userId);
+ResultSet rs = ps.executeQuery();""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Deploy a Web Application Firewall (WAF)",
+                language="bash",
+                description="Install ModSecurity as an additional defense layer.",
+                content="""# Install ModSecurity for Apache
+sudo apt install libapache2-mod-security2 -y
+sudo a2enmod security2
+sudo cp /etc/modsecurity/modsecurity.conf-recommended /etc/modsecurity/modsecurity.conf
+sudo sed -i 's/SecRuleEngine DetectionOnly/SecRuleEngine On/' /etc/modsecurity/modsecurity.conf
+sudo systemctl restart apache2""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/attacks/SQL_Injection",
+            "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── Cross-Site Scripting (XSS) ──────────────────────────────────────────────
+
+@_rule(r"cross.?site\s*script|xss|reflected.*script|stored.*script|dom.*xss")
+def _remediate_xss(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Cross-Site Scripting (XSS)"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Mitigate XSS by encoding output, validating input, and using Content Security Policy headers.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Add Content-Security-Policy header (Nginx)",
+                language="nginx",
+                filename="/etc/nginx/conf.d/security-headers.conf",
+                description="CSP prevents inline script execution.",
+                content="""add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none';" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Output encoding (Python/Jinja2)",
+                language="python",
+                description="Ensure all user input is HTML-escaped before rendering.",
+                content="""from markupsafe import escape
+
+# In Jinja2 templates, autoescaping is on by default:
+#   {{ user_input }}          ← auto-escaped
+#   {{ user_input | safe }}   ← DANGEROUS — avoid unless trusted
+
+# In Python code:
+safe_output = escape(user_input)""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Output encoding (JavaScript)",
+                language="javascript",
+                description="Use textContent instead of innerHTML for user data.",
+                content="""// VULNERABLE:
+// element.innerHTML = userData;
+
+// SECURE — use textContent:
+element.textContent = userData;
+
+// If HTML is needed, use a sanitizer:
+// import DOMPurify from 'dompurify';
+// element.innerHTML = DOMPurify.sanitize(userData);""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/attacks/xss/",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── Command Injection ────────────────────────────────────────────────────────
+
+@_rule(r"command\s*inject|os\s*command|shell\s*inject|rce|remote\s*code\s*exec")
+def _remediate_cmd_injection(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Command Injection"),
+        finding_severity=finding.get("severity", "Critical"),
+        summary="Prevent command injection by avoiding shell calls, using safe APIs, and validating input.",
+        priority=RemediationPriority.IMMEDIATE,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Use subprocess safely (Python)",
+                language="python",
+                description="Never use shell=True with user input.",
+                content="""import subprocess, shlex
+
+# VULNERABLE:
+# os.system(f"ping {user_input}")
+# subprocess.call(f"ping {user_input}", shell=True)
+
+# SECURE — use list arguments without shell=True:
+result = subprocess.run(
+    ["ping", "-c", "4", validated_host],
+    capture_output=True, text=True, timeout=10
+)""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Input validation",
+                language="python",
+                description="Whitelist allowed characters / values.",
+                content="""import re
+
+def validate_hostname(host: str) -> bool:
+    \"\"\"Allow only valid hostnames/IPs.\"\"\"
+    pattern = r'^[a-zA-Z0-9][a-zA-Z0-9\\-\\.]{0,253}[a-zA-Z0-9]$'
+    return bool(re.match(pattern, host))
+
+# Reject any input that doesn't pass validation
+if not validate_hostname(user_input):
+    raise ValueError("Invalid hostname")""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/attacks/Command_Injection",
+            "https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── Open Ports / Unnecessary Services ────────────────────────────────────────
+
+@_rule(r"open\s*port|unnecessary\s*service|exposed\s*port|unneeded.*service|port\s*\d+\s*open")
+def _remediate_open_ports(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Open Ports / Unnecessary Services"),
+        finding_severity=finding.get("severity", "Medium"),
+        summary="Close unnecessary ports and disable unused services to reduce the attack surface.",
+        priority=_severity_to_priority(finding.get("severity", "Medium")),
+        steps=[
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Identify and stop unnecessary services",
+                language="bash",
+                description="List listening services and disable unneeded ones.",
+                content="""# List all listening ports
+sudo ss -tulnp
+
+# Disable and stop an unnecessary service (e.g., telnet)
+sudo systemctl disable --now telnet.socket
+sudo systemctl disable --now rpcbind
+
+# Remove unnecessary packages
+sudo apt purge telnetd rsh-server -y""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Configure firewall (UFW)",
+                language="bash",
+                description="Allow only required ports.",
+                content="""# Enable UFW and set default deny
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+
+# Allow only needed services
+sudo ufw allow 22/tcp    # SSH
+sudo ufw allow 80/tcp    # HTTP
+sudo ufw allow 443/tcp   # HTTPS
+sudo ufw enable""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Configure firewall (iptables)",
+                language="bash",
+                description="Drop traffic to unnecessary ports.",
+                content="""# Drop all incoming by default
+sudo iptables -P INPUT DROP
+sudo iptables -P FORWARD DROP
+
+# Allow established connections
+sudo iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow loopback
+sudo iptables -A INPUT -i lo -j ACCEPT
+
+# Allow specific ports
+sudo iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 443 -j ACCEPT
+
+# Save rules
+sudo netfilter-persistent save""",
+            ),
+        ],
+        references=[
+            "https://www.cisecurity.org/benchmark",
+            "https://www.nist.gov/cyberframework",
+        ],
+    )
+
+
+# ── Weak / Default Credentials ──────────────────────────────────────────────
+
+@_rule(r"weak.*password|default.*cred|brute.?force|weak.*auth|default.*password|password.*policy")
+def _remediate_weak_creds(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Weak Credentials"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Enforce strong password policies, change all default credentials, and implement MFA.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Enforce password complexity (Linux PAM)",
+                language="bash",
+                description="Configure PAM to require strong passwords.",
+                content="""# Install password quality module
+sudo apt install libpam-pwquality -y
+
+# Configure password requirements
+sudo tee /etc/security/pwquality.conf << 'EOF'
+minlen = 14
+dcredit = -1
+ucredit = -1
+lcredit = -1
+ocredit = -1
+maxrepeat = 3
+dictcheck = 1
+EOF""",
+            ),
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Enforce SSH key-based authentication",
+                language="bash",
+                filename="/etc/ssh/sshd_config",
+                description="Disable password auth and require SSH keys.",
+                content="""# Disable password authentication
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+UsePAM yes
+
+# Allow only key-based auth
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+
+# Restart SSH
+# sudo systemctl restart sshd""",
+            ),
+        ],
+        references=[
+            "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html",
+            "https://pages.nist.gov/800-63-3/sp800-63b.html",
+        ],
+    )
+
+
+# ── SSL/TLS Issues ──────────────────────────────────────────────────────────
+
+@_rule(r"ssl|tls|certificate|cipher|heartbleed|poodle|beast|weak.*crypto|expired.*cert|self.?signed")
+def _remediate_ssl(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "SSL/TLS Misconfiguration"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Harden TLS configuration: use TLS 1.2+, strong ciphers, and valid certificates.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Harden Nginx TLS configuration",
+                language="nginx",
+                filename="/etc/nginx/conf.d/ssl.conf",
+                description="Enforce modern TLS with strong ciphers.",
+                content="""ssl_protocols TLSv1.2 TLSv1.3;
+ssl_prefer_server_ciphers on;
+ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
+ssl_session_timeout 1d;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;""",
+            ),
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Harden Apache TLS configuration",
+                language="apache",
+                filename="/etc/apache2/conf-available/ssl-hardening.conf",
+                description="Disable weak protocols and ciphers.",
+                content="""SSLProtocol -all +TLSv1.2 +TLSv1.3
+SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384
+SSLHonorCipherOrder on
+SSLCompression off
+SSLSessionTickets off
+Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" """,
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Obtain a valid certificate (Let's Encrypt)",
+                language="bash",
+                description="Replace self-signed or expired certificates.",
+                content="""# Install Certbot
+sudo apt install certbot python3-certbot-nginx -y
+
+# Obtain certificate
+sudo certbot --nginx -d yourdomain.com -d www.yourdomain.com
+
+# Auto-renew
+sudo certbot renew --dry-run""",
+            ),
+        ],
+        references=[
+            "https://ssl-config.mozilla.org/",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── Missing Security Headers ────────────────────────────────────────────────
+
+@_rule(r"missing.*header|security\s*header|x-frame|x-content|hsts|strict.?transport|clickjack|content.?security.?policy")
+def _remediate_headers(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Missing Security Headers"),
+        finding_severity=finding.get("severity", "Medium"),
+        summary="Add essential HTTP security headers to protect against common web attacks.",
+        priority=RemediationPriority.MEDIUM,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Add security headers (Nginx)",
+                language="nginx",
+                filename="/etc/nginx/conf.d/security-headers.conf",
+                content="""add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';" always;""",
+            ),
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Add security headers (Apache)",
+                language="apache",
+                filename="/etc/apache2/conf-available/security-headers.conf",
+                content="""Header always set X-Frame-Options "DENY"
+Header always set X-Content-Type-Options "nosniff"
+Header always set X-XSS-Protection "1; mode=block"
+Header always set Referrer-Policy "strict-origin-when-cross-origin"
+Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
+Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+
+# Enable: sudo a2enconf security-headers && sudo systemctl reload apache2""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Add security headers (Express.js / Node)",
+                language="javascript",
+                description="Use the helmet middleware.",
+                content="""const helmet = require('helmet');
+const app = require('express')();
+
+app.use(helmet());  // Sets all security headers automatically
+
+// Or configure individually:
+app.use(helmet.frameguard({ action: 'deny' }));
+app.use(helmet.contentSecurityPolicy({
+  directives: { defaultSrc: ["'self'"], scriptSrc: ["'self'"] }
+}));""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-project-secure-headers/",
+            "https://securityheaders.com/",
+        ],
+    )
+
+
+# ── Directory Traversal / Path Traversal ─────────────────────────────────────
+
+@_rule(r"directory.*travers|path.*travers|local.*file.*inclu|lfi|\.\.\/|file.*inclusion")
+def _remediate_path_traversal(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Path Traversal"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Prevent path traversal by validating file paths and using chroot/jail mechanisms.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Validate file paths (Python)",
+                language="python",
+                content="""import os
+from pathlib import Path
+
+ALLOWED_DIR = Path("/var/www/uploads").resolve()
+
+def safe_file_access(user_path: str) -> Path:
+    \"\"\"Prevent path traversal by resolving and validating paths.\"\"\"
+    requested = (ALLOWED_DIR / user_path).resolve()
+    if not str(requested).startswith(str(ALLOWED_DIR)):
+        raise ValueError("Path traversal detected")
+    return requested""",
+            ),
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Restrict access in Nginx",
+                language="nginx",
+                description="Block path traversal patterns.",
+                content="""# Block path traversal attempts
+location ~ \\.\\. {
+    deny all;
+    return 403;
+}
+
+# Restrict to specific directory
+location /uploads/ {
+    alias /var/www/uploads/;
+    autoindex off;
+}""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/attacks/Path_Traversal",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── CSRF ─────────────────────────────────────────────────────────────────────
+
+@_rule(r"csrf|cross.?site\s*request\s*forg")
+def _remediate_csrf(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Cross-Site Request Forgery (CSRF)"),
+        finding_severity=finding.get("severity", "Medium"),
+        summary="Implement CSRF tokens and SameSite cookie attributes.",
+        priority=RemediationPriority.MEDIUM,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="CSRF protection (Python/Flask)",
+                language="python",
+                description="Use Flask-WTF for automatic CSRF protection.",
+                content="""from flask_wtf.csrf import CSRFProtect
+
+app = Flask(__name__)
+app.secret_key = os.urandom(32)
+csrf = CSRFProtect(app)
+
+# In templates, include the token:
+# <input type=\"hidden\" name=\"csrf_token\" value=\"{{ csrf_token() }}\">""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="SameSite cookies (Express.js)",
+                language="javascript",
+                content="""app.use(session({
+  cookie: {
+    sameSite: 'strict',  // or 'lax'
+    secure: true,
+    httpOnly: true,
+  }
+}));""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/attacks/csrf",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── SSH Misconfigurations ────────────────────────────────────────────────────
+
+@_rule(r"ssh.*misconfig|ssh.*weak|openssh.*vuln|ssh.*root|ssh.*permit|ssh.*password")
+def _remediate_ssh(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "SSH Misconfiguration"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Harden SSH configuration: disable root login, use key-based auth, restrict access.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Harden sshd_config",
+                language="bash",
+                filename="/etc/ssh/sshd_config",
+                content="""# Disable root login
+PermitRootLogin no
+
+# Disable password authentication
+PasswordAuthentication no
+
+# Use only SSHv2
+Protocol 2
+
+# Limit authentication attempts
+MaxAuthTries 3
+LoginGraceTime 30
+
+# Disable empty passwords
+PermitEmptyPasswords no
+
+# Restrict to specific users/groups
+AllowGroups sshusers
+
+# Use strong key exchange and ciphers
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Apply and verify SSH changes",
+                language="bash",
+                content="""# Validate config before restart
+sudo sshd -t
+
+# Restart SSH
+sudo systemctl restart sshd
+
+# Verify settings
+sudo sshd -T | grep -E 'permitrootlogin|passwordauthentication|maxauthtries'""",
+            ),
+        ],
+        references=[
+            "https://www.ssh.com/academy/ssh/sshd_config",
+            "https://www.cisecurity.org/benchmark/distribution_independent_linux",
+        ],
+    )
+
+
+# ── Information Disclosure ───────────────────────────────────────────────────
+
+@_rule(r"info.*disclos|server.*version|version.*disclos|banner.*grab|sensitive.*info.*expos|directory.*listing|stack\s*trace")
+def _remediate_info_disclosure(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Information Disclosure"),
+        finding_severity=finding.get("severity", "Low"),
+        summary="Suppress server version banners, disable directory listings, and remove debug endpoints.",
+        priority=_severity_to_priority(finding.get("severity", "Low")),
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Hide server version (Nginx)",
+                language="nginx",
+                filename="/etc/nginx/nginx.conf",
+                content="""# In http block:
+server_tokens off;
+# Optionally add:
+# more_clear_headers Server;""",
+            ),
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Hide server version (Apache)",
+                language="apache",
+                filename="/etc/apache2/conf-available/security.conf",
+                content="""ServerTokens Prod
+ServerSignature Off
+TraceEnable Off""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Disable directory listing",
+                language="bash",
+                content="""# Nginx — remove autoindex
+# autoindex off;  (default, but ensure it's not 'on')
+
+# Apache — remove Indexes option
+sudo sed -i 's/Options Indexes/Options -Indexes/' /etc/apache2/apache2.conf
+sudo systemctl reload apache2""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/01-Information_Gathering/",
+        ],
+    )
+
+
+# ── Outdated Software / Known CVEs ──────────────────────────────────────────
+
+@_rule(r"outdated|end.?of.?life|eol|unpatched|cve-\d{4}|known.*vuln|update.*required|upgrade.*required")
+def _remediate_outdated(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Outdated Software"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Update affected software to the latest patched version.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Update system packages",
+                language="bash",
+                content="""# Debian/Ubuntu
+sudo apt update && sudo apt upgrade -y
+
+# RHEL/CentOS/Rocky
+sudo dnf update -y
+
+# Check for security updates only (Debian)
+sudo apt list --upgradable 2>/dev/null | grep -i security""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Update specific software",
+                language="bash",
+                description="Replace <package> with the affected software.",
+                content="""# Check installed version
+dpkg -l | grep <package>
+# or
+rpm -qa | grep <package>
+
+# Update specific package
+sudo apt install --only-upgrade <package>
+# or
+sudo dnf update <package>""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Enable automatic security updates",
+                language="bash",
+                content="""# Debian/Ubuntu — enable unattended upgrades
+sudo apt install unattended-upgrades -y
+sudo dpkg-reconfigure -plow unattended-upgrades""",
+            ),
+        ],
+        references=[
+            "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+            "https://nvd.nist.gov/",
+        ],
+    )
+
+
+# ── CORS Misconfiguration ───────────────────────────────────────────────────
+
+@_rule(r"cors|cross.?origin|access.?control.?allow|origin.*wildcard")
+def _remediate_cors(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "CORS Misconfiguration"),
+        finding_severity=finding.get("severity", "Medium"),
+        summary="Restrict CORS to specific trusted origins instead of wildcard or reflected origins.",
+        priority=RemediationPriority.MEDIUM,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Fix CORS in Nginx",
+                language="nginx",
+                content="""# Allow specific origins only (not wildcard *)
+set $cors_origin "";
+if ($http_origin ~* "^https://(www\\.)?yourdomain\\.com$") {
+    set $cors_origin $http_origin;
+}
+add_header Access-Control-Allow-Origin $cors_origin always;
+add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+add_header Access-Control-Allow-Headers "Authorization, Content-Type" always;
+add_header Access-Control-Allow-Credentials "true" always;""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Fix CORS in Express.js",
+                language="javascript",
+                content="""const cors = require('cors');
+
+// VULNERABLE: app.use(cors());  // allows all origins
+
+// SECURE:
+app.use(cors({
+  origin: ['https://yourdomain.com', 'https://app.yourdomain.com'],
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE'],
+}));""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/attacks/CORS_OriginHeaderScrutiny",
+            "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS",
+        ],
+    )
+
+
+# ── IDOR / Broken Access Control ─────────────────────────────────────────────
+
+@_rule(r"idor|insecure.*direct.*object|broken.*access.*control|privilege.*escalat|unauthorized.*access|access.*control")
+def _remediate_idor(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Broken Access Control"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Implement proper authorization checks on every endpoint and use indirect object references.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Authorization middleware (Python/Flask)",
+                language="python",
+                content="""from functools import wraps
+from flask import abort, g
+
+def require_owner(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        resource = get_resource(kwargs['resource_id'])
+        if resource.owner_id != g.current_user.id:
+            abort(403)
+        return f(*args, **kwargs)
+    return decorated
+
+@app.route('/api/documents/<resource_id>')
+@require_owner
+def get_document(resource_id):
+    # User can only access their own documents
+    ...""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Use indirect references",
+                language="python",
+                description="Map internal IDs to per-user tokens.",
+                content="""import secrets
+
+# Instead of: /api/invoice/12345 (sequential, guessable)
+# Use: /api/invoice/a7f3b2c9e1d4 (random token per user)
+
+def create_indirect_ref(user_id: int, internal_id: int) -> str:
+    token = secrets.token_urlsafe(16)
+    cache.set(f"ref:{user_id}:{token}", internal_id, timeout=3600)
+    return token""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/Top10/A01_2021-Broken_Access_Control/",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── File Upload Vulnerabilities ──────────────────────────────────────────────
+
+@_rule(r"file\s*upload|unrestrict.*upload|malicious.*upload|upload.*vuln|webshell")
+def _remediate_upload(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Unrestricted File Upload"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Validate file types, scan uploads, and store files outside the webroot.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Validate uploads (Python/Flask)",
+                language="python",
+                content="""import magic
+from pathlib import Path
+
+ALLOWED_MIME = {'image/jpeg', 'image/png', 'image/gif', 'application/pdf'}
+ALLOWED_EXT = {'.jpg', '.jpeg', '.png', '.gif', '.pdf'}
+MAX_SIZE = 10 * 1024 * 1024  # 10 MB
+UPLOAD_DIR = Path('/var/uploads')  # Outside webroot!
+
+def validate_upload(file):
+    # Check extension
+    ext = Path(file.filename).suffix.lower()
+    if ext not in ALLOWED_EXT:
+        raise ValueError(f"Extension {ext} not allowed")
+    # Check file size
+    file.seek(0, 2)
+    if file.tell() > MAX_SIZE:
+        raise ValueError("File too large")
+    file.seek(0)
+    # Check actual MIME type (not just header)
+    mime = magic.from_buffer(file.read(2048), mime=True)
+    file.seek(0)
+    if mime not in ALLOWED_MIME:
+        raise ValueError(f"MIME type {mime} not allowed")""",
+            ),
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Restrict uploads in Nginx",
+                language="nginx",
+                content="""# Limit upload size
+client_max_body_size 10m;
+
+# Disable script execution in upload directory
+location /uploads/ {
+    location ~ \\.(php|py|pl|cgi|sh|asp|aspx|jsp)$ {
+        deny all;
+    }
+}""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload",
+            "https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── XML External Entity (XXE) ───────────────────────────────────────────────
+
+@_rule(r"xxe|xml.*external.*entity|xml.*inject|xml.*parse")
+def _remediate_xxe(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "XML External Entity (XXE)"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Disable external entity processing in XML parsers.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Disable XXE (Python)",
+                language="python",
+                content="""import defusedxml.ElementTree as ET
+
+# VULNERABLE: xml.etree.ElementTree.parse(user_input)
+# SECURE:
+tree = ET.parse(user_input)  # defusedxml blocks XXE by default
+
+# Or with lxml:
+from lxml import etree
+parser = etree.XMLParser(resolve_entities=False, no_network=True)
+tree = etree.parse(user_input, parser)""",
+            ),
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Disable XXE (Java)",
+                language="java",
+                content="""DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+dbf.setXIncludeAware(false);
+dbf.setExpandEntityReferences(false);""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing",
+            "https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── Server-Side Request Forgery (SSRF) ──────────────────────────────────────
+
+@_rule(r"ssrf|server.?side\s*request\s*forg")
+def _remediate_ssrf(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Server-Side Request Forgery (SSRF)"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Validate and restrict outbound requests to prevent SSRF attacks.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="URL validation (Python)",
+                language="python",
+                content="""import ipaddress
+from urllib.parse import urlparse
+
+BLOCKED_NETWORKS = [
+    ipaddress.ip_network('127.0.0.0/8'),
+    ipaddress.ip_network('10.0.0.0/8'),
+    ipaddress.ip_network('172.16.0.0/12'),
+    ipaddress.ip_network('192.168.0.0/16'),
+    ipaddress.ip_network('169.254.0.0/16'),
+]
+
+def validate_url(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme not in ('http', 'https'):
+        return False
+    import socket
+    ip = socket.gethostbyname(parsed.hostname)
+    addr = ipaddress.ip_address(ip)
+    for net in BLOCKED_NETWORKS:
+        if addr in net:
+            return False  # Block internal network access
+    return True""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-community/attacks/Server_Side_Request_Forgery",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── Insecure Deserialization ─────────────────────────────────────────────────
+
+@_rule(r"deserializ|pickle|marshal|insecure.*serial|object.*inject")
+def _remediate_deserialization(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Insecure Deserialization"),
+        finding_severity=finding.get("severity", "Critical"),
+        summary="Avoid deserializing untrusted data; use safe formats like JSON instead of pickle/marshal.",
+        priority=RemediationPriority.IMMEDIATE,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CODE,
+                title="Replace pickle with JSON (Python)",
+                language="python",
+                content="""import json
+
+# VULNERABLE:
+# import pickle
+# data = pickle.loads(user_input)  # RCE risk!
+
+# SECURE:
+data = json.loads(user_input)
+
+# If you MUST use pickle, use restricted unpickler:
+import pickle, io
+class RestrictedUnpickler(pickle.Unpickler):
+    ALLOWED = {'builtins': {'range', 'dict', 'list', 'set', 'tuple'}}
+    def find_class(self, module, name):
+        if module in self.ALLOWED and name in self.ALLOWED[module]:
+            return getattr(__import__(module), name)
+        raise pickle.UnpicklingError(f"Blocked: {module}.{name}")""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/15-Testing_for_HTTP_Incoming_Requests",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html",
+        ],
+    )
+
+
+# ── DNS Zone Transfer ────────────────────────────────────────────────────────
+
+@_rule(r"dns.*zone\s*transfer|axfr|dns.*misconfig")
+def _remediate_dns(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "DNS Zone Transfer"),
+        finding_severity=finding.get("severity", "Medium"),
+        summary="Restrict DNS zone transfers to authorized secondary nameservers only.",
+        priority=RemediationPriority.MEDIUM,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Restrict zone transfers (BIND)",
+                language="bash",
+                filename="/etc/bind/named.conf.options",
+                content="""options {
+    allow-transfer { none; };     // Global default: deny all
+    allow-query { any; };
+};
+
+// Per-zone: allow only secondary NS
+zone "example.com" {
+    type master;
+    file "/etc/bind/db.example.com";
+    allow-transfer { 192.168.1.2; };  // Secondary NS IP only
+};""",
+            ),
+        ],
+        references=[
+            "https://www.cisecurity.org/benchmark/bind",
+        ],
+    )
+
+
+# ── SNMP Community Strings ──────────────────────────────────────────────────
+
+@_rule(r"snmp.*community|snmp.*public|snmp.*private|snmp.*default|snmp.*string")
+def _remediate_snmp(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "SNMP Default Community String"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Change default SNMP community strings and upgrade to SNMPv3 with authentication.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Configure SNMPv3 (snmpd.conf)",
+                language="bash",
+                filename="/etc/snmp/snmpd.conf",
+                content="""# Remove default community strings
+# rocommunity public  ← DELETE THIS
+# rwcommunity private ← DELETE THIS
+
+# Use SNMPv3 with auth and encryption
+createUser snmpMonitor SHA "StrongAuthPass!" AES "StrongPrivPass!"
+rouser snmpMonitor priv
+
+# Restrict access by IP
+agentAddress udp:161
+com2sec readonly  192.168.1.0/24  secret_community""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Apply SNMP changes",
+                language="bash",
+                content="""sudo systemctl restart snmpd
+# Verify with:
+snmpwalk -v3 -u snmpMonitor -l authPriv -a SHA -A "StrongAuthPass!" -x AES -X "StrongPrivPass!" localhost""",
+            ),
+        ],
+        references=[
+            "https://www.cisecurity.org/benchmark",
+        ],
+    )
+
+
+# ── Exposed Admin / Debug Panels ─────────────────────────────────────────────
+
+@_rule(r"admin.*panel|debug.*mode|debug.*endpoint|exposed.*admin|phpinfo|phpmyadmin|management.*console|dashboard.*exposed")
+def _remediate_admin_panels(finding: Dict, match) -> Remediation:
+    return Remediation(
+        finding_title=finding.get("title", "Exposed Admin/Debug Panel"),
+        finding_severity=finding.get("severity", "High"),
+        summary="Restrict access to admin and debug endpoints; disable debug mode in production.",
+        priority=RemediationPriority.HIGH,
+        steps=[
+            RemediationStep(
+                type=RemediationType.CONFIG,
+                title="Restrict admin access (Nginx)",
+                language="nginx",
+                content="""# Block admin panels from public access
+location ~ ^/(admin|phpmyadmin|wp-admin|debug|server-status|server-info) {
+    allow 10.0.0.0/8;      # Internal network only
+    allow 192.168.0.0/16;
+    deny all;
+}""",
+            ),
+            RemediationStep(
+                type=RemediationType.COMMAND,
+                title="Disable debug mode",
+                language="bash",
+                content="""# Django — set in settings.py or env:
+# DEBUG = False
+# ALLOWED_HOSTS = ['yourdomain.com']
+
+# Flask — never run with debug in production:
+# app.run(debug=False)
+
+# Remove phpinfo files:
+sudo find /var/www -name 'phpinfo.php' -delete
+sudo find /var/www -name 'info.php' -delete""",
+            ),
+        ],
+        references=[
+            "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/",
+        ],
+    )
+
+
+# ── Compile Rules ────────────────────────────────────────────────────────────
+
+_COMPILED_RULES: List[Tuple[re.Pattern, Callable]] = []
+
+
+def _compile_rules() -> None:
+    """Compile all rule patterns (lazy, on first use)."""
+    if _COMPILED_RULES:
+        return
+    _COMPILED_RULES.extend(
+        (re.compile(pattern, re.IGNORECASE), fn)
+        for pattern, fn in _RULES
+    )
+
+
+# ── Remediation Engine ───────────────────────────────────────────────────────
+
+class RemediationEngine:
+    """
+    Generates remediation guidance for security findings.
+
+    Two strategies:
+    1. Rule-based (instant, no API) — matches finding title/description
+       against built-in vulnerability patterns.
+    2. AI-enhanced (optional) — Falls back to an LLM for tailored fixes
+       when no rule matches or when --ai flag is used.
+    """
+
+    def __init__(self, ai_engine: Optional[Any] = None):
+        """
+        Args:
+            ai_engine: Optional AIEngine instance for AI-enhanced remediation.
+        """
+        _compile_rules()
+        self.ai_engine = ai_engine
+
+    # ── Rule-Based Remediation ───────────────────────────────────────────
+
+    def remediate_finding(self, finding: Dict[str, Any], use_ai: bool = False) -> Remediation:
+        """
+        Generate remediation for a single finding.
+
+        Args:
+            finding: Finding dict with title, severity, description, etc.
+            use_ai: Force AI-enhanced remediation even if rules match.
+
+        Returns:
+            Remediation object with fix steps.
+        """
+        title = finding.get("title", "")
+        desc = finding.get("description", "")
+        search_text = f"{title} {desc}"
+
+        # Try rule-based first
+        if not use_ai:
+            for pattern, builder in _COMPILED_RULES:
+                m = pattern.search(search_text)
+                if m:
+                    try:
+                        return builder(finding, m)
+                    except Exception as e:
+                        logger.warning(f"Rule failed for '{title}': {e}")
+
+        # AI-enhanced fallback
+        if self.ai_engine:
+            return self._ai_remediate(finding)
+
+        # Generic fallback
+        return self._generic_remediation(finding)
+
+    def remediate_findings(
+        self,
+        findings: List[Dict[str, Any]],
+        use_ai: bool = False,
+    ) -> List[Remediation]:
+        """Remediate a list of findings."""
+        return [self.remediate_finding(f, use_ai=use_ai) for f in findings]
+
+    # ── AI-Enhanced Remediation ──────────────────────────────────────────
+
+    def _ai_remediate(self, finding: Dict[str, Any]) -> Remediation:
+        """Use AI to generate tailored remediation."""
+        prompt = self._build_ai_prompt(finding)
+        try:
+            response = self.ai_engine.chat(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.3,
+            )
+            return self._parse_ai_response(finding, response)
+        except Exception as e:
+            logger.error(f"AI remediation failed: {e}")
+            return self._generic_remediation(finding)
+
+    @staticmethod
+    def _build_ai_prompt(finding: Dict[str, Any]) -> str:
+        """Build a prompt for AI-enhanced remediation."""
+        return f"""You are a cybersecurity remediation expert. Generate specific, actionable fix guidance for this security finding.
+
+**Finding:** {finding.get('title', 'Unknown')}
+**Severity:** {finding.get('severity', 'Unknown')}
+**Description:** {finding.get('description', 'No description')}
+**Evidence:** {finding.get('evidence', 'None')}
+**Tool:** {finding.get('tool', 'Unknown')}
+
+Provide your response in this exact format:
+
+SUMMARY: <one-sentence fix description>
+
+COMMAND:
+<title>: <title of the command step>
+<description>: <brief description>
+<language>: bash
+```
+<shell commands to fix the issue>
+```
+
+CONFIG:
+<title>: <title of the config step>
+<filename>: <config file path>
+<language>: <config type>
+```
+<config patch content>
+```
+
+CODE:
+<title>: <title of the code step>
+<language>: <programming language>
+```
+<code snippet to fix>
+```
+
+REFERENCES:
+- <relevant URL 1>
+- <relevant URL 2>
+
+Include at least one COMMAND and one CODE or CONFIG section. Be specific to the actual finding — don't give generic advice. Use real file paths and real commands."""
+
+    @staticmethod
+    def _parse_ai_response(finding: Dict[str, Any], response: str) -> Remediation:
+        """Parse AI response into structured Remediation."""
+        steps = []
+        references = []
+        summary = ""
+
+        # Extract summary
+        summary_match = re.search(r'SUMMARY:\s*(.+?)(?:\n\n|\nCOMMAND|\nCONFIG|\nCODE|\nREFERENCES)', response, re.DOTALL)
+        if summary_match:
+            summary = summary_match.group(1).strip()
+
+        # Extract code blocks with their section context
+        sections = re.split(r'\n(COMMAND|CONFIG|CODE|REFERENCES):', response)
+
+        current_type = None
+        for i, section in enumerate(sections):
+            section_stripped = section.strip()
+            if section_stripped in ('COMMAND', 'CONFIG', 'CODE'):
+                current_type = section_stripped
+                continue
+            if section_stripped == 'REFERENCES':
+                # Extract reference URLs
+                ref_matches = re.findall(r'-\s*(https?://\S+)', section if i + 1 < len(sections) else "")
+                if not ref_matches and i + 1 < len(sections):
+                    ref_matches = re.findall(r'-\s*(https?://\S+)', sections[i + 1])
+                references.extend(ref_matches)
+                continue
+
+            if current_type and section_stripped:
+                rtype = {
+                    'COMMAND': RemediationType.COMMAND,
+                    'CONFIG': RemediationType.CONFIG,
+                    'CODE': RemediationType.CODE,
+                }.get(current_type, RemediationType.COMMAND)
+
+                # Extract title
+                title_match = re.search(r'<title>:\s*(.+)', section)
+                title = title_match.group(1).strip() if title_match else f"{current_type.title()} Fix"
+
+                # Extract description
+                desc_match = re.search(r'<description>:\s*(.+)', section)
+                desc = desc_match.group(1).strip() if desc_match else ""
+
+                # Extract language
+                lang_match = re.search(r'<language>:\s*(.+)', section)
+                lang = lang_match.group(1).strip() if lang_match else ("bash" if rtype == RemediationType.COMMAND else "")
+
+                # Extract filename
+                file_match = re.search(r'<filename>:\s*(.+)', section)
+                filename = file_match.group(1).strip() if file_match else ""
+
+                # Extract code block
+                code_match = re.search(r'```\w*\n(.*?)```', section, re.DOTALL)
+                content = code_match.group(1).strip() if code_match else section_stripped[:500]
+
+                steps.append(RemediationStep(
+                    type=rtype,
+                    title=title,
+                    content=content,
+                    language=lang,
+                    filename=filename,
+                    description=desc,
+                ))
+
+        # Extract references from the end if not found yet
+        if not references:
+            ref_matches = re.findall(r'-\s*(https?://\S+)', response)
+            references = ref_matches[:5]
+
+        if not summary:
+            summary = f"AI-generated remediation for: {finding.get('title', 'Unknown')}"
+
+        return Remediation(
+            finding_title=finding.get("title", "Unknown"),
+            finding_severity=finding.get("severity", "Unknown"),
+            summary=summary,
+            priority=_severity_to_priority(finding.get("severity", "Medium")),
+            steps=steps or [RemediationStep(
+                type=RemediationType.REFERENCE,
+                title="AI Guidance",
+                content=response[:2000],
+                description="Full AI-generated remediation guidance.",
+            )],
+            references=references,
+            source="ai",
+            confidence=0.8,
+        )
+
+    # ── Generic Fallback ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _generic_remediation(finding: Dict[str, Any]) -> Remediation:
+        """Fallback remediation when no rule matches and AI is unavailable."""
+        severity = finding.get("severity", "Medium")
+        title = finding.get("title", "Security Finding")
+        recommendation = finding.get("recommendation", "")
+
+        steps = []
+        if recommendation:
+            steps.append(RemediationStep(
+                type=RemediationType.REFERENCE,
+                title="Original Recommendation",
+                content=recommendation,
+                description="Recommendation from the assessment tool.",
+            ))
+
+        steps.append(RemediationStep(
+            type=RemediationType.REFERENCE,
+            title="General Guidance",
+            content=f"""1. Research "{title}" in the OWASP Testing Guide and NVD
+2. Apply vendor-recommended patches or workarounds
+3. Implement defense-in-depth controls:
+   - Network segmentation and firewall rules
+   - Input validation and output encoding
+   - Least-privilege access controls
+   - Monitoring and alerting
+4. Verify the fix with a targeted re-test
+5. Document the remediation in your risk register""",
+            description="Follow these steps when a specific remediation is not available.",
+        ))
+
+        return Remediation(
+            finding_title=title,
+            finding_severity=severity,
+            summary=f"Review and apply vendor-recommended fixes for: {title}",
+            priority=_severity_to_priority(severity),
+            steps=steps,
+            references=[
+                "https://owasp.org/www-project-web-security-testing-guide/",
+                "https://nvd.nist.gov/",
+            ],
+            source="generic",
+            confidence=0.3,
+        )
+
+    # ── Batch Summary ────────────────────────────────────────────────────
+
+    @staticmethod
+    def get_summary_markdown(remediations: List[Remediation]) -> str:
+        """Generate a combined markdown report for all remediations."""
+        if not remediations:
+            return "No remediations generated.\n"
+
+        lines = ["# 🔧 Remediation Report\n"]
+
+        # Priority summary
+        by_priority: Dict[str, int] = {}
+        for r in remediations:
+            by_priority[r.priority.value] = by_priority.get(r.priority.value, 0) + 1
+        lines.append("## Priority Summary\n")
+        for p in ["immediate", "high", "medium", "low", "informational"]:
+            if p in by_priority:
+                icon = {"immediate": "🔴", "high": "🟠", "medium": "🟡", "low": "🔵", "informational": "⚪"}.get(p, "•")
+                lines.append(f"- {icon} **{p.upper()}:** {by_priority[p]} findings")
+        lines.append("")
+
+        # Stats
+        total_steps = sum(len(r.steps) for r in remediations)
+        cmd_count = sum(1 for r in remediations for s in r.steps if s.type == RemediationType.COMMAND)
+        cfg_count = sum(1 for r in remediations for s in r.steps if s.type == RemediationType.CONFIG)
+        code_count = sum(1 for r in remediations for s in r.steps if s.type == RemediationType.CODE)
+        lines.append(f"**Total:** {len(remediations)} findings → {total_steps} fix steps "
+                      f"({cmd_count} commands, {cfg_count} configs, {code_count} code snippets)\n")
+        lines.append("---\n")
+
+        # Individual remediations
+        for r in remediations:
+            lines.append(r.get_markdown())
+            lines.append("---\n")
+
+        return "\n".join(lines)
+
+    # ── Utilities ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def get_rule_count() -> int:
+        """Return the number of built-in remediation rules."""
+        return len(_RULES)
+
+    @staticmethod
+    def get_rule_patterns() -> List[str]:
+        """Return all rule patterns (for debugging/testing)."""
+        return [p for p, _ in _RULES]
+
+
+# ── Agent tool ───────────────────────────────────────────────────────────────
+
+
+def _findings_from_agent(agent: Any) -> List[Dict[str, Any]]:
+    session = getattr(agent, "session_state", None)
+    findings = getattr(session, "findings", None) or []
+    out: List[Dict[str, Any]] = []
+    for f in findings:
+        if isinstance(f, dict):
+            out.append(f)
+        elif hasattr(f, "model_dump"):
+            out.append(f.model_dump())
+    return out
+
+
+async def remediation_advice_tool(agent: Any, args: Dict[str, Any]) -> str:
+    """Agent tool: generate rule-based remediation guidance for findings.
+
+    Accepts a ``findings`` array, a single ``query`` string (vuln type/title),
+    or falls back to the current session's findings. Returns markdown with fix
+    commands, config patches, and code snippets.
+    """
+    findings = args.get("findings")
+    if not isinstance(findings, list) or not findings:
+        query = str(args.get("query", "") or "").strip()
+        if query:
+            findings = [{"title": query, "severity": str(args.get("severity", "Medium") or "Medium"),
+                         "description": query}]
+        else:
+            findings = _findings_from_agent(agent)
+    if not findings:
+        return (
+            "[remediation_advice] No findings to remediate. Pass a 'findings' array, "
+            "a 'query' string (e.g. 'SQL injection'), or run after findings exist."
+        )
+
+    engine = RemediationEngine()
+    remediations = engine.remediate_findings(findings, use_ai=False)
+    return RemediationEngine.get_summary_markdown(remediations)

--- a/vulnclaw/intel/tools.py
+++ b/vulnclaw/intel/tools.py
@@ -7,7 +7,11 @@ is a structured stub so the dispatch path is testable end-to-end.
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+if TYPE_CHECKING:
+    from vulnclaw.agent.agent_context import AgentContext
+
 
 # Read-only tools the constraint policy may treat as passive: no egress to the
 # target, no host-changing action.
@@ -318,7 +322,7 @@ def _build_handlers() -> dict[str, Callable[[Any, dict[str, Any]], Awaitable[str
 _HANDLERS: dict[str, Callable[[Any, dict[str, Any]], Awaitable[str]]] = _build_handlers()
 
 
-async def dispatch_intel_tool(agent: Any, tool_name: str, args: dict[str, Any]) -> str:
+async def dispatch_intel_tool(agent: AgentContext, tool_name: str, args: dict[str, Any]) -> str:
     """Route an intel tool call to its handler; structured error on unknown name."""
     if tool_name not in INTEL_TOOL_NAMES:
         return f"[intel_error] unknown intel tool: {tool_name}"

--- a/vulnclaw/intel/tools.py
+++ b/vulnclaw/intel/tools.py
@@ -1,0 +1,328 @@
+"""Intel tool schemas (OpenAI format) and name->dispatcher routing.
+
+Each real module (cve/osint/topology/compliance/remediation) registers its
+async handler in ``_HANDLERS`` as its port lands. Until then, a tool's handler
+is a structured stub so the dispatch path is testable end-to-end.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+# Read-only tools the constraint policy may treat as passive: no egress to the
+# target, no host-changing action.
+READ_ONLY_INTEL_TOOLS: set[str] = {
+    "cve_lookup",
+    "compliance_map",
+    "remediation_advice",
+    "topology_build",
+    "findings_report",
+    "findings_diff",
+    "attack_map",
+}
+
+# Active-recon tools: they contact the target / third-party services but are
+# low-impact reconnaissance. The constraint policy classifies them as "recon".
+RECON_INTEL_TOOLS: set[str] = {"osint_recon"}
+
+
+def intel_tool_schemas() -> list[dict[str, Any]]:
+    """OpenAI tool schemas for all intel tools."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "cve_lookup",
+                "description": (
+                    "Look up CVEs by keyword or CVE-ID against NVD, with optional "
+                    "exploit-PoC discovery. Read-only; safe to call during recon."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": (
+                                "Keyword (e.g. 'openssl 3.0') or a CVE-ID "
+                                "(e.g. CVE-2024-3094)."
+                            ),
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of results.",
+                            "default": 5,
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "osint_recon",
+                "description": (
+                    "Run OSINT reconnaissance on a domain: subdomain enumeration "
+                    "(Certificate Transparency), DNS records, WHOIS/RDAP, web "
+                    "technology fingerprinting, and common-email candidates. "
+                    "Active recon — contacts the target and third-party services."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "domain": {
+                            "type": "string",
+                            "description": "Target domain, e.g. example.com.",
+                        },
+                        "modules": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["subdomains", "dns", "whois", "tech", "emails"],
+                            },
+                            "description": "Subset of modules to run (default: all).",
+                        },
+                        "bruteforce": {
+                            "type": "boolean",
+                            "description": "DNS-brute-force a built-in subdomain wordlist.",
+                            "default": False,
+                        },
+                    },
+                    "required": ["domain"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "topology_build",
+                "description": (
+                    "Build a network topology (hosts, ports, services, subnets) "
+                    "from nmap (text or XML) or masscan scan output. Offline/read-only "
+                    "— parses scan text you already have. Returns markdown, ascii, or json."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "scan_output": {
+                            "type": "string",
+                            "description": "Raw nmap/masscan output (text or nmap XML).",
+                        },
+                        "format": {
+                            "type": "string",
+                            "enum": ["markdown", "ascii", "json"],
+                            "description": "Output format (default: markdown).",
+                            "default": "markdown",
+                        },
+                    },
+                    "required": ["scan_output"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "compliance_map",
+                "description": (
+                    "Map security findings to compliance controls (PCI DSS v4.0, "
+                    "NIST 800-53, OWASP Top 10, ISO 27001) with gap analysis. "
+                    "Read-only. Uses the provided findings, or the current session's "
+                    "findings if none are passed."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "findings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "title": {"type": "string"},
+                                    "severity": {"type": "string"},
+                                    "description": {"type": "string"},
+                                    "evidence": {"type": "string"},
+                                },
+                            },
+                            "description": "Findings to map (optional; defaults to session findings).",
+                        },
+                        "frameworks": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["pci", "nist", "owasp", "iso"],
+                            },
+                            "description": "Subset of frameworks (default: all four).",
+                        },
+                        "target": {
+                            "type": "string",
+                            "description": "Assessment target for the report header.",
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "findings_report",
+                "description": (
+                    "Risk-score findings: severity breakdown, total risk, top "
+                    "risks, and optional compliance-control coverage. Read-only. "
+                    "Uses provided findings or the current session's findings."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "findings": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": "Findings to score (optional; defaults to session findings).",
+                        },
+                        "with_compliance": {
+                            "type": "boolean",
+                            "description": "Include compliance-control coverage.",
+                            "default": False,
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "findings_diff",
+                "description": (
+                    "Diff two assessments: report new / fixed / persistent findings "
+                    "(and severity regressions) between a baseline and the current "
+                    "set. Read-only/offline."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "baseline": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": "Baseline (older) findings.",
+                        },
+                        "current": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": "Current (newer) findings (optional; defaults to session findings).",
+                        },
+                        "target": {"type": "string", "description": "Target label for the report."},
+                    },
+                    "required": ["baseline"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "remediation_advice",
+                "description": (
+                    "Generate actionable remediation guidance (fix commands, config "
+                    "patches, code snippets) for findings from a built-in rule "
+                    "knowledge base. Read-only. Accepts findings, a vuln 'query' "
+                    "string, or the current session's findings."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "findings": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": "Findings to remediate (optional).",
+                        },
+                        "query": {
+                            "type": "string",
+                            "description": "A vulnerability type/title to remediate, e.g. 'SQL injection'.",
+                        },
+                        "severity": {
+                            "type": "string",
+                            "description": "Severity for a 'query' finding (default Medium).",
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "attack_map",
+                "description": (
+                    "Map findings (and optional tool usage) to MITRE ATT&CK "
+                    "techniques/tactics. Read-only. Returns a markdown report, or "
+                    "an ATT&CK Navigator layer JSON when format='navigator'."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "findings": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": "Findings to map (optional; defaults to session findings).",
+                        },
+                        "tool_history": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": "Optional tool-execution records to map to techniques.",
+                        },
+                        "target": {"type": "string", "description": "Assessment target label."},
+                        "format": {
+                            "type": "string",
+                            "enum": ["markdown", "navigator"],
+                            "description": "Output format (default: markdown).",
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        },
+    ]
+
+
+INTEL_TOOL_NAMES: list[str] = [s["function"]["name"] for s in intel_tool_schemas()]
+
+
+async def _stub(tool_name: str, args: dict[str, Any]) -> str:
+    return f"[intel_pending] {tool_name} is not yet implemented in this build."
+
+
+def _build_handlers() -> dict[str, Callable[[Any, dict[str, Any]], Awaitable[str]]]:
+    """Map tool name -> async handler. Each ported module registers here."""
+    from vulnclaw.intel.attack import attack_map_tool
+    from vulnclaw.intel.compliance import compliance_map_tool
+    from vulnclaw.intel.cve import cve_lookup_tool
+    from vulnclaw.intel.findings import findings_diff_tool, findings_report_tool
+    from vulnclaw.intel.osint import osint_recon_tool
+    from vulnclaw.intel.remediation import remediation_advice_tool
+    from vulnclaw.intel.topology import topology_build_tool
+
+    return {
+        "cve_lookup": cve_lookup_tool,
+        "osint_recon": osint_recon_tool,
+        "topology_build": topology_build_tool,
+        "compliance_map": compliance_map_tool,
+        "findings_report": findings_report_tool,
+        "findings_diff": findings_diff_tool,
+        "remediation_advice": remediation_advice_tool,
+        "attack_map": attack_map_tool,
+    }
+
+
+# Handlers are filled in by each module's port. Tools in the schema list without
+# a handler fall back to a structured stub so dispatch stays testable.
+_HANDLERS: dict[str, Callable[[Any, dict[str, Any]], Awaitable[str]]] = _build_handlers()
+
+
+async def dispatch_intel_tool(agent: Any, tool_name: str, args: dict[str, Any]) -> str:
+    """Route an intel tool call to its handler; structured error on unknown name."""
+    if tool_name not in INTEL_TOOL_NAMES:
+        return f"[intel_error] unknown intel tool: {tool_name}"
+    handler = _HANDLERS.get(tool_name)
+    if handler is None:
+        return await _stub(tool_name, args)
+    return await handler(agent, args)

--- a/vulnclaw/intel/topology.py
+++ b/vulnclaw/intel/topology.py
@@ -1,0 +1,488 @@
+"""Network topology builder for VulnClaw.
+
+Ported from HackBot (``hackbot/core/topology.py``). Parses nmap (text or XML) and
+masscan output into a host/port/service graph, and renders it as JSON (for a
+future D3 view), ASCII (CLI), or markdown. Pure/offline — it only processes scan
+text the agent already holds, so the ``topology_build`` tool is read-only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+DEFAULT_SCANNER_LABEL = "VulnClaw"
+
+_MASSCAN_RE = re.compile(r"Discovered open port (\d+)/(\w+) on ([\d.]+)")
+_NMAP_PORT_RE = re.compile(r"(\d+)/(\w+)\s+(open|closed|filtered)\s+(\S+)\s*(.*)")
+
+
+# ── Data models ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class TopoNode:
+    id: str
+    label: str
+    node_type: str  # "scanner", "host", "subnet", "service", "os"
+    ip: str = ""
+    mac: str = ""
+    hostname: str = ""
+    os: str = ""
+    ports: list[dict[str, Any]] = field(default_factory=list)
+    status: str = "up"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "type": self.node_type,
+            "ip": self.ip,
+            "mac": self.mac,
+            "hostname": self.hostname,
+            "os": self.os,
+            "ports": self.ports,
+            "status": self.status,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class TopoEdge:
+    source: str
+    target: str
+    edge_type: str = "connection"  # "connection", "scan", "service"
+    label: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "target": self.target,
+            "type": self.edge_type,
+            "label": self.label,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class NetworkTopology:
+    nodes: list[TopoNode] = field(default_factory=list)
+    edges: list[TopoEdge] = field(default_factory=list)
+    scan_info: dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "nodes": [n.to_dict() for n in self.nodes],
+            "edges": [e.to_dict() for e in self.edges],
+            "scan_info": self.scan_info,
+            "timestamp": self.timestamp,
+            "stats": {
+                "total_hosts": len([n for n in self.nodes if n.node_type == "host"]),
+                "total_services": sum(
+                    len(n.ports) for n in self.nodes if n.node_type == "host"
+                ),
+                "subnets": len([n for n in self.nodes if n.node_type == "subnet"]),
+            },
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _get_subnet(ip: str) -> str:
+    """Extract the /24 subnet from an IPv4 address."""
+    parts = ip.split(".")
+    if len(parts) == 4:
+        return f"{parts[0]}.{parts[1]}.{parts[2]}.0/24"
+    return ""
+
+
+def _new_scanner_topology(scanner_label: str) -> NetworkTopology:
+    topo = NetworkTopology()
+    topo.nodes.append(TopoNode(id="scanner", label=scanner_label, node_type="scanner"))
+    return topo
+
+
+def _attach_host(topo: NetworkTopology, host: TopoNode, subnet_nodes: dict[str, TopoNode]) -> None:
+    """Add a host node and wire it to its subnet (or directly to the scanner)."""
+    subnet_id = _get_subnet(host.ip)
+    if subnet_id and subnet_id not in subnet_nodes:
+        sn = TopoNode(id=f"subnet_{subnet_id}", label=subnet_id, node_type="subnet")
+        subnet_nodes[subnet_id] = sn
+        topo.nodes.append(sn)
+        topo.edges.append(
+            TopoEdge(source="scanner", target=f"subnet_{subnet_id}", edge_type="scan", label="scanned")
+        )
+    topo.nodes.append(host)
+    if subnet_id and subnet_id in subnet_nodes:
+        topo.edges.append(
+            TopoEdge(source=f"subnet_{subnet_id}", target=host.id, edge_type="connection")
+        )
+    else:
+        topo.edges.append(TopoEdge(source="scanner", target=host.id, edge_type="scan"))
+
+
+def _host_id(ip: str) -> str:
+    return f"host_{ip.replace('.', '_').replace(':', '_')}"
+
+
+# ── Parsers ──────────────────────────────────────────────────────────────────
+
+
+def parse_masscan_output(
+    output: str, *, scanner_label: str = DEFAULT_SCANNER_LABEL
+) -> NetworkTopology:
+    """Parse masscan 'Discovered open port <port>/<proto> on <ip>' lines."""
+    topo = _new_scanner_topology(scanner_label)
+    hosts: dict[str, TopoNode] = {}
+    subnet_nodes: dict[str, TopoNode] = {}
+
+    for match in _MASSCAN_RE.finditer(output):
+        port, proto, ip = int(match.group(1)), match.group(2), match.group(3)
+        hid = _host_id(ip)
+        if hid not in hosts:
+            host = TopoNode(id=hid, label=ip, node_type="host", ip=ip)
+            hosts[hid] = host
+            _attach_host(topo, host, subnet_nodes)
+        hosts[hid].ports.append({"port": port, "protocol": proto, "state": "open"})
+
+    for host in hosts.values():
+        host.label = f"{host.ip} ({len(host.ports)} ports)"
+    return topo
+
+
+def _parse_scan_header(output: str) -> dict[str, Any]:
+    info: dict[str, Any] = {}
+    for line in output[:500].splitlines()[:5]:
+        if "Nmap scan report" in line or "Starting Nmap" in line:
+            info["scanner"] = "nmap"
+        if "scan report" in line.lower():
+            match = re.search(r"for\s+(\S+)", line)
+            if match:
+                info["target"] = match.group(1)
+    return info
+
+
+def _split_host_blocks(output: str) -> list[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    for line in output.splitlines():
+        if re.match(r"Nmap scan report for", line):
+            if current:
+                blocks.append("\n".join(current))
+            current = [line]
+        elif current:
+            current.append(line)
+    if current:
+        blocks.append("\n".join(current))
+    return blocks
+
+
+def _parse_host_block(block: str) -> Optional[TopoNode]:
+    lines = block.strip().splitlines()
+    if not lines:
+        return None
+    first = lines[0]
+
+    ip = ""
+    ip_match = re.search(r"(\d+\.\d+\.\d+\.\d+)", first)
+    if ip_match:
+        ip = ip_match.group(1)
+    if not ip:
+        return None
+
+    hostname = ""
+    host_match = re.search(r"for\s+(\S+)", first)
+    if host_match:
+        name = host_match.group(1)
+        if name != ip and not name.startswith("("):
+            hostname = name
+
+    status = "up"
+    for line in lines:
+        if "Host is up" in line:
+            status = "up"
+        elif "Host seems down" in line:
+            status = "down"
+
+    ports: list[dict[str, Any]] = []
+    for line in lines:
+        match = _NMAP_PORT_RE.match(line.strip())
+        if not match:
+            continue
+        port_info: dict[str, Any] = {
+            "port": int(match.group(1)),
+            "protocol": match.group(2),
+            "state": match.group(3),
+            "service": match.group(4),
+        }
+        banner = match.group(5).strip()
+        if banner:
+            parts = banner.split()
+            if parts:
+                port_info["product"] = parts[0]
+            if len(parts) > 1:
+                port_info["version"] = parts[1]
+            port_info["banner"] = banner
+        if port_info["state"] == "open":
+            ports.append(port_info)
+
+    os_name = ""
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("OS details:") or stripped.startswith("Running:"):
+            os_name = line.split(":", 1)[1].strip()
+            break
+        os_match = re.search(r"OS guess:\s*(.+)", line)
+        if os_match:
+            os_name = os_match.group(1)
+
+    mac = ""
+    mac_match = re.search(r"MAC Address:\s*([\w:]+)", block)
+    if mac_match:
+        mac = mac_match.group(1)
+
+    label = hostname or ip
+    if ports:
+        label += f" ({len(ports)} ports)"
+
+    return TopoNode(
+        id=_host_id(ip),
+        label=label,
+        node_type="host",
+        ip=ip,
+        mac=mac,
+        hostname=hostname,
+        os=os_name,
+        ports=ports,
+        status=status,
+    )
+
+
+def parse_nmap_text(
+    output: str, *, scanner_label: str = DEFAULT_SCANNER_LABEL
+) -> NetworkTopology:
+    """Parse standard nmap text output into a topology graph."""
+    topo = _new_scanner_topology(scanner_label)
+    topo.scan_info = _parse_scan_header(output)
+    subnet_nodes: dict[str, TopoNode] = {}
+    for block in _split_host_blocks(output):
+        host = _parse_host_block(block)
+        if host:
+            _attach_host(topo, host, subnet_nodes)
+    return topo
+
+
+def parse_nmap_xml(
+    xml_content: str, *, scanner_label: str = DEFAULT_SCANNER_LABEL
+) -> NetworkTopology:
+    """Parse nmap XML (-oX) output; falls back to text parsing on malformed XML."""
+    topo = _new_scanner_topology(scanner_label)
+    try:
+        root = ET.fromstring(xml_content)
+    except ET.ParseError:
+        return parse_nmap_text(xml_content, scanner_label=scanner_label)
+
+    topo.scan_info = {
+        "scanner": root.get("scanner", "nmap"),
+        "args": root.get("args", ""),
+        "start": root.get("startstr", ""),
+    }
+    subnet_nodes: dict[str, TopoNode] = {}
+
+    for host_elem in root.findall(".//host"):
+        addr_elem = host_elem.find("address[@addrtype='ipv4']")
+        if addr_elem is None:
+            addr_elem = host_elem.find("address[@addrtype='ipv6']")
+        if addr_elem is None:
+            continue
+        ip = addr_elem.get("addr", "")
+        if not ip:
+            continue
+
+        status_elem = host_elem.find("status")
+        status = status_elem.get("state", "up") if status_elem is not None else "up"
+
+        hostname = ""
+        hostnames = host_elem.find("hostnames")
+        if hostnames is not None:
+            hn = hostnames.find("hostname")
+            if hn is not None:
+                hostname = hn.get("name", "")
+
+        mac = ""
+        mac_elem = host_elem.find("address[@addrtype='mac']")
+        if mac_elem is not None:
+            mac = mac_elem.get("addr", "")
+
+        os_name = ""
+        os_elem = host_elem.find(".//osmatch")
+        if os_elem is not None:
+            os_name = os_elem.get("name", "")
+
+        ports: list[dict[str, Any]] = []
+        for port_elem in host_elem.findall(".//port"):
+            state_elem = port_elem.find("state")
+            service_elem = port_elem.find("service")
+            port_info: dict[str, Any] = {
+                "port": int(port_elem.get("portid", 0)),
+                "protocol": port_elem.get("protocol", "tcp"),
+                "state": state_elem.get("state", "unknown") if state_elem is not None else "unknown",
+            }
+            if service_elem is not None:
+                port_info["service"] = service_elem.get("name", "")
+                port_info["product"] = service_elem.get("product", "")
+                port_info["version"] = service_elem.get("version", "")
+                port_info["extrainfo"] = service_elem.get("extrainfo", "")
+            if port_info["state"] == "open":
+                ports.append(port_info)
+
+        label = hostname or ip
+        if ports:
+            label += f" ({len(ports)} ports)"
+        host_node = TopoNode(
+            id=_host_id(ip),
+            label=label,
+            node_type="host",
+            ip=ip,
+            mac=mac,
+            hostname=hostname,
+            os=os_name,
+            ports=ports,
+            status=status,
+        )
+        _attach_host(topo, host_node, subnet_nodes)
+
+    return topo
+
+
+def auto_parse(output: str, *, scanner_label: str = DEFAULT_SCANNER_LABEL) -> NetworkTopology:
+    """Auto-detect the scan format (XML / masscan / nmap text) and parse it."""
+    stripped = output.strip()
+    if stripped.startswith("<?xml") or stripped.startswith("<nmaprun"):
+        return parse_nmap_xml(output, scanner_label=scanner_label)
+    if "Discovered open port" in output:
+        return parse_masscan_output(output, scanner_label=scanner_label)
+    return parse_nmap_text(output, scanner_label=scanner_label)
+
+
+# ── Rendering ────────────────────────────────────────────────────────────────
+
+
+def format_markdown(topo: NetworkTopology) -> str:
+    stats = topo.to_dict()["stats"]
+    lines = ["## Network Topology\n", "| Metric | Value |", "|--------|-------|"]
+    lines.append(f"| Total Hosts | {stats['total_hosts']} |")
+    lines.append(f"| Open Services | {stats['total_services']} |")
+    lines.append(f"| Subnets | {stats['subnets']} |")
+    lines.append("")
+
+    hosts = [n for n in topo.nodes if n.node_type == "host"]
+    if not hosts:
+        lines.append("_No hosts discovered._")
+        return "\n".join(lines)
+
+    lines.append("### Discovered Hosts\n")
+    lines.append("| IP | Hostname | OS | Open Ports | Status |")
+    lines.append("|----|----------|-----|------------|--------|")
+    for host in hosts:
+        open_ports = [p for p in host.ports if p.get("state") == "open"]
+        summary = ", ".join(
+            f"{p['port']}/{p.get('protocol', 'tcp')}" for p in open_ports[:8]
+        )
+        if len(open_ports) > 8:
+            summary += f" +{len(open_ports) - 8} more"
+        lines.append(
+            f"| {host.ip} | {host.hostname or '—'} | {host.os or '—'} | "
+            f"{summary or '—'} | {host.status} |"
+        )
+    lines.append("")
+
+    for host in hosts:
+        open_ports = [p for p in host.ports if p.get("state") == "open"]
+        if not open_ports:
+            continue
+        title = host.hostname or host.ip
+        lines.append(f"#### {title} (`{host.ip}`)\n")
+        if host.os:
+            lines.append(f"**OS:** {host.os}\n")
+        lines.append("| Port | Service | Product | Version |")
+        lines.append("|------|---------|---------|---------|")
+        for p in open_ports:
+            lines.append(
+                f"| {p['port']}/{p.get('protocol', 'tcp')} | {p.get('service', '—')} | "
+                f"{p.get('product', '—')} | {p.get('version', '—')} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def render_ascii(topo: NetworkTopology) -> str:
+    lines = ["=" * 60, "  NETWORK TOPOLOGY MAP", "=" * 60]
+    hosts = [n for n in topo.nodes if n.node_type == "host"]
+    stats = topo.to_dict()["stats"]
+    lines.append(
+        f"  Hosts: {stats['total_hosts']}  |  "
+        f"Services: {stats['total_services']}  |  Subnets: {stats['subnets']}"
+    )
+    lines.append("-" * 60)
+    if not hosts:
+        lines.append("  No hosts discovered.")
+        return "\n".join(lines)
+
+    lines.append("")
+    lines.append(f"  [Scanner: {topo.nodes[0].label if topo.nodes else 'unknown'}]")
+    for host in hosts:
+        host_label = host.ip
+        if host.hostname:
+            host_label += f" ({host.hostname})"
+        status_icon = "●" if host.status == "up" else "○"
+        os_info = f" [{host.os}]" if host.os else ""
+        lines.append(f"   ├── {status_icon} {host_label}{os_info}")
+        open_ports = [p for p in host.ports if p.get("state") == "open"]
+        for p in open_ports[:15]:
+            port_line = f"{p['port']}/{p.get('protocol', 'tcp')}"
+            if p.get("service"):
+                port_line += f"  {p['service']}"
+            if p.get("product"):
+                port_line += f" ({p['product']}"
+                if p.get("version"):
+                    port_line += f" {p['version']}"
+                port_line += ")"
+            lines.append(f"   │     └─ {port_line}")
+        if len(open_ports) > 15:
+            lines.append(f"   │     └─ ... and {len(open_ports) - 15} more ports")
+    lines.append("")
+    lines.append("=" * 60)
+    return "\n".join(lines)
+
+
+# ── Tool handler ─────────────────────────────────────────────────────────────
+
+
+async def topology_build_tool(agent: Any, args: dict[str, Any]) -> str:
+    """Agent tool: build a network topology from nmap/masscan scan output."""
+    scan_output = str(args.get("scan_output", "") or "")
+    if not scan_output.strip():
+        return "[topology_build] error: 'scan_output' (nmap/masscan text or XML) is required."
+    fmt = str(args.get("format", "markdown") or "markdown").lower()
+
+    topo = auto_parse(scan_output)
+    if not any(n.node_type == "host" for n in topo.nodes):
+        return "[topology_build] No hosts parsed from the provided scan output."
+
+    if fmt == "json":
+        return topo.to_json()
+    if fmt == "ascii":
+        return render_ascii(topo)
+    return format_markdown(topo)

--- a/vulnclaw/mcp/lifecycle.py
+++ b/vulnclaw/mcp/lifecycle.py
@@ -1615,7 +1615,12 @@ class MCPLifecycleManager:
             )
 
     async def _call_fetch(self, args: dict) -> str:
-        """Execute a fetch request using httpx."""
+        """Execute a fetch request using httpx.
+
+        Reuses and updates the shared ``_fetch_cookies`` jar so that a
+        session established elsewhere (e.g. ``brute_force_login``) carries
+        over to subsequent fetch calls against the same target.
+        """
         try:
             import httpx
 
@@ -1624,13 +1629,19 @@ class MCPLifecycleManager:
             headers = args.get("headers", {})
             body = args.get("body")
 
-            async with httpx.AsyncClient(verify=False, timeout=30.0) as client:
+            jar = getattr(self, "_fetch_cookies", None)
+            if jar is None:
+                jar = httpx.Cookies()
+                self._fetch_cookies = jar
+
+            async with httpx.AsyncClient(verify=False, timeout=30.0, cookies=jar) as client:
                 response = await client.request(
                     method=method,
                     url=url,
                     headers=headers,
                     content=body,
                 )
+                jar.extract_cookies(response)
 
             result = f"Status: {response.status_code}\n"
             result += f"Headers: {dict(response.headers)}\n"

--- a/vulnclaw/report/pdf_exporter.py
+++ b/vulnclaw/report/pdf_exporter.py
@@ -1,0 +1,200 @@
+"""PDF export for VulnClaw reports.
+
+Spec §5.3: consume VulnClaw's existing report (the markdown produced by
+``vulnclaw.report.generator.generate_report``) and render it to a styled PDF —
+not a parallel report builder. ``reportlab`` is an optional extra
+(``vulnclaw[pdf]``); importing this module is fine without it, but calling
+``export_pdf`` without the extra raises a clear, actionable error.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Optional, Union
+
+try:  # optional dependency
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import mm
+    from reportlab.platypus import (
+        HRFlowable,
+        ListFlowable,
+        ListItem,
+        Paragraph,
+        Preformatted,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    )
+
+    _HAVE_REPORTLAB = True
+except ImportError:  # pragma: no cover - exercised via monkeypatch in tests
+    _HAVE_REPORTLAB = False
+
+_PDF_EXTRA_HINT = (
+    "PDF export requires reportlab. Install the extra with: pip install 'vulnclaw[pdf]'"
+)
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_BULLET_RE = re.compile(r"^\s*[-*]\s+(.*)$")
+_ORDERED_RE = re.compile(r"^\s*\d+\.\s+(.*)$")
+_TABLE_SEP_RE = re.compile(r"^\s*\|?[\s:-]+\|[\s:|-]*$")
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+_CODE_RE = re.compile(r"`([^`]+)`")
+
+
+def _inline(text: str) -> str:
+    """Escape XML and apply inline markdown (bold/italic/code) -> reportlab markup."""
+    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    text = _BOLD_RE.sub(r"<b>\1</b>", text)
+    text = _CODE_RE.sub(r'<font face="Courier">\1</font>', text)
+    text = _ITALIC_RE.sub(r"<i>\1</i>", text)
+    return text
+
+
+def _split_row(line: str) -> list[str]:
+    cells = line.strip().strip("|").split("|")
+    return [c.strip() for c in cells]
+
+
+def _build_flowables(markdown: str, styles: Any) -> list:
+    body = styles["BodyText"]
+    code_style = ParagraphStyle(
+        "ClawCode", parent=styles["Code"], backColor=colors.whitesmoke, leftIndent=6, fontSize=8
+    )
+    flow: list = []
+    lines = markdown.splitlines()
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+
+        # Fenced code block
+        if line.strip().startswith("```"):
+            i += 1
+            buf = []
+            while i < n and not lines[i].strip().startswith("```"):
+                buf.append(lines[i])
+                i += 1
+            i += 1  # closing fence
+            if buf:
+                flow.append(Preformatted("\n".join(buf), code_style))
+                flow.append(Spacer(1, 4))
+            continue
+
+        # Table (consecutive pipe lines)
+        if line.lstrip().startswith("|") and "|" in line.strip()[1:]:
+            rows = []
+            while i < n and lines[i].lstrip().startswith("|"):
+                if not _TABLE_SEP_RE.match(lines[i]):
+                    rows.append([_inline(c) for c in _split_row(lines[i])])
+                i += 1
+            if rows:
+                flow.append(_make_table(rows, body))
+                flow.append(Spacer(1, 6))
+            continue
+
+        # Heading
+        m = _HEADING_RE.match(line)
+        if m:
+            level = len(m.group(1))
+            style_name = f"Heading{min(level, 4)}"
+            flow.append(Paragraph(_inline(m.group(2)), styles[style_name]))
+            i += 1
+            continue
+
+        # Horizontal rule
+        if line.strip() in ("---", "***", "___"):
+            flow.append(HRFlowable(width="100%", thickness=0.5, color=colors.grey))
+            flow.append(Spacer(1, 4))
+            i += 1
+            continue
+
+        # Bullet / ordered list (group consecutive items)
+        if _BULLET_RE.match(line) or _ORDERED_RE.match(line):
+            items = []
+            ordered = bool(_ORDERED_RE.match(line))
+            while i < n and (_BULLET_RE.match(lines[i]) or _ORDERED_RE.match(lines[i])):
+                mm_ = _BULLET_RE.match(lines[i]) or _ORDERED_RE.match(lines[i])
+                items.append(ListItem(Paragraph(_inline(mm_.group(1)), body)))
+                i += 1
+            flow.append(
+                ListFlowable(items, bulletType="1" if ordered else "bullet", leftIndent=14)
+            )
+            flow.append(Spacer(1, 4))
+            continue
+
+        # Blank line
+        if not line.strip():
+            flow.append(Spacer(1, 4))
+            i += 1
+            continue
+
+        # Paragraph
+        flow.append(Paragraph(_inline(line), body))
+        i += 1
+
+    return flow
+
+
+def _make_table(rows: list[list[str]], body: Any) -> Table:
+    data = [[Paragraph(c, body) for c in row] for row in rows]
+    table = Table(data, repeatRows=1, hAlign="LEFT")
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#2d3748")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("GRID", (0, 0), (-1, -1), 0.4, colors.grey),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#f7fafc")]),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
+                ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    return table
+
+
+def export_pdf(
+    markdown: str, out_path: Union[str, Path], *, title: Optional[str] = None
+) -> Path:
+    """Render a VulnClaw markdown report to a PDF file.
+
+    Args:
+        markdown: report markdown (e.g. from ``generate_report``).
+        out_path: destination ``.pdf`` path.
+        title: optional document title rendered at the top.
+
+    Raises:
+        RuntimeError: if the ``[pdf]`` extra (reportlab) is not installed.
+    """
+    if not _HAVE_REPORTLAB:
+        raise RuntimeError(_PDF_EXTRA_HINT)
+
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    styles = getSampleStyleSheet()
+
+    flow: list = []
+    if title:
+        flow.append(Paragraph(_inline(title), styles["Title"]))
+        flow.append(Spacer(1, 6))
+    flow.extend(_build_flowables(markdown, styles))
+
+    doc = SimpleDocTemplate(
+        str(out),
+        pagesize=A4,
+        leftMargin=18 * mm,
+        rightMargin=18 * mm,
+        topMargin=16 * mm,
+        bottomMargin=16 * mm,
+        title=title or "VulnClaw Report",
+    )
+    doc.build(flow)
+    return out

--- a/vulnclaw/skills/flag_skills.py
+++ b/vulnclaw/skills/flag_skills.py
@@ -1,0 +1,342 @@
+"""Flag skills built from the public VulnClaw CLI manual."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any, Literal
+
+from vulnclaw.cli.manual import COMMANDS, COMMON_TASK_FLAGS, ROOT_OPTIONS
+
+TuiFlagAction = Literal[
+    "target",
+    "mode",
+    "only_port",
+    "only_host",
+    "only_path",
+    "blocked_host",
+    "blocked_path",
+    "allow_actions",
+    "block_actions",
+    "resume_true",
+    "resume_false",
+]
+
+_OPTION_RE = re.compile(r"(?<!-)(--[A-Za-z0-9][A-Za-z0-9-]*|-{1}[A-Za-z])")
+_CHECK_MODES = {"quick", "standard", "deep", "continuous"}
+
+_TUI_ACTIONS: dict[str, TuiFlagAction] = {
+    "--target": "target",
+    "--mode": "mode",
+    "--only-port": "only_port",
+    "--only-host": "only_host",
+    "--only-path": "only_path",
+    "--blocked-host": "blocked_host",
+    "--blocked-path": "blocked_path",
+    "--allow-actions": "allow_actions",
+    "--block-actions": "block_actions",
+    "--resume": "resume_true",
+    "--no-resume": "resume_false",
+}
+
+
+@dataclass(frozen=True)
+class FlagSkill:
+    """A compact help/apply skill for one documented CLI flag."""
+
+    canonical: str
+    value_hint: str = ""
+    summary: str = ""
+    availability: tuple[str, ...] = ()
+    aliases: tuple[str, ...] = ()
+    examples: tuple[str, ...] = ()
+    descriptions: tuple[str, ...] = ()
+    tui_action: TuiFlagAction | None = None
+
+    @property
+    def name(self) -> str:
+        """Return the user-facing skill name without leading dashes."""
+        return self.canonical.lstrip("-")
+
+
+@dataclass(frozen=True)
+class FlagSkillCommand:
+    """Parsed `/.` command input."""
+
+    query: str
+    value: str = ""
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Result of applying a flag skill to a TUI draft state."""
+
+    applied: bool
+    message: str
+    error: bool = False
+
+
+@dataclass
+class _FlagSkillBuilder:
+    canonical: str
+    value_hint: str = ""
+    summary: str = ""
+    availability: list[str] = field(default_factory=list)
+    aliases: set[str] = field(default_factory=set)
+    examples: list[str] = field(default_factory=list)
+    descriptions: list[str] = field(default_factory=list)
+
+    def add_context(
+        self,
+        *,
+        topic: str,
+        description: str,
+        value_hint: str,
+        aliases: set[str],
+        examples: tuple[str, ...],
+    ) -> None:
+        if topic not in self.availability:
+            self.availability.append(topic)
+        if description and description not in self.descriptions:
+            self.descriptions.append(description)
+        if not self.summary and description:
+            self.summary = description
+        if not self.value_hint and value_hint:
+            self.value_hint = value_hint
+        self.aliases.update(aliases)
+        for example in examples:
+            if example not in self.examples:
+                self.examples.append(example)
+
+    def build(self) -> FlagSkill:
+        return FlagSkill(
+            canonical=self.canonical,
+            value_hint=self.value_hint,
+            summary=self.summary,
+            availability=tuple(self.availability),
+            aliases=tuple(sorted(self.aliases)),
+            examples=tuple(self.examples),
+            descriptions=tuple(self.descriptions),
+            tui_action=_TUI_ACTIONS.get(self.canonical),
+        )
+
+
+def parse_flag_skill_command(text: str) -> FlagSkillCommand:
+    """Parse `/.flag [value]` text into a query and optional value."""
+    stripped = text.strip()
+    if stripped.startswith("/."):
+        stripped = stripped[2:]
+    elif stripped.startswith("."):
+        stripped = stripped[1:]
+    parts = stripped.split(maxsplit=1)
+    if not parts:
+        return FlagSkillCommand(query="")
+    return FlagSkillCommand(query=parts[0], value=parts[1].strip() if len(parts) > 1 else "")
+
+
+def normalize_flag_query(query: str) -> str:
+    """Normalize a user-entered flag skill lookup key."""
+    parsed = parse_flag_skill_command(query)
+    raw = parsed.query or query.strip()
+    if raw.startswith("/."):
+        raw = raw[2:]
+    if raw.startswith("."):
+        raw = raw[1:]
+    raw = raw.strip().lower().replace("_", "-")
+    if raw.startswith("--"):
+        return raw[2:]
+    if raw.startswith("-"):
+        return raw
+    return raw
+
+
+@lru_cache(maxsize=1)
+def list_flag_skills() -> tuple[FlagSkill, ...]:
+    """List all documented flag skills from the CLI manual."""
+    builders: dict[str, _FlagSkillBuilder] = {}
+
+    for option_spec, description in ROOT_OPTIONS:
+        _add_option_spec(builders, "root", option_spec, description, ())
+
+    for option_spec, description in COMMON_TASK_FLAGS:
+        _add_option_spec(builders, "common task flags", option_spec, description, ())
+
+    for topic in COMMANDS:
+        for option_spec, description in topic.flags:
+            _add_option_spec(builders, topic.name, option_spec, description, topic.examples)
+
+    return tuple(sorted((builder.build() for builder in builders.values()), key=lambda item: item.name))
+
+
+def find_flag_skill(query: str) -> FlagSkill | None:
+    """Find a documented flag skill by slash-dot syntax, bare name, or alias."""
+    key = normalize_flag_query(query)
+    if not key:
+        return None
+    aliases = _flag_skill_aliases()
+    return aliases.get(key)
+
+
+def complete_flag_skills(prefix: str = "") -> tuple[FlagSkill, ...]:
+    """Return flag skills whose canonical name or alias starts with *prefix*."""
+    normalized = normalize_flag_query(prefix) if prefix else ""
+    skills = list_flag_skills()
+    if not normalized:
+        return skills
+    matches: list[FlagSkill] = []
+    for skill in skills:
+        keys = {normalize_flag_query(skill.canonical), normalize_flag_query(skill.name)}
+        keys.update(normalize_flag_query(alias) for alias in skill.aliases)
+        if any(key.startswith(normalized) for key in keys):
+            matches.append(skill)
+    return tuple(matches)
+
+
+def render_flag_skill(skill: FlagSkill) -> str:
+    """Render a user-facing flag skill help card."""
+    lines = [
+        f"{skill.canonical} ({'/.' + skill.name})",
+        f"Available on: {', '.join(skill.availability)}",
+    ]
+    if skill.value_hint:
+        lines.append(f"Usage: /.{skill.name} {skill.value_hint}")
+    else:
+        lines.append(f"Usage: /.{skill.name}")
+    if skill.tui_action:
+        lines.append("TUI: can apply to the current task draft.")
+    else:
+        lines.append("TUI: guidance only for this flag.")
+    if skill.summary:
+        lines.append(f"Summary: {skill.summary}")
+    if skill.examples:
+        lines.append(f"Example: {skill.examples[0]}")
+    return "\n".join(lines)
+
+
+def render_flag_skill_compact(skill: FlagSkill) -> str:
+    """Render a one-line flag skill summary for compact TUI status surfaces."""
+    usage = f"/.{skill.name} {skill.value_hint}".rstrip()
+    availability = ", ".join(skill.availability)
+    return f"{skill.canonical}: {skill.summary} | {availability} | {usage}"
+
+
+def apply_flag_skill_to_tui_state(skill: FlagSkill, value: str, state: Any) -> ApplyResult:
+    """Apply a supported flag skill to a TUI state object."""
+    action = skill.tui_action
+    if action is None:
+        return ApplyResult(False, f"{skill.canonical} is guidance-only in the TUI.")
+
+    value = value.strip()
+
+    if action in {"resume_true", "resume_false"}:
+        setattr(state, "resume", action == "resume_true")
+        return ApplyResult(True, f"Set resume to {'on' if action == 'resume_true' else 'off'}.")
+
+    if not value:
+        return ApplyResult(False, f"{skill.canonical} needs a value before it can be applied.")
+
+    if action == "target":
+        state.target = value
+    elif action == "mode":
+        if value not in _CHECK_MODES:
+            return ApplyResult(
+                False,
+                f"Unknown mode '{value}'. Expected one of: {', '.join(sorted(_CHECK_MODES))}.",
+                error=True,
+            )
+        state.mode = value
+    elif action == "only_port":
+        try:
+            _validate_port(value)
+        except ValueError as exc:
+            return ApplyResult(False, str(exc), error=True)
+        state.only_port = value
+    elif action == "only_host":
+        state.only_host = value
+    elif action == "only_path":
+        state.only_path = value
+    elif action == "blocked_host":
+        state.blocked_host = value
+    elif action == "blocked_path":
+        state.blocked_path = value
+    elif action == "allow_actions":
+        state.allow_actions = _parse_csv(value)
+    elif action == "block_actions":
+        state.block_actions = _parse_csv(value)
+
+    return ApplyResult(True, f"Applied {skill.canonical} to the current task draft.")
+
+
+@lru_cache(maxsize=1)
+def _flag_skill_aliases() -> dict[str, FlagSkill]:
+    aliases: dict[str, FlagSkill] = {}
+    for skill in list_flag_skills():
+        keys = {skill.canonical, skill.name, f"/.{skill.name}", f"/.{skill.canonical}"}
+        keys.update(skill.aliases)
+        for key in keys:
+            aliases[normalize_flag_query(key)] = skill
+    return aliases
+
+
+def _add_option_spec(
+    builders: dict[str, _FlagSkillBuilder],
+    topic: str,
+    option_spec: str,
+    description: str,
+    examples: tuple[str, ...],
+) -> None:
+    options = _extract_options(option_spec)
+    if not options:
+        return
+
+    long_options = [option for option in options if option.startswith("--")]
+    if not long_options:
+        return
+
+    short_aliases = {option for option in options if option.startswith("-") and not option.startswith("--")}
+    for canonical in long_options:
+        builder = builders.setdefault(canonical, _FlagSkillBuilder(canonical=canonical))
+        aliases = _aliases_for(canonical)
+        if canonical == long_options[0]:
+            aliases.update(short_aliases)
+        builder.add_context(
+            topic=topic,
+            description=description,
+            value_hint=_extract_value_hint(option_spec, canonical),
+            aliases=aliases,
+            examples=examples,
+        )
+
+
+def _extract_options(option_spec: str) -> list[str]:
+    return [match.group(1) for match in _OPTION_RE.finditer(option_spec)]
+
+
+def _extract_value_hint(option_spec: str, option: str) -> str:
+    index = option_spec.find(option)
+    if index < 0:
+        return ""
+    tail = option_spec[index + len(option) :]
+    stop_positions = [pos for pos in [tail.find(","), tail.find("/")] if pos >= 0]
+    if stop_positions:
+        tail = tail[: min(stop_positions)]
+    return tail.strip()
+
+
+def _aliases_for(canonical: str) -> set[str]:
+    bare = canonical.lstrip("-")
+    return {canonical, bare, canonical.replace("-", "_"), bare.replace("-", "_")}
+
+
+def _parse_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _validate_port(value: str) -> None:
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise ValueError("Invalid port. Expected an integer from 1 to 65535.") from exc
+    if port < 1 or port > 65535:
+        raise ValueError("Invalid port. Expected an integer from 1 to 65535.")

--- a/vulnclaw/skills/specialized/cve-triage/SKILL.md
+++ b/vulnclaw/skills/specialized/cve-triage/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: cve-triage
+description: CVE lookup and triage — map discovered services/versions to known CVEs via the cve_lookup tool, score by CVSS/exploitability, and prioritize what to verify first.
+---
+
+# CVE Triage
+
+Turn version/banner evidence from recon into a prioritized, exploitability-aware
+list of CVEs worth verifying. Use this after fingerprinting a service, when a
+banner or `Server:` header reveals a product and version, or whenever the target
+exposes software with a known version.
+
+## The `cve_lookup` tool
+
+VulnClaw ships a read-only `cve_lookup` tool backed by NVD:
+
+- **Keyword search** — `cve_lookup(query="Apache httpd 2.4.49", limit=5)` returns
+  the top CVEs sorted by CVSS, highest first.
+- **CVE-ID detail** — `cve_lookup(query="CVE-2021-44228")` returns the full record
+  plus best-effort exploit / PoC repositories discovered on GitHub.
+
+It performs no egress to the target and is safe during recon. Without an
+`NVD_API_KEY` it still works (lower rate limit); set one for heavier use.
+
+## Workflow
+
+1. **Extract product + version** from recon — service banners, `Server` headers,
+   JS bundles, login footers, package manifests. A precise version string
+   (`OpenSSH 8.2p1`, `nginx 1.18.0`) yields far better matches than a bare name.
+2. **Query** `cve_lookup` with `"<product> <version>"`. Pull the detail record for
+   any high/critical hit by re-querying its `CVE-ID`.
+3. **Score & prioritize** — see `references/cve-triage-workflow.md`. Rank by CVSS,
+   then by exploit availability, then by exposure (is the vulnerable surface
+   actually reachable on this target?).
+4. **Confirm version applicability** — match the target's version against the
+   CVE's affected `cpe` range before claiming it. Banner ≠ proof of vulnerability.
+5. **Record findings** with the CVE-ID, CVSS, and the evidence that maps this
+   target to it. Mark unconfirmed version-only matches as needs-manual-review,
+   not verified.
+
+## Pitfalls
+
+- A keyword match is a *hypothesis*, not a finding — version ranges and backported
+  patches mean a banner version can be patched in place.
+- GitHub "PoC" repos are unverified third-party code; treat as leads, never run
+  blindly against a target.
+- Prefer the CVSS **base** score for triage, but let exploit availability and real
+  exposure override raw score when prioritizing verification effort.

--- a/vulnclaw/skills/specialized/cve-triage/references/cve-triage-workflow.md
+++ b/vulnclaw/skills/specialized/cve-triage/references/cve-triage-workflow.md
@@ -1,0 +1,62 @@
+# CVE Triage — Scoring & Prioritization Reference
+
+A reference for turning `cve_lookup` output into an ordered work list.
+
+## Severity bands (CVSS base score)
+
+| Band | CVSS | Triage meaning |
+|------|------|----------------|
+| Critical | 9.0–10.0 | Drop everything; likely RCE/auth-bypass. Verify first. |
+| High | 7.0–8.9 | Strong candidate; verify after criticals. |
+| Medium | 4.0–6.9 | Verify if exposed and cheap to confirm. |
+| Low | 0.1–3.9 | Note only; rarely worth active verification. |
+| Info | 0 | Context only. |
+
+## Prioritization order
+
+Rank candidates by, in order:
+
+1. **CVSS base score** — start from the band above.
+2. **Exploit availability** — a public, credible PoC (Metasploit module, a
+   high-star GitHub repo, an ExploitDB entry) promotes a finding above a
+   higher-CVSS item with no known exploit.
+3. **Exposure / reachability** — is the vulnerable component actually exposed on
+   *this* target (right port, right endpoint, required preconditions met)? An
+   unreachable critical is lower priority than a reachable high.
+4. **Blast radius** — pre-auth > post-auth; unauthenticated network > local; RCE >
+   info-leak.
+5. **Cost to confirm** — when two candidates tie, verify the cheaper-to-prove one
+   first to build evidence momentum.
+
+## Version applicability check
+
+Before recording a CVE as applicable:
+
+- Compare the observed version against the CVE's affected `cpe` range
+  (`cpe:2.3:a:vendor:product:version:...`). `cve_lookup` detail includes
+  `cpe_matches`.
+- Account for **backported patches**: distro packages (Debian/RHEL) often keep the
+  upstream version string while patching the flaw. A version match on such a
+  package is *needs-manual-review*, not *verified*.
+- Account for **build flags / modules**: some CVEs require a specific module or
+  configuration (e.g. `mod_cgi` enabled). If you can't confirm the precondition,
+  downgrade confidence.
+
+## Recording the finding
+
+For each kept candidate, capture:
+
+- `CVE-ID`, CVSS base score and vector, severity band.
+- The exact recon evidence that maps this target to the CVE (banner line, header,
+  endpoint).
+- Applicability verdict: `verified` (exploit confirmed or version+precondition
+  proven), `needs_manual_review` (version-only match), or `rejected`.
+- Links: NVD references and any exploit/PoC leads (clearly marked unverified).
+
+## What not to do
+
+- Do not mass-assert every keyword hit as a vulnerability — that floods the report
+  with noise and erodes trust in real findings.
+- Do not execute third-party PoC code against a target without reading it and
+  having authorization for the action it performs.
+- Do not let a flashy PoC override the exposure check — unreachable is unreachable.

--- a/vulnclaw/target_state/store.py
+++ b/vulnclaw/target_state/store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -17,6 +18,7 @@ from vulnclaw.target_state.planner import (
 )
 
 TARGET_STATE_SCHEMA_VERSION = 2
+SNAPSHOT_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]{1,160}$")
 
 
 @dataclass
@@ -48,8 +50,20 @@ def _snapshot_dir(target: str) -> Path:
     return _target_dir(target) / "snapshots"
 
 
+def _snapshot_path(target: str, snapshot_id: str) -> Path | None:
+    """Return a safe snapshot path, or None for invalid snapshot ids."""
+    if not SNAPSHOT_ID_PATTERN.fullmatch(snapshot_id):
+        return None
+    return _snapshot_dir(target) / f"{snapshot_id}.json"
+
+
 def load_target_state(target: str, snapshot_id: Optional[str] = None) -> Optional[dict[str, Any]]:
-    path = _snapshot_dir(target) / f"{snapshot_id}.json" if snapshot_id else _target_path(target)
+    if snapshot_id:
+        path = _snapshot_path(target, snapshot_id)
+        if path is None:
+            return None
+    else:
+        path = _target_path(target)
     if not path.exists():
         return None
     raw = json.loads(path.read_text(encoding="utf-8"))

--- a/vulnclaw/web/app.py
+++ b/vulnclaw/web/app.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from vulnclaw.web.schemas import ConfigUpdateRequest, ReportGenerateRequest, TaskCreateRequest
+from vulnclaw.web.schemas import (
+    ConfigUpdateRequest,
+    ProviderModelsRequest,
+    ReportGenerateRequest,
+    TaskCreateRequest,
+)
 from vulnclaw.web.services.config_service import get_public_config, update_public_config
 from vulnclaw.web.services.constraint_audit_service import get_constraint_audit
 from vulnclaw.web.services.mcp_service import get_mcp_diagnostics
+from vulnclaw.web.services.provider_service import fetch_models, get_provider_presets
 from vulnclaw.web.services.report_service import (
     generate_target_report,
     list_reports,
@@ -31,6 +37,7 @@ from vulnclaw.web.task_manager import WebTaskManager
 try:
     from fastapi import FastAPI, HTTPException
     from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+    from starlette.middleware.base import BaseHTTPMiddleware
 
     FASTAPI_AVAILABLE = True
 except ImportError:  # pragma: no cover - exercised in CLI dry-run and tests
@@ -39,6 +46,7 @@ except ImportError:  # pragma: no cover - exercised in CLI dry-run and tests
     FileResponse = None  # type: ignore[assignment]
     JSONResponse = None  # type: ignore[assignment]
     StreamingResponse = None  # type: ignore[assignment]
+    BaseHTTPMiddleware = object  # type: ignore[assignment,misc]
     FASTAPI_AVAILABLE = False
 
 
@@ -58,7 +66,7 @@ def resolve_web_index() -> Path:
 
 def resolve_web_asset(path: str) -> Path:
     """Resolve a frontend asset path from dist or fallback static dir."""
-    normalized = path.lstrip("/").strip()
+    normalized = path.replace("\\", "/").lstrip("/").strip()
     if not normalized:
         return resolve_web_index()
 
@@ -79,6 +87,7 @@ def create_app():
         )
 
     app = FastAPI(title="VulnClaw Web UI", version="0.3.2")
+    app.add_middleware(SecurityHeadersMiddleware)
 
     @app.get("/api/health")
     async def health():
@@ -99,6 +108,14 @@ def create_app():
     @app.post("/api/config")
     async def config_update(request: ConfigUpdateRequest):
         return update_public_config(request).model_dump(mode="json")
+
+    @app.get("/api/providers")
+    async def providers_view():
+        return get_provider_presets().model_dump(mode="json")
+
+    @app.post("/api/provider-models")
+    async def provider_models_view(request: ProviderModelsRequest):
+        return fetch_models(request).model_dump(mode="json")
 
     @app.get("/api/tasks")
     async def tasks():
@@ -221,6 +238,8 @@ def create_app():
             )
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
         return {"status": "ok", "path": path}
 
     @app.get("/")
@@ -234,3 +253,26 @@ def create_app():
         return FileResponse(resolve_web_asset(full_path))
 
     return app
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add conservative browser security headers for the local Web UI."""
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        response.headers.setdefault(
+            "Content-Security-Policy",
+            "default-src 'self'; "
+            "script-src 'self'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data: blob:; "
+            "connect-src 'self'; "
+            "frame-src 'self' about: data: blob:; "
+            "frame-ancestors 'none'; "
+            "base-uri 'self'; "
+            "form-action 'self'",
+        )
+        return response

--- a/vulnclaw/web/schemas.py
+++ b/vulnclaw/web/schemas.py
@@ -4,21 +4,48 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any, Literal, Optional
+from urllib.parse import urlsplit
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 TaskCommand = Literal["run", "recon", "scan", "exploit", "persistent"]
 TaskStatus = Literal["pending", "restoring", "running", "completed", "failed", "stopped"]
+PythonExecuteMode = Literal["safe", "lab", "trusted-local"]
+
+
+def _validate_http_base_url(value: str | None) -> str | None:
+    """Validate an OpenAI-compatible HTTP(S) base URL from the Web UI."""
+    if value is None:
+        return None
+    normalized = value.strip().rstrip("/")
+    if not normalized:
+        return ""
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("base_url must use http or https")
+    if not parsed.netloc or not parsed.hostname:
+        raise ValueError("base_url must include a host")
+    if parsed.username or parsed.password:
+        raise ValueError("base_url must not include credentials")
+    if parsed.query or parsed.fragment:
+        raise ValueError("base_url must not include query strings or fragments")
+    return normalized
 
 
 class TaskOptions(BaseModel):
-    max_rounds: Optional[int] = Field(default=None, description="Override for autonomous rounds")
-    rounds_per_cycle: Optional[int] = Field(
-        default=None, description="Persistent mode rounds per cycle"
+    max_rounds: Optional[int] = Field(
+        default=None, ge=1, le=100, description="Override for autonomous rounds"
     )
-    max_cycles: Optional[int] = Field(default=None, description="Persistent mode max cycles")
-    cve: Optional[str] = Field(default=None, description="Exploit command CVE hint")
-    cmd: Optional[str] = Field(default=None, description="Exploit command execution hint")
+    rounds_per_cycle: Optional[int] = Field(
+        default=None, ge=1, le=1000, description="Persistent mode rounds per cycle"
+    )
+    max_cycles: Optional[int] = Field(
+        default=None, ge=0, le=1000, description="Persistent mode max cycles"
+    )
+    cve: Optional[str] = Field(default=None, max_length=64, description="Exploit command CVE hint")
+    cmd: Optional[str] = Field(
+        default=None, max_length=512, description="Exploit command execution hint"
+    )
     only_port: Optional[int] = Field(
         default=None,
         ge=1,
@@ -26,26 +53,30 @@ class TaskOptions(BaseModel):
         description="Restrict task scope to a single port",
     )
     only_host: Optional[str] = Field(
-        default=None, description="Restrict task scope to a single host"
+        default=None, max_length=253, description="Restrict task scope to a single host"
     )
     only_path: Optional[str] = Field(
-        default=None, description="Restrict task scope to a single path"
+        default=None, max_length=2048, description="Restrict task scope to a single path"
     )
-    blocked_host: Optional[str] = Field(default=None, description="Explicitly blocked host")
-    blocked_path: Optional[str] = Field(default=None, description="Explicitly blocked path")
+    blocked_host: Optional[str] = Field(
+        default=None, max_length=253, description="Explicitly blocked host"
+    )
+    blocked_path: Optional[str] = Field(
+        default=None, max_length=2048, description="Explicitly blocked path"
+    )
     allow_actions: Optional[list[str]] = Field(
-        default=None, description="Explicit allow-list for task actions"
+        default=None, max_length=20, description="Explicit allow-list for task actions"
     )
     block_actions: Optional[list[str]] = Field(
-        default=None, description="Explicit block-list for task actions"
+        default=None, max_length=20, description="Explicit block-list for task actions"
     )
 
 
 class TaskCreateRequest(BaseModel):
     command: TaskCommand
-    target: str
+    target: str = Field(min_length=1, max_length=2048)
     resume: bool = True
-    snapshot_id: Optional[str] = None
+    snapshot_id: Optional[str] = Field(default=None, max_length=160)
     options: TaskOptions = Field(default_factory=TaskOptions)
 
 
@@ -166,9 +197,9 @@ class TargetStateDiffView(BaseModel):
 
 
 class ReportGenerateRequest(BaseModel):
-    target: str
-    output_path: Optional[str] = None
-    report_format: str = "markdown"
+    target: str = Field(min_length=1, max_length=2048)
+    output_path: Optional[str] = Field(default=None, max_length=1024)
+    report_format: Literal["markdown", "html"] = "markdown"
 
 
 class ConfigView(BaseModel):
@@ -188,18 +219,51 @@ class ConfigView(BaseModel):
 
 
 class ConfigUpdateRequest(BaseModel):
-    provider: Optional[str] = None
-    model: Optional[str] = None
-    base_url: Optional[str] = None
-    output_dir: Optional[str] = None
-    max_rounds: Optional[int] = None
-    persistent_rounds_per_cycle: Optional[int] = None
-    persistent_max_cycles: Optional[int] = None
+    provider: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    model: Optional[str] = Field(default=None, min_length=1, max_length=160)
+    base_url: Optional[str] = Field(default=None, max_length=512)
+    output_dir: Optional[str] = Field(default=None, min_length=1, max_length=1024)
+    max_rounds: Optional[int] = Field(default=None, ge=1, le=100)
+    persistent_rounds_per_cycle: Optional[int] = Field(default=None, ge=1, le=1000)
+    persistent_max_cycles: Optional[int] = Field(default=None, ge=0, le=1000)
     show_thinking: Optional[bool] = None
     python_execute_enabled: Optional[bool] = None
-    python_execute_mode: Optional[str] = None
-    python_execute_max_lines: Optional[int] = None
+    python_execute_mode: Optional[PythonExecuteMode] = None
+    python_execute_max_lines: Optional[int] = Field(default=None, ge=1, le=500)
     python_execute_audit_enabled: Optional[bool] = None
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str | None) -> str | None:
+        return _validate_http_base_url(value)
+
+
+class ProviderPresetView(BaseModel):
+    id: str
+    label: str
+    base_url: str
+    default_model: str
+
+
+class ProvidersView(BaseModel):
+    providers: list[ProviderPresetView] = Field(default_factory=list)
+
+
+class ProviderModelsRequest(BaseModel):
+    provider: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    base_url: Optional[str] = Field(default=None, max_length=512)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str | None) -> str | None:
+        return _validate_http_base_url(value)
+
+
+class ProviderModelsResponse(BaseModel):
+    base_url: str
+    models: list[str] = Field(default_factory=list)
+    has_api_key: bool = False
+    detail: str = ""
 
 
 class ReportContentView(BaseModel):

--- a/vulnclaw/web/services/provider_service.py
+++ b/vulnclaw/web/services/provider_service.py
@@ -1,0 +1,113 @@
+"""Provider preset + model-listing service for the Web UI backend.
+
+Powers the Settings page dropdowns: the static list of provider presets
+(provider / base URL) and a live "list models" call that reuses the saved
+API key server-side (the key is never sent to the browser).
+"""
+
+from __future__ import annotations
+
+from vulnclaw.config.schema import PROVIDER_PRESETS, LLMProvider
+from vulnclaw.config.settings import fetch_provider_models, load_config
+from vulnclaw.web.schemas import (
+    ProviderModelsRequest,
+    ProviderModelsResponse,
+    ProviderPresetView,
+    ProvidersView,
+)
+
+
+def get_provider_presets() -> ProvidersView:
+    """Return the built-in provider presets for the Settings dropdowns."""
+    providers = [
+        ProviderPresetView(
+            id=provider.value,
+            label=str(preset.get("label", provider.value)),
+            base_url=str(preset.get("base_url", "")),
+            default_model=str(preset.get("default_model", "")),
+        )
+        for provider, preset in PROVIDER_PRESETS.items()
+    ]
+    return ProvidersView(providers=providers)
+
+
+def _resolve_base_url(request: ProviderModelsRequest, config_base_url: str) -> str:
+    """Pick the base URL to query: request override > provider preset > config."""
+    explicit = (request.base_url or "").strip()
+    if explicit:
+        return explicit
+    if request.provider:
+        try:
+            preset = PROVIDER_PRESETS.get(LLMProvider(request.provider.lower()))
+        except ValueError:
+            preset = None
+        if preset and preset.get("base_url"):
+            return str(preset["base_url"])
+    return config_base_url
+
+
+def _normalize_base_url(value: str) -> str:
+    return value.strip().rstrip("/").lower()
+
+
+def _is_trusted_base_url(base_url: str, config_base_url: str) -> bool:
+    """Only send the saved API key to a base_url we already trust.
+
+    The saved key must never be sent to an arbitrary client-supplied host: that
+    would let a malicious page (CSRF against this local API) exfiltrate the key
+    by pointing base_url at a server it controls. Restrict to the currently
+    saved base_url or one of the built-in provider presets.
+    """
+    normalized = _normalize_base_url(base_url)
+    if not normalized:
+        return False
+    if normalized == _normalize_base_url(config_base_url):
+        return True
+    trusted_urls = {
+        _normalize_base_url(str(preset.get("base_url", "")))
+        for preset in PROVIDER_PRESETS.values()
+        if preset.get("base_url")
+    }
+    return normalized in trusted_urls
+
+
+def fetch_models(request: ProviderModelsRequest) -> ProviderModelsResponse:
+    """List models for a provider/base URL using the saved API key.
+
+    The key is read from the saved config (never accepted from the browser),
+    and is only ever sent to the saved base_url or a known provider preset —
+    never to an arbitrary client-supplied host — to avoid SSRF-style key
+    exfiltration via a spoofed base_url.
+    Returns an empty list with a hint when no key is configured.
+    """
+    config = load_config()
+    base_url = _resolve_base_url(request, config.llm.base_url)
+    api_key = config.llm.primary_key()
+
+    if not api_key:
+        return ProviderModelsResponse(
+            base_url=base_url,
+            models=[],
+            has_api_key=False,
+            detail="No API key configured. Save your API key first, then refresh.",
+        )
+
+    if not _is_trusted_base_url(base_url, config.llm.base_url):
+        return ProviderModelsResponse(
+            base_url=base_url,
+            models=[],
+            has_api_key=True,
+            detail=(
+                "This base URL isn't saved or a known provider preset, so the saved "
+                "API key won't be sent to it. Save it first, then refresh."
+            ),
+        )
+
+    models = fetch_provider_models(base_url, api_key)
+    detail = "" if models else "The provider returned no models (check the base URL / key)."
+    return ProviderModelsResponse(
+        base_url=base_url,
+        models=models,
+        has_api_key=True,
+        detail=detail,
+    )

--- a/vulnclaw/web/services/report_service.py
+++ b/vulnclaw/web/services/report_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -23,7 +24,8 @@ def _report_item(path: Path, kind: str) -> dict[str, str | int]:
 
 
 def _default_report_path(target: str, report_format: str) -> Path:
-    safe_target = (target or "unknown").replace("/", "_").replace(":", "_")
+    safe_target = re.sub(r"[^A-Za-z0-9_.-]+", "_", target or "unknown").strip("._")
+    safe_target = safe_target[:80] or "unknown"
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     suffix = ".html" if report_format == "html" else ".md"
     return SESSIONS_DIR / f"report_{timestamp}_{safe_target}{suffix}"
@@ -47,6 +49,7 @@ def generate_target_report(
     report_format: str = "markdown",
 ) -> str:
     """Generate a report from target state and return the saved path."""
+    SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
     raw = load_target_state(target)
     if not raw:
         raise FileNotFoundError(f"Target state not found: {target}")
@@ -57,10 +60,7 @@ def generate_target_report(
         output_path=str(_default_report_path(target, normalized_format)),
     )
     if output_path:
-        destination = Path(output_path).resolve()
-        sessions_root = SESSIONS_DIR.resolve()
-        if sessions_root not in destination.parents and destination != sessions_root:
-            raise PermissionError(f"output_path is outside sessions dir: {destination}")
+        destination = resolve_report_output_path(output_path, normalized_format)
         destination.write_text(Path(path).read_text(encoding="utf-8"), encoding="utf-8")
         return str(destination)
     return str(Path(path).resolve())
@@ -90,5 +90,26 @@ def resolve_report_path(path: str) -> Path:
         raise FileNotFoundError(f"Report not found: {candidate}")
     if not candidate.is_file():
         raise FileNotFoundError(f"Report is not a file: {candidate}")
+    if candidate.suffix.lower() not in {".md", ".html"}:
+        raise PermissionError(f"Unsupported report file type: {candidate.suffix}")
 
+    return candidate
+
+
+def resolve_report_output_path(path: str, report_format: str) -> Path:
+    """Resolve a web report output path under sessions dir."""
+    ensure_dirs()
+    normalized_format = "html" if report_format.lower() == "html" else "markdown"
+    expected_suffix = ".html" if normalized_format == "html" else ".md"
+    destination = Path(path)
+    if not destination.name:
+        raise PermissionError("Report output path must include a file name")
+    if destination.suffix.lower() != expected_suffix:
+        raise PermissionError(f"Report output path must end with {expected_suffix}")
+
+    candidate = destination.resolve()
+    sessions_root = SESSIONS_DIR.resolve()
+    if sessions_root not in candidate.parents and candidate != sessions_root:
+        raise PermissionError(f"Report output path is outside sessions dir: {candidate}")
+    candidate.parent.mkdir(parents=True, exist_ok=True)
     return candidate


### PR DESCRIPTION
Fixes three confirmed bugs from the issue tracker, each fixed test-first (red → green) with no regressions in related suites.

## Bugs fixed

### 1. Scope constraints not re-injected into the per-round system prompt — closes #4
`TaskConstraints.to_prompt_block()` was documented as rendering "every round," but `build_dynamic_system_prompt` never called it — the block was only appended to the user message once per ~100-round cycle in `persistent_pentest`. Long runs increasingly lost the active scope constraints from the model-visible prompt.

`build_dynamic_system_prompt` now accepts `task_constraints` and renders the block on every round; `AgentCore._build_system_prompt` passes the live constraints through. Both engines were verified to route through this path per round — the rounds engine (`loop_controller.py`) and the solve engine (`solver.py`). Hard, tool-level enforcement (`enforce_port_constraints` / `enforce_host_path_constraints`) was already the real safety net and is unchanged — this just stops the agent burning rounds on already-blocked attempts.

### 2. `vulnclaw run` never wrote a report; `--output` was dead code — closes #5
`run` accepted an `--output` flag that was silently discarded and never triggered report generation at all — only the REPL `report` command, `vulnclaw report <session>`, or `vulnclaw persistent` produced a file. A user running `vulnclaw run <target>` saw a findings count but no report.

`run` now calls the existing report-generation path after completion, honoring `--output` when given and otherwise falling back to the default output directory, and prints the report path (via the existing `cli.report_generated` i18n key).

### 3. `fetch` tool never reused the brute-force session's cookie jar — closes #39
`brute_force_login` synced its authenticated session cookies into `MCPLifecycleManager._fetch_cookies`, but `_call_fetch` created a fresh, cookie-less `httpx.AsyncClient` on every call and never read or wrote that jar — dead code, making post-login testing impossible.

`_call_fetch` now threads the shared jar into the client and extracts response cookies back into it, so a session established by brute-force (or a prior fetch) carries forward. Calls with no prior session still send no cookie header, so black-box behavior is unchanged.



## Testing

- New tests, each written failing-first:
  - `tests/test_system_prompt_constraints.py` — constraint block present/absent per round
  - `tests/test_cli.py` — `run` generates a report and honors `--output`
  - `tests/test_mcp_fetch_cookies.py` — fetch persists and reuses the shared cookie jar; no cookie header without a prior session
- `867 passed` across the full suite. The only failures are 6 pre-existing TUI i18n tests (expecting Chinese strings, getting English — unrelated to this change and failing on `main` too).
- `ruff check` clean on all changed files.
