### PR TITLE
feat(web): add Token auth middleware for Web UI API endpoints

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1239,9 +1239,12 @@ class TestWebApp:
 
     def test_web_target_preview_and_diff_endpoints(self, monkeypatch):
         import vulnclaw.web.app as web_app
+        import vulnclaw.web.auth as web_auth
 
         if not web_app.FASTAPI_AVAILABLE:
             pytest.skip("FastAPI is not installed in this environment")
+
+        monkeypatch.setattr(web_auth, "verify_token", lambda _token: True)
 
         monkeypatch.setattr(
             web_app,
@@ -1269,11 +1272,16 @@ class TestWebApp:
 
         app = web_app.create_app()
         client = pytest.importorskip("fastapi.testclient").TestClient(app)
+        headers = {"Authorization": "Bearer test-token"}
 
-        preview = client.get("/api/target-preview/example.com")
+        preview = client.get("/api/target-preview/example.com", headers=headers)
         assert preview.status_code == 200
         assert preview.json()["schema_version"] == 2
 
-        diff = client.get("/api/target-diff/example.com", params={"from_snapshot_id": "snap_a"})
+        diff = client.get(
+            "/api/target-diff/example.com",
+            params={"from_snapshot_id": "snap_a"},
+            headers=headers,
+        )
         assert diff.status_code == 200
         assert diff.json()["from_snapshot_id"] == "snap_a"

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -3182,6 +3182,19 @@ def web(
         raise typer.Exit(1)
 
     from vulnclaw.web.app import create_app
+    from vulnclaw.web.auth import generate_token
+
+    token = generate_token()
+    if allow_remote:
+        console.print(
+            Panel(
+                f"Token: [bold]{token}[/]\n\n"
+                "Use this token in the Authorization header:\n"
+                f"[dim]Authorization: Bearer {token}[/]",
+                title="Web UI Auth Token",
+                border_style="yellow",
+            )
+        )
 
     uvicorn.run(create_app(), host=host, port=port, log_level="info")
 

--- a/vulnclaw/web/app.py
+++ b/vulnclaw/web/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from pathlib import Path
 
+from vulnclaw.web.auth import AuthMiddleware
 from vulnclaw.web.schemas import (
     ConfigUpdateRequest,
     ProviderModelsRequest,
@@ -100,6 +101,7 @@ def create_app():
 
     app = FastAPI(title="VulnClaw Web UI", version="0.3.3")
     app.add_middleware(SecurityHeadersMiddleware)
+    app.add_middleware(AuthMiddleware)
 
     @app.get("/api/health")
     async def health():

--- a/vulnclaw/web/auth.py
+++ b/vulnclaw/web/auth.py
@@ -1,0 +1,108 @@
+"""Token-based authentication for the VulnClaw Web UI.
+
+The token is generated once and persisted to ``~/.vulnclaw/web_token``.
+All ``/api/`` routes (except ``/api/health``) require a valid
+``Authorization: Bearer <token>`` header.
+"""
+
+from __future__ import annotations
+
+import hmac
+import secrets
+from pathlib import Path
+
+try:
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+
+    _HAS_STARLETTE = True
+except ImportError:  # pragma: no cover
+    _HAS_STARLETTE = False
+
+TOKEN_DIR = Path.home() / ".vulnclaw"
+TOKEN_FILE = TOKEN_DIR / "web_token"
+
+
+def _token_path() -> Path:
+    """Return the token file path, ensuring the parent directory exists."""
+    TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+    return TOKEN_FILE
+
+
+def generate_token() -> str:
+    """Return a persisted bearer token.
+
+    If a token file already exists its content is reused.  Otherwise a new
+    32-byte URL-safe token is generated, written to disk and returned.
+    """
+    path = _token_path()
+    if path.exists():
+        existing = path.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+
+    token = secrets.token_urlsafe(32)
+    path.write_text(token, encoding="utf-8")
+    # Restrict file permissions on POSIX (best-effort on Windows).
+    try:
+        import os
+
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return token
+
+
+def verify_token(token: str) -> bool:
+    """Return *True* if *token* matches the stored bearer token.
+
+    Uses :func:`hmac.compare_digest` for timing-safe comparison.
+    """
+    path = _token_path()
+    if not path.exists():
+        return False
+    stored = path.read_text(encoding="utf-8").strip()
+    return hmac.compare_digest(stored, token)
+
+
+if _HAS_STARLETTE:
+
+    class AuthMiddleware(BaseHTTPMiddleware):  # type: ignore[no-redef]
+        """ASGI middleware that enforces bearer-token auth on ``/api/`` routes.
+
+        ``/api/health`` is always exempt so that uptime probes work without
+        credentials.
+        """
+
+        _EXEMPT_PREFIXES: tuple[str, ...] = ("/api/health",)
+
+        async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+            path = request.url.path
+            if path.startswith("/api/") and not any(
+                path.startswith(p) for p in self._EXEMPT_PREFIXES
+            ):
+                auth_header = request.headers.get("Authorization", "")
+                if not auth_header.startswith("Bearer "):
+                    return JSONResponse(
+                        {"detail": "Missing or malformed Authorization header"},
+                        status_code=401,
+                    )
+                bearer = auth_header[len("Bearer ") :]
+                if not verify_token(bearer):
+                    return JSONResponse(
+                        {"detail": "Invalid token"},
+                        status_code=403,
+                    )
+            return await call_next(request)
+
+else:  # pragma: no cover
+
+    class AuthMiddleware:  # type: ignore[no-redef]
+        """Stub raised when Starlette is not installed."""
+
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError(
+                "Starlette is not installed. Install the web extra: "
+                "pip install vulnclaw[web]"
+            )


### PR DESCRIPTION
## 变更

- 新增 \ulnclaw/web/auth.py\：Token 生成（secrets.token_urlsafe）+ 验证（compare_digest）
- \pp.py\ 添加 AuthMiddleware：\/api/\ 路径需 Bearer token，\/api/health\ 豁免
- \main.py\：\--allow-remote\ 时打印 token 供用户使用
- 前端：首次访问弹出 token 输入框，存入 localStorage

## 关联

Fixes #120

## 验证

- 不带 token 访问 /api/config 返回 401
- 带 token 访问 /api/config 返回 200
- \--allow-remote\ 启动后终端显示 token
- \uff check vulnclaw tests\ + \pytest -q\ + \
px tsc -b\ 通过