### PR TITLE
refactor(agent): rename _extract_json/_structured_call to public names

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -39,9 +39,9 @@ def test_flag_evidence_helpers():
 
 
 def test_extract_json_handles_fences_and_noise():
-    assert solver._extract_json('```json\n{"complete": "ok"}\n```') == {"complete": "ok"}
-    assert solver._extract_json('prefix {"intents": []} suffix') == {"intents": []}
-    assert solver._extract_json("not json at all") is None
+    assert solver.extract_json('```json\n{"complete": "ok"}\n```') == {"complete": "ok"}
+    assert solver.extract_json('prefix {"intents": []} suffix') == {"intents": []}
+    assert solver.extract_json("not json at all") is None
 
 
 def test_reason_prompt_requires_frontier_recovery_without_open_intents():

--- a/tests/test_team_agents.py
+++ b/tests/test_team_agents.py
@@ -131,7 +131,7 @@ async def test_make_team_plan_uses_adviser_role_and_json_extraction(monkeypatch)
         ]}
         """
 
-    monkeypatch.setattr(solver, "_structured_call", fake_structured_call)
+    monkeypatch.setattr(solver, "structured_call", fake_structured_call)
 
     class PlannerAgent(FakeAgent):
         def _get_client(self):

--- a/vulnclaw/agent/solver.py
+++ b/vulnclaw/agent/solver.py
@@ -207,7 +207,7 @@ def _completion_is_grounded(goal: str, evidence: str) -> tuple[bool, str]:
     return False, "目标要求 flag，但任何真实工具输出中都没有出现 flag，判定为未验证/疑似幻觉"
 
 
-def _extract_json(text: str) -> Optional[dict]:
+def extract_json(text: str) -> Optional[dict]:
     """从 LLM 回复中稳健地抽取一个 JSON 对象。"""
     if not text:
         return None
@@ -243,7 +243,7 @@ def _extract_json(text: str) -> Optional[dict]:
     return None
 
 
-async def _structured_call(agent: AgentContext, prompt: str, *, max_tokens: int = 900) -> str:
+async def structured_call(agent: AgentContext, prompt: str, *, max_tokens: int = 900) -> str:
     """无工具的结构化 LLM 调用（用于 Reason / Conclude）。"""
     client = agent._get_client()
     messages = [{"role": "user", "content": prompt}]
@@ -474,8 +474,8 @@ def _add_fallback_recovery_intents(board: Blackboard, max_intents: int) -> int:
 
 
 async def reason_step(agent: AgentContext, board: Blackboard, max_intents: int) -> dict:
-    raw = await _structured_call(agent, _reason_prompt(board, max_intents), max_tokens=1200)
-    parsed = _extract_json(raw)
+    raw = await structured_call(agent, _reason_prompt(board, max_intents), max_tokens=1200)
+    parsed = extract_json(raw)
     return parsed or {}
 
 
@@ -485,10 +485,10 @@ async def frontier_recovery_step(
     max_intents: int,
     streak: int,
 ) -> dict:
-    raw = await _structured_call(
+    raw = await structured_call(
         agent, _frontier_recovery_prompt(board, max_intents, streak), max_tokens=1200
     )
-    parsed = _extract_json(raw)
+    parsed = extract_json(raw)
     return parsed or {}
 
 
@@ -553,10 +553,10 @@ async def explore_step(
     # 无论 explore 如何结束（轮数耗尽/advance/dead-end/空转），都进入 conclude 阶段。
     # conclude 基于真实工具输出总结，偏向保留有价值的发现。
     intent_evidence = "\n".join(evidence_buffer[evidence_start:])[-6000:]
-    raw = await _structured_call(
+    raw = await structured_call(
         agent, _conclude_prompt(board, intent, intent_evidence), max_tokens=600
     )
-    parsed = _extract_json(raw) or {}
+    parsed = extract_json(raw) or {}
     advanced = bool(parsed.get("advanced"))
     fact = str(parsed.get("fact", "")).strip()
     if not fact:
@@ -933,3 +933,8 @@ async def _explore_batch(
         else:
             results.append(r)
     return results
+
+
+# Backward-compatible aliases for old private names.
+_extract_json = extract_json
+_structured_call = structured_call

--- a/vulnclaw/agent/team.py
+++ b/vulnclaw/agent/team.py
@@ -86,7 +86,7 @@ def validate_plan(raw: TeamPlan | dict[str, Any], *, fallback_goal: str) -> Team
 
 async def make_team_plan(agent: Any, origin: str, goal: str, facts: list[str]) -> TeamPlan:
     """Ask the Adviser for a structured team plan."""
-    from vulnclaw.agent.solver import _extract_json, _structured_call
+    from vulnclaw.agent.solver import extract_json, structured_call
 
     if not hasattr(agent, "_get_client"):
         return _fallback_plan(goal)
@@ -105,12 +105,12 @@ async def make_team_plan(agent: Any, origin: str, goal: str, facts: list[str]) -
     agent.active_role = "adviser"
     try:
         try:
-            raw = await _structured_call(agent, prompt, max_tokens=1200)
+            raw = await structured_call(agent, prompt, max_tokens=1200)
         except Exception:
             return _fallback_plan(goal)
     finally:
         agent.active_role = previous_role
-    return validate_plan(_extract_json(raw) or {}, fallback_goal=goal)
+    return validate_plan(extract_json(raw) or {}, fallback_goal=goal)
 
 
 async def ask_adviser(
@@ -121,7 +121,7 @@ async def ask_adviser(
     step_result: Any,
 ) -> TeamDecision:
     """Ask the Adviser whether to continue, re-plan, or stop after a step."""
-    from vulnclaw.agent.solver import _extract_json, _structured_call
+    from vulnclaw.agent.solver import extract_json, structured_call
 
     if not hasattr(agent, "_get_client"):
         return TeamDecision(action="continue", reason="no adviser LLM client available")
@@ -142,12 +142,12 @@ async def ask_adviser(
     agent.active_role = "adviser"
     try:
         try:
-            raw = await _structured_call(agent, prompt, max_tokens=600)
+            raw = await structured_call(agent, prompt, max_tokens=600)
         except Exception:
             return TeamDecision(action="continue", reason="adviser structured call failed")
     finally:
         agent.active_role = previous_role
-    return _coerce_decision(_extract_json(raw) or {})
+    return _coerce_decision(extract_json(raw) or {})
 
 
 async def run_team_pentest(


### PR DESCRIPTION
## 变更

- \_extract_json\ → \extract_json\，\_structured_call\ → \structured_call\
- 同步更新 solver.py（3 处）、team.py（2 import + 4 调用）、测试文件（5 处）
- 保留旧名别名兼容

## 关联

Fixes #121

## 验证

- \uff check vulnclaw tests\ + \pytest -q\ 通过（589 passed，1 pre-existing failure 无关）