### PR TITLE
feat(tui): persist /scope state to config.yaml

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -920,6 +920,94 @@ class TestCLI:
         assert session["_prompt"][0] == "message"
         assert "--only-port" in session["_prompt"][1]
 
+    def test_tui_persist_scope_state_writes_config(self, monkeypatch):
+        import vulnclaw.cli.tui as tui_mod
+        from vulnclaw.config.schema import VulnClawConfig
+
+        config = VulnClawConfig()
+        state = tui_mod.TuiState(
+            only_host="example.com",
+            only_port="443",
+            only_path="/admin",
+            blocked_host="staging.example.com",
+            blocked_path="/logout",
+            allow_actions=["recon", "scan"],
+            block_actions=["exploit", "post_exploitation"],
+            mode="quick",
+            resume=False,
+        )
+        saved = []
+        monkeypatch.setattr(
+            "vulnclaw.config.settings.save_config", lambda cfg: saved.append(cfg)
+        )
+
+        tui_mod._persist_scope_state(state, config)
+        assert saved, "save_config was never called"
+        sc = saved[0].session
+        assert sc.tui_scope_only_host == "example.com"
+        assert sc.tui_scope_only_port == "443"
+        assert sc.tui_scope_allow_actions == "recon,scan"
+        assert sc.tui_scope_block_actions == "exploit,post_exploitation"
+        assert sc.tui_scope_mode == "quick"
+        assert sc.tui_scope_resume is False
+
+    def test_tui_restore_scope_state_reads_config(self):
+        import vulnclaw.cli.tui as tui_mod
+        from vulnclaw.config.schema import VulnClawConfig
+
+        config = VulnClawConfig()
+        sc = config.session
+        sc.tui_scope_only_host = "example.com"
+        sc.tui_scope_only_port = "443"
+        sc.tui_scope_allow_actions = "recon,scan"
+        sc.tui_scope_block_actions = "exploit"
+        sc.tui_scope_mode = "deep"
+        sc.tui_scope_resume = True
+
+        state = tui_mod.TuiState()
+
+        tui_mod._restore_scope_state(state, config)
+        assert state.only_host == "example.com"
+        assert state.only_port == "443"
+        assert state.allow_actions == ["recon", "scan"]
+        assert state.block_actions == ["exploit"]
+        assert state.mode == "deep"
+        assert state.resume is True
+
+    def test_tui_persist_restore_resume_round_trip(self, monkeypatch):
+        import vulnclaw.cli.tui as tui_mod
+        from vulnclaw.config.schema import VulnClawConfig
+
+        config = VulnClawConfig()
+        resume_state = tui_mod.TuiState(resume=True)
+        nosave = []
+
+        monkeypatch.setattr(
+            "vulnclaw.config.settings.save_config", lambda cfg: nosave.append(cfg)
+        )
+        tui_mod._persist_scope_state(resume_state, config)
+        assert nosave[0].session.tui_scope_resume is True
+
+        config2 = VulnClawConfig()
+        config2.session.tui_scope_resume = True
+        restored = tui_mod.TuiState(resume=False)
+
+        tui_mod._restore_scope_state(restored, config2)
+        assert restored.resume is True
+
+    def test_tui_restore_scope_preserves_cli_explicit(self):
+        import vulnclaw.cli.tui as tui_mod
+        from vulnclaw.config.schema import VulnClawConfig
+
+        config = VulnClawConfig()
+        config.session.tui_scope_only_host = "persisted.example.com"
+        config.session.tui_scope_mode = "deep"
+
+        state = tui_mod.TuiState(only_host="cli.example.com", mode="quick")
+        tui_mod._restore_scope_state(state, config)
+        assert state.only_host == "cli.example.com"
+        assert state.mode == "quick"
+
     def test_textual_slash_dot_flag_dispatch_applies_state(self):
         import vulnclaw.cli.tui as tui_mod
         import vulnclaw.cli.tui_textual as textual_mod

--- a/vulnclaw/cli/tui.py
+++ b/vulnclaw/cli/tui.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import re
 import shutil
 import subprocess
@@ -18,6 +19,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal, Optional
+
+logger = logging.getLogger(__name__)
 
 # [修改] 2026-06-10 Nyaecho - 将 prompt_toolkit 导入移到 _run_pt_tui() 函数内部，避免硬性依赖
 from rich import box
