### PR TITLE
fix(tui): 修复 Textual TUI 中 deep/continuous 模式 /run 确认后未启动子进程的问题，并新增了测试

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -991,6 +991,92 @@ class TestCLI:
         assert result == "launch"
         assert session["_nl_text"] == "Use VulnClaw skill ctf-web. find the flag"
 
+    def _make_textual_session(self, monkeypatch, mode):
+        """Build a Textual TUI session with _start_execution stubbed out."""
+        from types import SimpleNamespace
+
+        import vulnclaw.cli.tui as tui_mod
+        import vulnclaw.cli.tui_textual as textual_mod
+
+        session = {
+            "config": SimpleNamespace(
+                llm=SimpleNamespace(provider="test", model="m", api_key="x")
+            ),
+            "state": tui_mod.TuiState(target="https://example.com", mode=mode),
+            "launcher": None,
+            "_action": None,
+            "_prompt": None,
+            "_message": "",
+            "_launch": False,
+        }
+        launched = []
+        monkeypatch.setattr(
+            textual_mod.DashboardScreen,
+            "_start_execution",
+            lambda screen, draft=None, **kw: launched.append(draft),
+        )
+        return textual_mod, session, launched
+
+    @pytest.mark.parametrize("mode", ["deep", "continuous"])
+    async def test_textual_extra_confirm_mode_run_confirmed_launches(self, mode, monkeypatch):
+        """/run in deep/continuous mode: pressing y in the confirm popup must
+        start execution (the async confirm callback sets session["_action"]
+        after _dispatch already returned, so it must be consumed later)."""
+        textual_mod, session, launched = self._make_textual_session(monkeypatch, mode)
+        app = textual_mod.VulnClawApp(session)
+        async with app.run_test() as pilot:
+            await pilot.press(*"/run", "escape", "enter")
+            await pilot.pause()
+            popup = app.screen.query_one(textual_mod.SecondaryPopup)
+            assert popup.has_class("open")
+            await pilot.press("y")
+            await pilot.pause()
+            await pilot.pause()
+
+        assert launched, "confirming /run with y should start execution"
+        assert session["_action"] is None
+
+    async def test_textual_deep_mode_run_confirm_via_input_launches(self, monkeypatch):
+        """Answering the deep-mode confirm by typing y in the main input must
+        also start execution (legacy _handle_prompt path)."""
+        from textual.widgets import Input
+
+        textual_mod, session, launched = self._make_textual_session(monkeypatch, "deep")
+        app = textual_mod.VulnClawApp(session)
+        async with app.run_test() as pilot:
+            await pilot.press(*"/run", "escape", "enter")
+            await pilot.pause()
+            app.screen.query_one("#cmd-input", Input).focus()
+            await pilot.press("y", "enter")
+            await pilot.pause()
+            await pilot.pause()
+
+        assert launched, "confirming /run with y should start execution"
+
+    async def test_textual_deep_mode_run_declined_does_not_launch(self, monkeypatch):
+        """Pressing n in the deep-mode confirm popup must not start execution."""
+        textual_mod, session, launched = self._make_textual_session(monkeypatch, "deep")
+        app = textual_mod.VulnClawApp(session)
+        async with app.run_test() as pilot:
+            await pilot.press(*"/run", "escape", "enter")
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.pause()
+
+        assert not launched
+        assert session["_action"] is None
+
+    async def test_textual_standard_mode_run_launches_without_confirm(self, monkeypatch):
+        """/run in standard mode launches directly, no confirm popup."""
+        textual_mod, session, launched = self._make_textual_session(monkeypatch, "standard")
+        app = textual_mod.VulnClawApp(session)
+        async with app.run_test() as pilot:
+            await pilot.press(*"/run", "escape", "enter")
+            await pilot.pause()
+
+        assert launched
+
     def test_skill_slash_with_args_requires_target_by_default(self, monkeypatch):
         import vulnclaw.cli.tui as tui_mod
 

