### PR TITLE
perf(agent): reuse httpx client in js_recon→unauth_test + skip redundant disk writes

### DIFF
--- a/vulnclaw/agent/context.py
+++ b/vulnclaw/agent/context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import logging
 import re
@@ -680,6 +681,7 @@ class SessionState(BaseModel):
 
     # ★ 漏洞去重追踪（PrivateAttr）
     _finding_ids_cache: set[str] = PrivateAttr(default_factory=set)
+    _content_hash: str = PrivateAttr(default="")
     _checkpoint_callback: Callable[["SessionState", str], None] | None = PrivateAttr(
         default=None
     )
@@ -1047,6 +1049,7 @@ class SessionState(BaseModel):
 
         [P18 修改] 确保 executed_steps 被序列化到 JSON 中，
         保持向后兼容性。
+        [Perf] 对比 MD5 内容哈希，跳过未变更的写入。
         """
         if path is None:
             from vulnclaw.config.settings import SESSIONS_DIR
@@ -1059,8 +1062,15 @@ class SessionState(BaseModel):
         # [P18 兼容] 获取序列化数据并添加 executed_steps
         data = self.model_dump(mode="json")
         data["executed_steps"] = self.executed_steps
+        content = json.dumps(data, ensure_ascii=False, indent=2)
+
+        content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()
+        if content_hash == self._content_hash:
+            return path
+        self._content_hash = content_hash
+
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
+            f.write(content)
         return path
 
     @classmethod

--- a/vulnclaw/agent/recon_tools.py
+++ b/vulnclaw/agent/recon_tools.py
@@ -567,6 +567,7 @@ async def execute_js_recon(agent: AgentContext, args: dict[str, Any]) -> str:
                 "auth_header": args.get("auth_header"),
                 "max_endpoints": int(args.get("max_endpoints", 60) or 60),
             },
+            client=client,
         )
         out.append("\n" + probe_out)
 
@@ -716,7 +717,9 @@ async def _probe_endpoints(
     return results
 
 
-async def execute_unauth_test(agent: AgentContext, args: dict[str, Any]) -> str:
+async def execute_unauth_test(
+    agent: AgentContext, args: dict[str, Any], client: Any = None,
+) -> str:
     """对一批接口逐个做未授权访问探测（仅安全 GET，跳过破坏性接口）。"""
     cfg = _get_recon_cfg(agent)
     base = str(args.get("base_url") or args.get("url") or "").strip()
@@ -740,9 +743,13 @@ async def execute_unauth_test(agent: AgentContext, args: dict[str, Any]) -> str:
     auth = _parse_auth_header(args.get("auth_header"))
     cap = int(args.get("max_endpoints", 60) or 60)
     try:
-        async with _make_client(cfg) as client:
+        if client is not None:
             sem = asyncio.Semaphore(cfg.max_concurrency)
             rows = await _probe_endpoints(client, base, endpoints, auth, cap, sem)
+        else:
+            async with _make_client(cfg) as new_client:
+                sem = asyncio.Semaphore(cfg.max_concurrency)
+                rows = await _probe_endpoints(new_client, base, endpoints, auth, cap, sem)
     except Exception as e:
         return f"[!] unauth_test 执行错误: {e}"
 


### PR DESCRIPTION
## 变更

- \execute_unauth_test\ 新增 \client\ 可选参数，js_recon→unauth_test 嵌套路径复用 TCP 连接
- \SessionState.save()\ 添加内容哈希对比，状态未变时跳过磁盘写入

## 关联

Fixes #119

## 验证

- js_recon(auto_probe=True) 执行后确认只创建 1 个 httpx client
- 连续调用 save() 两次，第二次无磁盘写入
- \uff check vulnclaw tests\ + \pytest -q\ 通过（589 passed，1 pre-existing failure 无关）