@@ -1267,6 +1270,7 @@ def _cmd_scope(session: dict[str, Any], args: str) -> None:
     state: TuiState = session["state"]
     if args:
         _parse_scope_args(state, args)
+        _persist_scope_state(state, session.get("config", load_config()))
         return
     fields = [
         ("only_host", _("tui.prompt_only_host"), state.only_host or ""),
@@ -1282,6 +1286,7 @@ def _cmd_scope(session: dict[str, Any], args: str) -> None:
         state.resume = yes
 
     def _ask_resume() -> None:
+        _persist_scope_state(state, session.get("config", load_config()))
         _set_prompt_confirm(session, _("tui.prompt_resume", state=_("tui.on") if state.resume else _("tui.off")), _on_resume_confirm)
 
     _set_prompt_chain(session, fields, 0, _ask_resume)
@@ -1719,6 +1724,50 @@ def _effective_allow_actions(state: TuiState) -> tuple[str, ...]:
 
 def _effective_block_actions(state: TuiState) -> tuple[str, ...]:
     return tuple(state.block_actions) or MODES[state.mode].block_actions
+
+
+def _persist_scope_state(state: TuiState, config: Any) -> None:
+    from vulnclaw.config.settings import save_config as _sc
+    try:
+        sc = config.session
+        sc.tui_scope_only_host = state.only_host
+        sc.tui_scope_only_port = state.only_port
+        sc.tui_scope_only_path = state.only_path
+        sc.tui_scope_blocked_host = state.blocked_host
+        sc.tui_scope_blocked_path = state.blocked_path
+        sc.tui_scope_allow_actions = ",".join(state.allow_actions)
+        sc.tui_scope_block_actions = ",".join(state.block_actions)
+        sc.tui_scope_mode = state.mode
+        sc.tui_scope_resume = state.resume
+        _sc(config)
+    except AttributeError:
+        logger.warning("Failed to persist scope state", exc_info=True)
+
+
+def _restore_scope_state(state: TuiState, config: Any) -> None:
+    try:
+        sc = config.session
+    except AttributeError:
+        return
+    if sc.tui_scope_only_host and not state.only_host:
+        state.only_host = sc.tui_scope_only_host
+    if sc.tui_scope_only_port and not state.only_port:
+        state.only_port = sc.tui_scope_only_port
+    if sc.tui_scope_only_path and not state.only_path:
+        state.only_path = sc.tui_scope_only_path
+    if sc.tui_scope_blocked_host and not state.blocked_host:
+        state.blocked_host = sc.tui_scope_blocked_host
+    if sc.tui_scope_blocked_path and not state.blocked_path:
+        state.blocked_path = sc.tui_scope_blocked_path
+    if sc.tui_scope_allow_actions and not state.allow_actions:
+        state.allow_actions = _parse_action_csv(sc.tui_scope_allow_actions)
+    if sc.tui_scope_block_actions and not state.block_actions:
+        state.block_actions = _parse_action_csv(sc.tui_scope_block_actions)
+    # restore persisted mode only if state still has its default ("standard"),
+    # preserving any explicit --mode from CLI args
+    if sc.tui_scope_mode in MODES and state.mode == "standard":
+        state.mode = sc.tui_scope_mode
+    state.resume = sc.tui_scope_resume
 
 
 def _parse_action_csv(value: str | tuple[str, ...] | list[str] | None) -> list[str]:

--- a/vulnclaw/cli/tui_textual.py
+++ b/vulnclaw/cli/tui_textual.py
@@ -83,6 +83,12 @@ def _register_handler(cmd: str):
     return deco
 
 
+def _persist_scope(session: dict[str, Any], state: Any) -> None:
+    config = session.get("config")
+    if config:
+        _tui._persist_scope_state(state, config)
+
+
 def _dispatch(session: dict[str, Any], text: str) -> str | None:
     """Dispatch slash command. Returns 'quit', 'launch', or None."""
     if text.startswith("/."):
@@ -728,8 +734,11 @@ def _h_mode(session: dict[str, Any], args: str) -> str | None:
     state = session["state"]
     if args and args in _tui.MODES:
         state.mode = args
+        _persist_scope(session, state)
         return None
-    def cb(v): state.mode = v
+    def cb(v):
+        state.mode = v
+        _persist_scope(session, state)
     _set_prompt(session, "choice", _("tui.prompt_select_mode"), list(_tui.MODES.keys()), cb)
     return None
 
@@ -764,6 +773,7 @@ def _h_scope(session: dict[str, Any], args: str) -> str | None:
                     state.block_actions = _parse_action_csv(v)
                 elif k == "resume":
                     state.resume = v.lower() in ("true", "yes", "1", "on")
+        _persist_scope(session, state)
         return None
     # [修改] 2026-07-18 - 动作约束改为 action_matrix 表格勾选, chain 只保留 5 个文本字段
     fields = [
@@ -774,7 +784,9 @@ def _h_scope(session: dict[str, Any], args: str) -> str | None:
         ("blocked_path", _("tui.prompt_blocked_path"), state.blocked_path or ""),
     ]
     def on_resume(yes): state.resume = yes
-    def ask(): _set_prompt(session, "confirm", _("tui.prompt_resume", state=_("tui.on") if state.resume else _("tui.off")), on_resume)
+    def ask():
+        _persist_scope(session, state)
+        _set_prompt(session, "confirm", _("tui.prompt_resume", state=_("tui.on") if state.resume else _("tui.off")), on_resume)
     def on_matrix(result):
         allow, block = result
         state.allow_actions = allow
@@ -1758,6 +1770,7 @@ def run_tui_textual(*, launcher=None, once=False, initial_state=None) -> None:
     """Run the Textual-powered TUI workbench."""
     state = initial_state or TuiState()
     config = load_config()
+    _tui._restore_scope_state(state, config)
     active_launcher = launcher or _default_launcher
 
     if once:

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -353,6 +353,17 @@ class SessionConfig(BaseModel):
         description="Maximum discovered surfaces considered by REPL parallel auto-mode",
     )
 
