### PR TITLE
fix(agent): 修复 LLM 无限重试、print 污染、异常捕获过宽

### DIFF
--- a/vulnclaw/agent/context.py
+++ b/vulnclaw/agent/context.py
@@ -745,7 +745,7 @@ class SessionState(BaseModel):
 
         # 第一层：finding_id 精确去重
         if finding.finding_id in self._finding_ids_cache:
-            print(f"[DEDUP] 跳过重复漏洞: {finding.title} (ID: {finding.finding_id})")
+            logger.debug("跳过重复漏洞: %s (ID: %s)", finding.title, finding.finding_id)
             return False
 
         # 第二层：语义相似度去重
@@ -758,15 +758,16 @@ class SessionState(BaseModel):
             if finding_similarity(finding, existing) >= self.semantic_dedup_threshold:
                 # 命中语义重复：保留证据更强者
                 if _evidence_strength(finding) > _evidence_strength(existing):
-                    print(
-                        f"[DEDUP-SEM] 语义重复，替换为证据更强的漏洞: "
-                        f"{finding.title} 取代 {existing.title}"
+                    logger.debug(
+                        "语义重复，替换为证据更强的漏洞: %s 取代 %s",
+                        finding.title,
+                        existing.title,
                     )
                     self._finding_ids_cache.discard(existing.finding_id)
                     self._finding_ids_cache.add(finding.finding_id)
                     self.findings[idx] = finding
                 else:
-                    print(f"[DEDUP-SEM] 跳过语义重复漏洞: {finding.title}")
+                    logger.debug("跳过语义重复漏洞: %s", finding.title)
                 return False
 
         # 附加 skill 溯源（若未显式提供且当前有活跃选择）。深拷贝以免其中的

--- a/vulnclaw/agent/context.py
+++ b/vulnclaw/agent/context.py
@@ -12,8 +12,6 @@ from typing import Any, Callable, Optional
 
 from pydantic import BaseModel, Field, PrivateAttr
 
-logger = logging.getLogger(__name__)
-
 from vulnclaw.agent.blackboard import Blackboard
 from vulnclaw.agent.reasoning_state import ReasoningState
 
@@ -36,6 +34,8 @@ from vulnclaw.config.domain_models import (  # noqa: F401 — re-export
     normalize_action_name,
     validate_action_constraints,
 )
+
+logger = logging.getLogger(__name__)
 
 # ==============================================================================
 # [P17 重构] 子状态类定义

--- a/vulnclaw/agent/context.py
+++ b/vulnclaw/agent/context.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import copy
 import json
+import logging
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from pydantic import BaseModel, Field, PrivateAttr
+
+logger = logging.getLogger(__name__)
 
 from vulnclaw.agent.blackboard import Blackboard
 from vulnclaw.agent.reasoning_state import ReasoningState
@@ -113,7 +116,7 @@ class VulnerabilityStore(BaseModel):
 
         # 第一层：finding_id 精确去重
         if finding.finding_id in self._finding_ids_cache:
-            print(f"[DEDUP] 跳过重复漏洞: {finding.title} (ID: {finding.finding_id})")
+            logger.debug("跳过重复漏洞: %s (ID: %s)", finding.title, finding.finding_id)
             return False
 
         # 第二层：语义相似度去重
@@ -126,16 +129,16 @@ class VulnerabilityStore(BaseModel):
             if finding_similarity(finding, existing) >= self.semantic_dedup_threshold:
                 # 命中语义重复：保留证据更强者
                 if _evidence_strength(finding) > _evidence_strength(existing):
-                    print(
-                        f"[DEDUP-SEM] 语义重复，替换为证据更强的漏洞: "
-                        f"{finding.title} 取代 {existing.title}"
+                    logger.debug(
+                        "语义重复，替换为证据更强的漏洞: %s 取代 %s",
+                        finding.title, existing.title,
                     )
                     self._finding_ids_cache.discard(existing.finding_id)
                     self._finding_ids_cache.add(finding.finding_id)
                     self.findings[idx] = finding
                     self._notify_checkpoint("finding_updated")
                 else:
-                    print(f"[DEDUP-SEM] 跳过语义重复漏洞: {finding.title}")
+                    logger.debug("跳过语义重复漏洞: %s", finding.title)
                 return False
 
         # 附加 skill 溯源（若未显式提供且当前有活跃选择）。深拷贝以免其中的

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -9,14 +9,13 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
 
-logger = logging.getLogger(__name__)
-
 if TYPE_CHECKING:
     from vulnclaw.agent.agent_context import AgentContext
 
+logger = logging.getLogger(__name__)
 
-from vulnclaw.agent.token_counter import estimate_tokens, truncate_messages
-from vulnclaw.agent.tool_call_manager import (
+from vulnclaw.agent.token_counter import estimate_tokens, truncate_messages  # noqa: E402
+from vulnclaw.agent.tool_call_manager import (  # noqa: E402
     handle_tool_calls,
     handle_tool_calls_with_results,
 )
@@ -231,8 +230,7 @@ async def _call_with_persistent_retries(
             await asyncio.sleep(5)
 
     raise RuntimeError(
-        f"{stage_label} LLM 调用失败：已达到最大重试次数 {max_retries}，"
-        f"最后一次错误: {exc if 'exc' in locals() else '响应为空'}"
+        f"{stage_label} LLM 调用失败：已达到最大重试次数 {max_retries}"
     )
 
 

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import logging
 import sys
 from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from vulnclaw.agent.agent_context import AgentContext
@@ -45,7 +48,7 @@ def _fit_context_window(agent: AgentContext, messages: list[dict[str, Any]]) -> 
             f"已截断至约 {estimate_tokens(trimmed)} tokens[/yellow]"
         )
     except Exception:
-        print(f"[!] 上下文截断: {current} → {estimate_tokens(trimmed)} tokens (预算 {budget})")
+        logger.warning("上下文截断: %d → %d tokens (预算 %d)", current, estimate_tokens(trimmed), budget)
     return trimmed
 
 
@@ -175,10 +178,9 @@ async def _call_with_persistent_retries(
                 return response, retry_attempts
 
             retry_attempts += 1
-            print(
-                f"[!] {stage_label} LLM API 异常响应，第 {retry_attempts} 次重连尝试中... (5s 后重试)",
-                file=sys.stdout,
-                flush=True,
+            logger.warning(
+                "%s LLM API 异常响应，第 %d 次重连尝试中... (5s 后重试)",
+                stage_label, retry_attempts,
             )
             await asyncio.sleep(5)
         except asyncio.CancelledError:
@@ -197,10 +199,9 @@ async def _call_with_persistent_retries(
                 if len(keys_tried) < pool_size:
                     agent.rotate_api_key()
                     retry_attempts += 1
-                    print(
-                        f"[!] {stage_label} 当前密钥失败 ({exc})，切换到下一个 API 密钥并重试...",
-                        file=sys.stdout,
-                        flush=True,
+                    logger.warning(
+                        "%s 当前密钥失败 (%s)，切换到下一个 API 密钥并重试...",
+                        stage_label, exc,
                     )
                     continue
                 # Every key has now failed in this burst.
@@ -212,10 +213,9 @@ async def _call_with_persistent_retries(
                 keys_tried.clear()
                 agent.rotate_api_key()
                 retry_attempts += 1
-                print(
-                    f"[!] {stage_label} 所有 API 密钥均已限流，第 {retry_attempts} 次重连尝试中... (5s 后重试)",
-                    file=sys.stdout,
-                    flush=True,
+                logger.warning(
+                    "%s 所有 API 密钥均已限流，第 %d 次重连尝试中... (5s 后重试)",
+                    stage_label, retry_attempts,
                 )
                 await asyncio.sleep(5)
                 continue
@@ -224,10 +224,9 @@ async def _call_with_persistent_retries(
                 raise
 
             retry_attempts += 1
-            print(
-                f"[!] {stage_label} LLM 连接异常，第 {retry_attempts} 次重连尝试中... ({exc})",
-                file=sys.stdout,
-                flush=True,
+            logger.warning(
+                "%s LLM 连接异常，第 %d 次重连尝试中... (%s)",
+                stage_label, retry_attempts, exc,
             )
             await asyncio.sleep(5)
 

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -6,7 +6,6 @@ import asyncio
 import inspect
 import json
 import logging
-import sys
 from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -317,9 +316,7 @@ async def call_llm_auto(
         executed_tcs = []
         for tc in tool_results:
             if not isinstance(tc, dict) or "tool_call" not in tc:
-                import sys
-
-                print(f"[!] 跳过异常工具结果: {type(tc).__name__} {str(tc)[:100]}", file=sys.stderr)
+                logger.warning("跳过异常工具结果: %s %s", type(tc).__name__, str(tc)[:100])
                 continue
             executed_tcs.append(tc["tool_call"])
 
@@ -537,12 +534,11 @@ def _assemble_tool_calls(tool_calls_chunks: list[dict]) -> list[Any]:
             tc_data["function"]["arguments"],
         )
         if not _validate_tool_call(candidate):
-            print(
-                f"[!] 丢弃不完整的流式 tool_call: id={tc_data['id']!r} "
-                f"name={tc_data['function']['name']!r} "
-                f"args={tc_data['function']['arguments'][:80]!r}",
-                file=sys.stderr,
-                flush=True,
+            logger.warning(
+                "丢弃不完整的流式 tool_call: id=%r name=%r args=%r",
+                tc_data["id"],
+                tc_data["function"]["name"],
+                tc_data["function"]["arguments"][:80],
             )
             continue
         tool_calls.append(candidate)

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -147,12 +147,19 @@ def build_chat_completion_kwargs(
 
 
 async def _call_with_persistent_retries(
-    agent: AgentContext, request_fn, stage_label: str
+    agent: AgentContext, request_fn, stage_label: str, max_retries: int = 20
 ) -> tuple[Any, int]:
-    """Keep retrying retriable LLM calls until success or manual interruption.
+    """Keep retrying retriable LLM calls until success, max retries, or manual interruption.
+
+    Args:
+        max_retries: Maximum number of retry attempts before raising RuntimeError.
+                     Default is 20 (at 5s intervals = ~100s total wait).
 
     Returns:
         (response, retry_attempts)
+
+    Raises:
+        RuntimeError: If max_retries is exceeded.
     """
     loop = asyncio.get_running_loop()
     retry_attempts = 0
@@ -160,7 +167,7 @@ async def _call_with_persistent_retries(
     can_rotate = pool_size > 1 and callable(getattr(agent, "rotate_api_key", None))
     keys_tried: set[int] = set()
 
-    while True:
+    while retry_attempts < max_retries:
         try:
             maybe_response = loop.run_in_executor(None, request_fn)
             response = await maybe_response if inspect.isawaitable(maybe_response) else maybe_response
@@ -223,6 +230,11 @@ async def _call_with_persistent_retries(
                 flush=True,
             )
             await asyncio.sleep(5)
+
+    raise RuntimeError(
+        f"{stage_label} LLM 调用失败：已达到最大重试次数 {max_retries}，"
+        f"最后一次错误: {exc if 'exc' in locals() else '响应为空'}"
+    )
 
 
 def _prepend_retry_notice(text: str, retry_attempts: int) -> str:

--- a/vulnclaw/agent/tool_call_manager.py
+++ b/vulnclaw/agent/tool_call_manager.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from vulnclaw.agent.agent_context import AgentContext
+
+logger = logging.getLogger(__name__)
 
 
 # Default concurrency cap used when the agent config does not specify one.
@@ -151,7 +154,7 @@ async def _execute_single(agent: AgentContext, item: dict[str, Any]) -> dict[str
             "structured_content": structured_content,
         }
     except Exception as e:
-        print(f"[!] 工具执行失败 {func_name}: {e}", file=sys.stderr)
+        logger.error("工具执行失败 %s: %s", func_name, e)
         return None
 
 

--- a/vulnclaw/agent/tool_call_manager.py
+++ b/vulnclaw/agent/tool_call_manager.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import logging
 import re
-import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:

--- a/vulnclaw/skills/crypto_tools.py
+++ b/vulnclaw/skills/crypto_tools.py
@@ -12,12 +12,16 @@ All functions return a dict with:
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import html
 import json
+import logging
 import re
 import urllib.parse
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 # ── Morse Code Tables ────────────────────────────────────────────────
 
@@ -132,7 +136,7 @@ def _base64_decode(input_str: str, **_) -> dict:
             "utf-8", errors="replace"
         )
         return {"success": True, "result": decoded}
-    except Exception as e:
+    except (ValueError, binascii.Error) as e:
         return {"success": False, "result": "", "error": f"Base64 解码失败: {e}"}
 
 
@@ -151,7 +155,7 @@ def _base32_decode(input_str: str, **_) -> dict:
             cleaned += "=" * (8 - missing_padding)
         decoded = base64.b32decode(cleaned).decode("utf-8", errors="replace")
         return {"success": True, "result": decoded}
-    except Exception as e:
+    except (ValueError, binascii.Error) as e:
         return {"success": False, "result": "", "error": f"Base32 解码失败: {e}"}
 
 
@@ -190,7 +194,7 @@ def _base58_decode(input_str: str, **_) -> dict:
         result_bytes = num.to_bytes((num.bit_length() + 7) // 8, "big") if num else b""
         result_bytes = b"\x00" * leading_zeros + result_bytes
         return {"success": True, "result": result_bytes.decode("utf-8", errors="replace")}
-    except Exception as e:
+    except (ValueError, binascii.Error) as e:
         return {"success": False, "result": "", "error": f"Base58 解码失败: {e}"}
 
 


### PR DESCRIPTION
## 问题

agent 核心模块存在 3 个影响稳定性的问题：

1. **LLM 调用无限重试** (#98)：`_call_with_persistent_retries` 使用 `while True` 无退出条件，瞬态网络错误会导致程序挂起
2. **print() 污染 stdout** (#99)：agent 核心文件直接写 stdout，TUI/Web 模式下界面被破坏
3. **except Exception 过于宽泛** (#100)：crypto_tools.py 捕获所有异常，可能吞掉 KeyboardInterrupt

## 修复方案

### #98: 添加最大重试限制
- `_call_with_persistent_retries` 新增 `max_retries=20` 参数
- 超过限制后抛出 `RuntimeError`，让上层决定处理方式

### #99: bare print() 替换为 logging
- `llm_client.py`: 8 处 → `logger.warning`
- `context.py`: 6 处 → `logger.debug`
- `tool_call_manager.py`: 1 处 → `logger.error`

### #100: 缩小异常捕获范围
- base64/base32/base58 操作改为捕获 `(ValueError, binascii.Error)`

## 验证

**单元测试**:
```bash
pytest tests/test_solver.py tests/test_agent.py -v
# 125 passed
```

**代码风格**:
```bash
ruff check vulnclaw/agent/llm_client.py vulnclaw/agent/context.py vulnclaw/agent/tool_call_manager.py vulnclaw/skills/crypto_tools.py
# All checks passed
```

**手动验证**:
- 配置不存在的 API endpoint，运行 `vulnclaw solve`，确认 20 次重试后报错退出
- 运行 `vulnclaw tui`，确认无 stdout 污染

## 修改文件

- `vulnclaw/agent/llm_client.py`
- `vulnclaw/agent/context.py`
- `vulnclaw/agent/tool_call_manager.py`
- `vulnclaw/skills/crypto_tools.py`
