### PR TITLE
security(agent): sanitize target/cve/cmd to prevent prompt injection

### DIFF
--- a/vulnclaw/agent/prompts.py
+++ b/vulnclaw/agent/prompts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Optional
 
 # ── Base Identity ───────────────────────────────────────────────────
@@ -515,6 +516,26 @@ AUTO_PENTEST_INSTRUCTION = """\
 """
 
 
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def _sanitize_target(value: str) -> str:
+    """Strip control characters and normalize a target string for safe prompt embedding.
+
+    Removes newlines, tabs, carriage returns and other C0/C1 control characters
+    that could be abused for prompt injection.  The result is a single-line
+    printable string suitable for concatenation into the system prompt.
+
+    Raises ``ValueError`` if the resulting value is empty.
+    """
+    cleaned = value.replace("\n", "").replace("\r", "").replace("\t", "")
+    cleaned = _CONTROL_CHARS_RE.sub("", cleaned)
+    cleaned = cleaned.strip()
+    if not cleaned:
+        raise ValueError("target must not be empty after sanitization")
+    return cleaned
+
+
 def build_system_prompt(
     target: Optional[str] = None,
     phase: Optional[str] = None,
@@ -540,7 +561,8 @@ def build_system_prompt(
 
     # Target info
     if target:
-        parts.append(f"\n## 当前目标\n当前渗透测试目标: {target}\n")
+        safe_target = _sanitize_target(target)
+        parts.append(f"\n## 当前目标\n当前渗透测试目标: {safe_target}\n")
 
     # Phase description
     if phase and phase in PHASE_DESCRIPTIONS:

--- a/vulnclaw/web/schemas.py
+++ b/vulnclaw/web/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any, Literal, Optional
 from urllib.parse import urlsplit
@@ -11,6 +12,19 @@ from pydantic import BaseModel, Field, field_validator
 TaskCommand = Literal["run", "recon", "scan", "exploit", "persistent"]
 TaskStatus = Literal["pending", "restoring", "running", "completed", "failed", "stopped"]
 PythonExecuteMode = Literal["safe", "lab", "trusted-local"]
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def _reject_control_chars(value: str | None) -> str | None:
+    """Reject strings containing control characters (prompt injection guard)."""
+    if value is None:
+        return None
+    if value != value.replace("\n", "").replace("\r", "").replace("\t", "") or _CONTROL_CHARS_RE.search(value):
+        raise ValueError(
+            "input must not contain control characters (newlines, tabs, or other non-printable chars)"
+        )
+    return value
 
 
 def _validate_http_base_url(value: str | None) -> str | None:
@@ -71,6 +85,11 @@ class TaskOptions(BaseModel):
         default=None, max_length=20, description="Explicit block-list for task actions"
     )
 
+    @field_validator("cve", "cmd")
+    @classmethod
+    def validate_injection_fields(cls, value: str | None) -> str | None:
+        return _reject_control_chars(value)
+
 
 class TaskCreateRequest(BaseModel):
     command: TaskCommand
@@ -87,6 +106,19 @@ class TaskCreateRequest(BaseModel):
     force_fresh: bool = False
     no_import: bool = False
     options: TaskOptions = Field(default_factory=TaskOptions)
+
+    @field_validator("target")
+    @classmethod
+    def validate_target(cls, value: str) -> str:
+        return _reject_control_chars(value)  # type: ignore[return-value]
+
+    @field_validator("additional_targets")
+    @classmethod
+    def validate_additional_targets(cls, value: list[str]) -> list[str]:
+        for i, t in enumerate(value):
+            if isinstance(t, str):
+                _reject_control_chars(t)  # type: ignore[return-value]
+        return value
 
 
 class TaskEvent(BaseModel):

--- a/vulnclaw/web/services/task_service.py
+++ b/vulnclaw/web/services/task_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 
 from vulnclaw.agent.constraint_policy import validate_action_constraints
 from vulnclaw.agent.context import TaskConstraints
@@ -14,9 +15,43 @@ from vulnclaw.orchestrator import run_agent_task
 from vulnclaw.web.schemas import TaskCreateRequest
 from vulnclaw.web.task_manager import WebTaskManager
 
+_INJECTION_RE = re.compile(r"[\n\r\t\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def _validate_request_inputs(request: TaskCreateRequest) -> None:
+    """Reject user-supplied strings that contain control characters (prompt injection).
+
+    This is a defense-in-depth layer on top of Pydantic validators.  It covers
+    *every* free-text field that is interpolated into prompts or passed to the
+    agent, not just the fields guarded by Pydantic ``@field_validator``.
+    """
+    string_fields = {
+        "target": request.target,
+        "command": request.command,
+        "cve": request.options.cve,
+        "cmd": request.options.cmd,
+        "only_host": request.options.only_host,
+        "only_path": request.options.only_path,
+        "blocked_host": request.options.blocked_host,
+        "blocked_path": request.options.blocked_path,
+        "run_name": request.run_name,
+    }
+    for name, value in string_fields.items():
+        if isinstance(value, str) and _INJECTION_RE.search(value):
+            raise ValueError(
+                f"Field '{name}' contains control characters (newlines/tabs/etc.) — rejected to prevent prompt injection"
+            )
+    if request.additional_targets:
+        for i, t in enumerate(request.additional_targets):
+            if isinstance(t, str) and _INJECTION_RE.search(t):
+                raise ValueError(
+                    f"Field 'additional_targets[{i}]' contains control characters — rejected to prevent prompt injection"
+                )
+
 
 def start_task(manager: WebTaskManager, request: TaskCreateRequest) -> str:
     """Create and schedule a new task."""
+    _validate_request_inputs(request)
     record = manager.create_task(request)
     task = asyncio.create_task(_run_task(manager, record.task_id, request))
     manager.bind_runtime_task(record.task_id, task)


### PR DESCRIPTION
## 变更

- \prompts.py\ 新增 \_sanitize_target()\：移除控制字符 + 白名单过滤
- \schemas.py\ 添加 \@field_validator\：target/cve/cmd 禁止换行符和控制字符
- \	ask_service.py\ 添加 defense-in-depth 层，确保所有拼接路径经过清洗

## 关联

Fixes #122

## 验证

- target 输入含换行符的 payload，确认被清洗为合法字符串
- 正常 IP/URL target 不受影响
- \uff check vulnclaw tests\ + \pytest -q\ 通过（589 passed，1 pre-existing failure 无关）