--- a/vulnclaw/cli/tui_textual.py
+++ b/vulnclaw/cli/tui_textual.py
@@ -1214,6 +1214,9 @@ class DashboardScreen(Screen):
                 self._s["_prompt"] = None
                 self._set_bar("")
                 cb(True)
+                # [修改] 2026-07-17 - 确认回调可能异步请求 launch (deep/continuous /run), 在此消费
+                if self._consume_launch_action():
+                    return
             elif text.lower() in ("n", "no"):
                 self._s["_prompt"] = None
                 self._set_bar("")
@@ -1310,7 +1313,21 @@ class DashboardScreen(Screen):
 
         return "\n".join(lines)
 
+    def _consume_launch_action(self) -> bool:
+        # [新增] 2026-07-17 - 修复 deep/continuous 模式 /run 确认后不启动的问题:
+        # 确认弹窗回调是异步执行的, 此时 _dispatch 早已返回 None,
+        # on_input_submitted 永远看不到 session["_action"] == "launch",
+        # 因此必须在弹窗/提示收尾处消费它并启动执行
+        if self._s.get("_action") != "launch":
+            return False
+        self._s["_action"] = None
+        self._s["_launch"] = False
+        self._start_execution()
+        return True
+
     def _post_popup_refresh(self) -> None:
+        if self._consume_launch_action():
+            return
         # If language was switched via popup, refresh dashboard text immediately
         # then recompose the whole UI for full hot-reload (commit 201e8ec pattern).
         if self._s.pop("_needs_recompose", False):


### PR DESCRIPTION
  ## 解决了什么问题
  
  Fixes #131 

  在 Textual TUI 中将模式切换为 deep 或 continuous 后，输入 `/run` 并在确认弹窗中按 `y`，
  子进程实际不会启动：TUI 仅清空输入框、刷新仪表盘，不进入执行视图（无输出日志、无
  spinner），也没有任何执行反馈。quick 和 standard 模式不受影响。

  **根因**：deep/continuous 模式的 `/run` 需要二次确认，确认回调是异步执行的——
  `_h_start` 设置 confirm 弹窗后返回 `None`，`_dispatch` 同步流程随即结束；用户按 `y`
  后回调把 `session["_action"] = "launch"`，但此时已没有任何代码消费这个值
  （`_post_popup_refresh` 只刷新仪表盘，`run_tui_textual` 外层循环只在 app 退出后检查
  且仅处理 `"quit"`）。quick/standard 因为同步返回 `"launch"` 走 `_start_execution`，
  所以正常。

  ## 如何修复

  在 `vulnclaw/cli/tui_textual.py` 新增 `DashboardScreen._consume_launch_action()`，
  在两个异步收尾点消费挂起的 launch 请求并启动执行：

  1. `_post_popup_refresh()` 开头——弹窗按 `y` 的路径（即 issue 的复现路径）；
  2. `_handle_prompt()` 的 confirm 分支——在主输入框直接输入 `y` 的旧路径（同一根因）。

  消费后调用 `_start_execution()`（draft 传 `None`，从当前 state 全新构建），TUI 正常
  进入执行视图并启动 CLI 子进程。按 `n` 不设置 `_action`，行为不变。

  ## 逻辑变更与验证方式

  变更逻辑：弹窗/提示收尾处新增 `_action == "launch"` 消费分支，无其他行为改动。

  **手动测试步骤**：

  1. 启动 TUI，设置 `/target <目标>`，`/mode` 切换为 deep（或 continuous）
  2. 输入 `/run` 回车，确认弹窗出现
  3. 按 `y` → 应进入执行视图：仪表盘隐藏、子进程启动
  4. 重复上述步骤按 `n` → 应返回且不启动

  ## 测试情况

  - `tests/test_cli.py`：**93/93 通过**
  - 全量套件：**1093 通过**、5 失败——经 `git stash` 在干净 HEAD 上复跑确认，该 5 个失败与本 PR 无关
