### PR TITLE
fix(agent): filter VULNCLAW_* env vars from sandbox + add retry backoff

### DIFF
--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -1272,7 +1272,7 @@ async def execute_python(agent: AgentContext, args: dict[str, Any]) -> str:
             tmp_path = f.name
 
         base_env = {"PYTHONIOENCODING": "utf-8"}
-        env = {**os.environ, **base_env} if mode == "trusted-local" else base_env
+        env = {**{k: v for k, v in os.environ.items() if not k.startswith("VULNCLAW_")}, **base_env} if mode == "trusted-local" else base_env
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(

--- a/vulnclaw/agent/loop_controller.py
+++ b/vulnclaw/agent/loop_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 from collections import Counter
 from typing import TYPE_CHECKING, Any, Callable
@@ -267,6 +268,7 @@ async def auto_pentest(
         except Exception as e:
             result.output = f"[!] Round {round_num} 错误: {e}"
             agent.runtime.consecutive_errors += 1
+            await asyncio.sleep(min(2 ** (agent.runtime.consecutive_errors - 1), 8))
             if agent.runtime.consecutive_errors >= 3:
                 result.should_continue = False
             else:


### PR DESCRIPTION
## 变更

- trusted-local 模式下过滤 \VULNCLAW_*\ 环境变量，防止 API Key 泄漏到 python_execute 子进程
- agent loop 错误重试加入指数退避（1s→2s→4s→8s），避免限流时连续快速请求

## 关联

Fixes #117

## 验证

- trusted-local 模式执行 \import os; print(os.environ)\ 确认无 VULNCLAW_* 变量
- 模拟 LLM API 错误，确认重试间隔递增
- \uff check vulnclaw tests\ + \pytest -q\ 通过（589 passed，1 pre-existing failure 无关）