### PR TITLE
fix: 替换 bare print() 为 logger

### DIFF
--- a/vulnclaw/config/settings.py
+++ b/vulnclaw/config/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from contextlib import suppress
 from pathlib import Path
@@ -19,6 +20,8 @@ from .schema import (
     MCPTransportConfig,
     VulnClawConfig,
 )
+
+logger = logging.getLogger(__name__)
 
 # ── Paths ──────────────────────────────────────────────────────────
 
@@ -82,7 +85,7 @@ def load_config() -> VulnClawConfig:
             config = _merge_config(config, raw)
         except (yaml.YAMLError, ValidationError) as e:
             # Log warning but don't crash
-            print(f"[!] Warning: Failed to parse config file {CONFIG_FILE}: {e}")
+            logger.warning("Failed to parse config file %s: %s", CONFIG_FILE, e)
 
     # Overlay from env vars
     config = _overlay_env(config)

--- a/vulnclaw/report/generator.py
+++ b/vulnclaw/report/generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import datetime
 from pathlib import Path
@@ -14,6 +15,8 @@ from jinja2 import Template
 # 修改原因: 消除 V2 违规 — 叶子类型已移至 config/domain_models.py。
 from vulnclaw.agent.context import SessionState
 from vulnclaw.config.domain_models import VulnerabilityFinding
+
+logger = logging.getLogger(__name__)
 
 # ── Report Template ─────────────────────────────────────────────────
 
@@ -278,7 +281,7 @@ def generate_report(
     if not llm_attack_summary:
         llm_attack_summary = _generate_attack_summary_from_session(session)
         if llm_attack_summary:
-            print("[*] LLM attack summary generated for report section 4")
+            logger.info("LLM attack summary generated for report section 4")
     filtered_summary = ReportContentFilter.filter(llm_attack_summary) if llm_attack_summary else ""
 
     context = {
@@ -586,7 +589,7 @@ def _generate_attack_summary_from_session(session: SessionState) -> str:
             raw = response.choices[0].message.content or ""
             return strip_think_tags(raw).strip()
     except Exception as exc:
-        print(f"[!] LLM attack summary generation failed: {exc}")
+        logger.warning("LLM attack summary generation failed: %s", exc)
         return ""
     return ""
 

--- a/vulnclaw/report/verifier.py
+++ b/vulnclaw/report/verifier.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,8 @@ from typing import Any, Optional
 # 修改时间: 2026-07-08
 # 修改原因: 消除 V2 违规 — 叶子类型已移至 config/domain_models.py。
 from vulnclaw.config.domain_models import VulnerabilityFinding
+
+logger = logging.getLogger(__name__)
 
 
 class VerificationStatus(str, Enum):
@@ -663,7 +666,7 @@ class VulnerabilityVerifier:
         )
 
         # 记录排除原因，但不加入报告
-        print(f"[VERIFIER] 排除漏洞: {original.title} | 原因: {vf.rejection_reason}")
+        logger.info("排除漏洞: %s | 原因: %s", original.title, vf.rejection_reason)
 
     def get_verified_report_findings(self) -> list[VulnerabilityFinding]:
         """获取可写入报告的漏洞列表.


### PR DESCRIPTION
Fixes #107

问题
#107 print() 污染 stdout
settings.py、generator.py、verifier.py 共4处 bare print() 绕过 logger，破坏 TUI/Web 输出

修复方案
settings.py:85 — print → logger.warning
generator.py:269 — print → logger.info
generator.py:580 — print → logger.warning
verifier.py:666 — print → logger.info
每个文件添加 import logging

验证
ruff check 通过
pytest 102 项全绿