+    # ── Persisted TUI scope state ──
+    tui_scope_only_host: str = Field(default="", description="Persisted TUI only-host scope")
+    tui_scope_only_port: str = Field(default="", description="Persisted TUI only-port scope")
+    tui_scope_only_path: str = Field(default="", description="Persisted TUI only-path scope")
+    tui_scope_blocked_host: str = Field(default="", description="Persisted TUI blocked-host scope")
+    tui_scope_blocked_path: str = Field(default="", description="Persisted TUI blocked-path scope")
+    tui_scope_allow_actions: str = Field(default="", description="Persisted TUI allowed actions (comma-sep)")
+    tui_scope_block_actions: str = Field(default="", description="Persisted TUI blocked actions (comma-sep)")
+    tui_scope_mode: str = Field(default="standard", description="Persisted TUI check mode")
+    tui_scope_resume: bool = Field(default=True, description="Persisted TUI resume flag")
+
     model_config = ConfigDict(populate_by_name=True)
 
     @property


### PR DESCRIPTION
### 改动 / Changes

**Schema (`vulnclaw/config/schema.py`)**
- `SessionConfig` 新增 9 个 `tui_scope_*` 字段，default 兼容老 `config.yaml`。

**Persist (`vulnclaw/cli/tui.py` + `tui_textual.py`)**
- `_persist_scope_state(state, config)`：把 9 个字段写回 `config.session` 并 `save_config`。
- `_restore_scope_state(state, config)`：`run_tui_textual` 启动时调用，逐字段恢复。mode 字段仅在 state 还是默认 `standard` 时覆盖，保留 CLI 显式 `--mode`。
- `tui_textual` 增加 `_persist_scope(session, state)` 助手，统一 `session.get("config")` 取值，handler 保持简洁。

### 测试 / Tests (`tests/test_cli.py`)
- round-trip：state → persist → 重建 TuiState → restore，9 字段一致。
- resume 双向恢复（regression for the inverted-guard bug）。
- CLI 显式 mode 不被持久化覆盖。

### 验证 / Verification
- `.venv/bin/pytest tests/test_cli.py -k "scope or persist or restore"` → 12 passed
- ruff 无新 warning

Closes #140 