### PR TITLE
fix: 修复上下文截断并实现冷热记忆分离

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -635,6 +635,95 @@ class TestMemoryStore:
         result = store.retrieve("complex")
         assert result["findings"] == ["SQLi", "XSS"]
 
+    def test_archived_messages_are_persisted_and_searchable(self, tmp_path):
+        from vulnclaw.agent.memory import MemoryStore
+
+        store = MemoryStore(store_dir=tmp_path)
+        store.archive_messages(
+            [
+                {"role": "user", "content": "check legacy-admin endpoint"},
+                {"role": "assistant", "content": "confirmed historical finding"},
+            ]
+        )
+
+        reloaded = MemoryStore(store_dir=tmp_path)
+        results = reloaded.search_messages("legacy-admin")
+        assert len(results) == 1
+        assert results[0]["messages"][0]["role"] == "user"
+
+
+def test_context_manager_moves_complete_old_turns_to_cold_memory(tmp_path):
+    from vulnclaw.agent.context import ContextManager
+    from vulnclaw.agent.memory import MemoryStore
+
+    store = MemoryStore(store_dir=tmp_path)
+    context = ContextManager(max_history=4, memory_store=store)
+    context.add_user_message("old question")
+    context.add_message(
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-old",
+                    "type": "function",
+                    "function": {"name": "probe", "arguments": "{}"},
+                }
+            ],
+        }
+    )
+    context.add_message({"role": "tool", "tool_call_id": "call-old", "content": "secret-marker"})
+    context.add_assistant_message("old answer")
+    context.add_user_message("current task")
+    context.add_assistant_message("current answer")
+
+    hot = context.get_messages()
+    assert [message["content"] for message in hot] == ["current task", "current answer"]
+    archived = store.search_messages("secret-marker")
+    assert len(archived) == 1
+    assert [message["role"] for message in archived[0]["messages"]] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+
+
+def test_context_manager_bounds_one_long_subtask_without_splitting_tools(tmp_path):
+    from vulnclaw.agent.context import ContextManager
+    from vulnclaw.agent.memory import MemoryStore
+
+    store = MemoryStore(store_dir=tmp_path)
+    context = ContextManager(max_history=5, memory_store=store)
+    context.add_user_message("keep this current objective")
+    for index in range(4):
+        call_id = f"call-{index}"
+        context.add_message(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "probe", "arguments": "{}"},
+                    }
+                ],
+            }
+        )
+        context.add_message(
+            {"role": "tool", "tool_call_id": call_id, "content": f"result-{index}"}
+        )
+
+    hot = context.get_messages()
+    assert len(hot) <= 5
+    assert hot[0]["content"] == "keep this current objective"
+    for index, message in enumerate(hot):
+        if message["role"] == "tool":
+            assert hot[index - 1]["role"] == "assistant"
+            assert hot[index - 1]["tool_calls"][0]["id"] == message["tool_call_id"]
+    assert store.search_messages("result-0")
+
 
 # ── prompts.py ───────────────────────────────────────────────────────
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -649,7 +649,7 @@ class TestMemoryStore:
         reloaded = MemoryStore(store_dir=tmp_path)
         results = reloaded.search_messages("legacy-admin")
         assert len(results) == 1
-        assert results[0]["messages"][0]["role"] == "user"
+        assert "legacy-admin" in results[0]["snippet"]
 
 
 def test_context_manager_moves_complete_old_turns_to_cold_memory(tmp_path):
@@ -681,12 +681,7 @@ def test_context_manager_moves_complete_old_turns_to_cold_memory(tmp_path):
     assert [message["content"] for message in hot] == ["current task", "current answer"]
     archived = store.search_messages("secret-marker")
     assert len(archived) == 1
-    assert [message["role"] for message in archived[0]["messages"]] == [
-        "user",
-        "assistant",
-        "tool",
-        "assistant",
-    ]
+    assert "secret-marker" in archived[0]["snippet"]
 
 
 def test_context_manager_bounds_one_long_subtask_without_splitting_tools(tmp_path):
@@ -723,6 +718,135 @@ def test_context_manager_bounds_one_long_subtask_without_splitting_tools(tmp_pat
             assert hot[index - 1]["role"] == "assistant"
             assert hot[index - 1]["tool_calls"][0]["id"] == message["tool_call_id"]
     assert store.search_messages("result-0")
+
+
+def test_context_manager_enforces_token_limit_below_message_limit(tmp_path):
+    from vulnclaw.agent.context import ContextManager
+    from vulnclaw.agent.memory import MemoryStore
+    from vulnclaw.agent.token_counter import estimate_tokens
+
+    store = MemoryStore(store_dir=tmp_path)
+    context = ContextManager(max_history=100, max_tokens=256, memory_store=store)
+    for index in range(4):
+        context.add_user_message(f"task-{index} " + "x" * 300)
+        context.add_assistant_message(f"answer-{index}")
+
+    assert estimate_tokens(context.get_messages()) <= 256
+    assert store.search_messages("task-0")
+
+
+def test_context_manager_keeps_hot_history_when_archive_fails():
+    from vulnclaw.agent.context import ContextManager
+
+    class FailingStore:
+        session_id = "failing"
+
+        def archive_messages(self, *args, **kwargs):
+            raise OSError("disk full")
+
+    context = ContextManager(max_history=2, memory_store=FailingStore())
+    context.add_user_message("one")
+    context.add_user_message("two")
+    context.add_user_message("three")
+
+    assert [message["content"] for message in context.get_messages()] == [
+        "one",
+        "two",
+        "three",
+    ]
+
+
+def test_large_tool_result_is_archived_and_replaced_with_reference(tmp_path):
+    from vulnclaw.agent.context import ContextManager
+    from vulnclaw.agent.memory import MemoryStore
+
+    store = MemoryStore(store_dir=tmp_path)
+    context = ContextManager(max_tokens=1000, memory_store=store)
+    context.add_message(
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "large-call",
+                    "type": "function",
+                    "function": {"name": "probe", "arguments": "{}"},
+                }
+            ],
+        }
+    )
+    context.add_message(
+        {"role": "tool", "tool_call_id": "large-call", "content": "unique-marker " * 1000}
+    )
+
+    hot_tool = context.get_messages()[-1]
+    assert hot_tool["content"].startswith("[cold-memory:mem-")
+    assert len(hot_tool["content"]) < 2300
+    assert store.search_messages("unique-marker", scope=store.session_id)
+
+
+def test_memory_search_is_bounded_and_task_scoped(tmp_path):
+    from vulnclaw.agent.memory import MemoryStore
+
+    store = MemoryStore(store_dir=tmp_path)
+    store.archive_messages(
+        [{"role": "tool", "content": "needle " + "z" * 10000}], scope="task-a"
+    )
+
+    results = store.search_messages("needle", scope="task-a", max_chars=512)
+    assert results
+    assert sum(len(item["snippet"]) for item in results) <= 512
+    assert store.search_messages("needle", scope="task-b", max_chars=512) == []
+
+
+def test_memory_search_skips_corrupt_jsonl_record(tmp_path):
+    from vulnclaw.agent.memory import MemoryStore
+
+    store = MemoryStore(store_dir=tmp_path)
+    store.archive_messages([{"role": "user", "content": "recoverable-marker"}])
+    with open(tmp_path / "conversation_archive.jsonl", "a", encoding="utf-8") as handle:
+        handle.write("{broken\n")
+
+    assert store.search_messages("recoverable-marker")
+
+
+def test_memory_archive_serializes_concurrent_writers(tmp_path):
+    import json
+    from concurrent.futures import ThreadPoolExecutor
+
+    from vulnclaw.agent.memory import MemoryStore
+
+    stores = [MemoryStore(store_dir=tmp_path) for _ in range(12)]
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        list(
+            pool.map(
+                lambda item: item[1].archive_messages(
+                    [{"role": "tool", "content": f"parallel-{item[0]}"}],
+                    scope="shared-task",
+                ),
+                enumerate(stores),
+            )
+        )
+
+    lines = (tmp_path / "conversation_archive.jsonl").read_text(encoding="utf-8").splitlines()
+    records = [json.loads(line) for line in lines]
+    assert len(records) == 12
+    assert len({record["record_id"] for record in records}) == 12
+
+
+def test_memory_archive_rotates_and_bounds_shard_count(tmp_path):
+    from vulnclaw.agent.memory import MemoryStore
+
+    store = MemoryStore(store_dir=tmp_path, archive_max_bytes=1024, archive_max_files=3)
+    for index in range(20):
+        store.archive_messages(
+            [{"role": "tool", "content": f"rotation-{index}-" + "x" * 300}],
+            scope="rotation-task",
+        )
+
+    shards = list(tmp_path.glob("conversation_archive*.jsonl"))
+    assert 1 < len(shards) <= 3
+    assert store.search_messages("rotation-19", scope="rotation-task")
 
 
 # ── prompts.py ───────────────────────────────────────────────────────

--- a/tests/test_builtin_tools.py
+++ b/tests/test_builtin_tools.py
@@ -65,6 +65,26 @@ class TestColdMemoryTool:
         names = {tool["function"]["name"] for tool in build_openai_tools(None)}
         assert "memory_search" in names
 
+    async def test_memory_search_final_output_is_bounded(self, tmp_path):
+        from vulnclaw.agent.builtin_tools import execute_mcp_tool
+        from vulnclaw.agent.context import ContextManager
+        from vulnclaw.agent.memory import MemoryStore
+
+        agent = DummyAgent()
+        store = MemoryStore(store_dir=tmp_path)
+        store.archive_messages(
+            [{"role": "tool", "content": "needle " + "x" * 10000}],
+            scope=store.session_id,
+        )
+        agent.context = ContextManager(
+            memory_store=store,
+            search_max_chars=512,
+        )
+
+        result = await execute_mcp_tool(agent, "memory_search", {"query": "needle"})
+
+        assert len(result) <= 512
+
 
 class TestBuiltinPythonExecute:
     async def test_safe_mode_blocks_network_access(self, monkeypatch, tmp_path):

--- a/tests/test_builtin_tools.py
+++ b/tests/test_builtin_tools.py
@@ -42,6 +42,30 @@ class DummyAgent:
         self.mcp_manager = None
 
 
+class TestColdMemoryTool:
+    async def test_memory_search_retrieves_archived_turn_on_demand(self, tmp_path):
+        from vulnclaw.agent.builtin_tools import execute_mcp_tool
+        from vulnclaw.agent.context import ContextManager
+        from vulnclaw.agent.memory import MemoryStore
+
+        agent = DummyAgent()
+        store = MemoryStore(store_dir=tmp_path)
+        store.archive_messages(
+            [{"role": "tool", "tool_call_id": "old-call", "content": "legacy-marker"}]
+        )
+        agent.context = ContextManager(memory_store=store)
+
+        result = await execute_mcp_tool(agent, "memory_search", {"query": "legacy-marker"})
+
+        assert "legacy-marker" in result
+
+    def test_memory_search_is_exposed_to_the_model(self):
+        from vulnclaw.agent.builtin_tools import build_openai_tools
+
+        names = {tool["function"]["name"] for tool in build_openai_tools(None)}
+        assert "memory_search" in names
+
+
 class TestBuiltinPythonExecute:
     async def test_safe_mode_blocks_network_access(self, monkeypatch, tmp_path):
         import vulnclaw.agent.builtin_tools as builtin_tools

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,6 +90,11 @@ class TestSessionConfig:
         assert config.plugin_default_timeout == 10
         assert config.plugin_max_requests_per_target == 30
         assert config.evidence_min_report_level == "L4"
+        assert config.context_hot_max_messages == 48
+        assert config.context_hot_max_tokens == 32000
+        assert config.memory_search_max_chars == 6000
+        assert config.memory_archive_max_bytes == 64 * 1024 * 1024
+        assert config.memory_archive_max_files == 8
 
 
 class TestVulnClawConfig:

--- a/tests/test_token_counter.py
+++ b/tests/test_token_counter.py
@@ -143,3 +143,68 @@ class TestTruncateMessages:
         result = truncate_messages(msgs, max_tokens=10, min_recent=4)
         # Body has only 1 message <= min_recent, so nothing dropped
         assert result == msgs
+
+
+def test_truncation_never_orphans_tool_result_at_recent_boundary():
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "A" * 1200},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "probe", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "result"},
+        {"role": "assistant", "content": "observed"},
+        {"role": "user", "content": "next"},
+        {"role": "assistant", "content": "working"},
+    ]
+
+    result = truncate_messages(messages, max_tokens=80, min_recent=4)
+
+    tool_index = next(
+        index for index, message in enumerate(result) if message.get("role") == "tool"
+    )
+    assistant = result[tool_index - 1]
+    assert assistant.get("role") == "assistant"
+    assert {call["id"] for call in assistant["tool_calls"]} == {"call-1"}
+
+
+def test_truncation_keeps_assistant_and_all_tool_results_together():
+    tool_exchange = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "probe", "arguments": "{}"},
+                },
+                {
+                    "id": "call-2",
+                    "type": "function",
+                    "function": {"name": "probe", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "one"},
+        {"role": "tool", "tool_call_id": "call-2", "content": "two"},
+    ]
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "A" * 1200},
+        *tool_exchange,
+        {"role": "assistant", "content": "observed"},
+    ]
+
+    result = truncate_messages(messages, max_tokens=120, min_recent=2)
+
+    present = [message for message in result if message.get("role") in {"assistant", "tool"}]
+    assert present[:3] == tool_exchange

--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -883,7 +883,12 @@ async def execute_mcp_tool(agent: AgentContext, tool_name: str, args: dict[str, 
         matches = search(query, limit=args.get("limit", 5))
         if not matches:
             return "[-] No matching archived conversation"
-        return json.dumps(matches, ensure_ascii=False, indent=2)
+        rendered = json.dumps(matches, ensure_ascii=False, indent=2)
+        max_chars = max(256, int(getattr(context, "search_max_chars", 6000)))
+        if len(rendered) > max_chars:
+            suffix = "\n...[cold-memory search output truncated]"
+            rendered = rendered[: max_chars - len(suffix)] + suffix
+        return rendered
 
     if tool_name == "source_extract":
         return await execute_source_extract(agent, args)

--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -872,6 +872,19 @@ async def execute_mcp_tool(agent: AgentContext, tool_name: str, args: dict[str, 
     if tool_name in {"evidence_list", "evidence_view", "evidence_search"}:
         return execute_evidence_tool(agent, tool_name, args)
 
+    if tool_name == "memory_search":
+        query = str(args.get("query") or "").strip()
+        if not query:
+            return "[!] memory_search requires a non-empty query"
+        context = getattr(agent, "context", None)
+        search = getattr(context, "search_cold_memory", None)
+        if not callable(search):
+            return "[-] No cold memory is configured"
+        matches = search(query, limit=args.get("limit", 5))
+        if not matches:
+            return "[-] No matching archived conversation"
+        return json.dumps(matches, ensure_ascii=False, indent=2)
+
     if tool_name == "source_extract":
         return await execute_source_extract(agent, args)
 
@@ -1096,6 +1109,34 @@ def build_openai_tools(mcp_manager: Any, *, active_role: str | None = None) -> l
                         },
                     },
                     "required": ["skill_name", "reference_name"],
+                },
+            },
+        }
+    )
+
+    append_tool(
+        {
+            "type": "function",
+            "function": {
+                "name": "memory_search",
+                "description": (
+                    "Search conversation turns moved out of the short-term context into local "
+                    "cold storage. Call this only when an older decision, tool result, or clue is "
+                    "needed for the current subtask; archived history is not included automatically."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Keyword or phrase expected in older conversation history.",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum archived turns to return (default 5, maximum 20).",
+                        },
+                    },
+                    "required": ["query"],
                 },
             },
         }

--- a/vulnclaw/agent/context.py
+++ b/vulnclaw/agent/context.py
@@ -1135,8 +1135,17 @@ class SessionState(BaseModel):
 class ContextManager:
     """Manages conversation context and session state."""
 
-    def __init__(self, max_history: int = 200, memory_store: Any = None) -> None:
-        self.max_history = max_history
+    def __init__(
+        self,
+        max_history: int = 200,
+        memory_store: Any = None,
+        *,
+        max_tokens: int = 32000,
+        search_max_chars: int = 6000,
+    ) -> None:
+        self.max_history = max(1, int(max_history))
+        self.max_tokens = max(256, int(max_tokens))
+        self.search_max_chars = max(256, int(search_max_chars))
         self.messages: list[dict[str, Any]] = []
         self.state = SessionState()
         self.memory_store = memory_store
@@ -1164,7 +1173,10 @@ class ContextManager:
         role = str(message.get("role", "") or "").strip()
         if not role:
             return
-        self.messages.append(copy.deepcopy(message))
+        stored_message = copy.deepcopy(message)
+        if role == "tool":
+            stored_message = self._offload_large_tool_message(stored_message)
+        self.messages.append(stored_message)
         self._trim()
 
     def add_system_message(self, content: str) -> None:
@@ -1180,6 +1192,53 @@ class ContextManager:
         """Reset context and session state."""
         self.messages = []
         self.state = SessionState()
+        if self.memory_store is not None:
+            new_scope = getattr(self.memory_store, "new_scope", None)
+            if callable(new_scope):
+                new_scope()
+
+    def _memory_scope(self) -> str:
+        return str(getattr(self.memory_store, "session_id", "") or "")
+
+    def _archive_messages(self, messages: list[dict[str, Any]], *, kind: str) -> str:
+        if not messages or self.memory_store is None:
+            return ""
+        try:
+            return str(
+                self.memory_store.archive_messages(
+                    copy.deepcopy(messages),
+                    scope=self._memory_scope(),
+                    target=str(self.state.target or ""),
+                    kind=kind,
+                )
+                or ""
+            )
+        except (OSError, ValueError, TypeError) as exc:
+            logger.warning("Cold-memory archive failed; retaining hot history: %s", exc)
+            return ""
+
+    def _offload_large_tool_message(self, message: dict[str, Any]) -> dict[str, Any]:
+        from vulnclaw.agent.token_counter import estimate_message_tokens
+
+        if self.memory_store is None or estimate_message_tokens(message) <= self.max_tokens // 2:
+            return message
+        record_id = self._archive_messages([message], kind="large_tool_result")
+        if not record_id:
+            return message
+        content = str(message.get("content", "") or "")
+        preview = content[:2000]
+        if len(content) > len(preview):
+            preview += "..."
+        message["content"] = (
+            f"[cold-memory:{record_id}] Large tool result archived. "
+            f"Use memory_search with query '{record_id}' for a bounded excerpt.\n{preview}"
+        )
+        return message
+
+    def _over_hot_limit(self, messages: list[dict[str, Any]]) -> bool:
+        from vulnclaw.agent.token_counter import estimate_tokens
+
+        return len(messages) > self.max_history or estimate_tokens(messages) > self.max_tokens
 
     def _trim(self) -> None:
         """Trim old messages to stay within limit.
@@ -1187,36 +1246,48 @@ class ContextManager:
         Instead of blindly dropping old messages, we compress them
         into a summary to preserve key discoveries for multi-round loops.
         """
-        if len(self.messages) <= self.max_history:
+        if not self._over_hot_limit(self.messages):
             return
 
         from vulnclaw.agent.token_counter import group_conversation_turns, group_tool_exchanges
 
-        turns = group_conversation_turns(self.messages)
-        while len(self.messages) > self.max_history and len(turns) > 1:
+        candidate = list(self.messages)
+        turns = group_conversation_turns(candidate)
+        archived_messages: list[dict[str, Any]] = []
+        while self._over_hot_limit(candidate) and len(turns) > 1:
             archived = turns.pop(0)
-            self.messages = self.messages[len(archived) :]
-            if self.memory_store is not None:
-                self.memory_store.archive_messages(archived)
+            archived_messages.extend(archived)
+            candidate = candidate[len(archived) :]
 
         # A single automated subtask can itself contain hundreds of tool
         # exchanges. Keep its user instruction as a hot anchor, then spill the
         # oldest complete exchanges until the window is bounded.
-        exchanges = group_tool_exchanges(self.messages)
-        archived_exchanges: list[dict[str, Any]] = []
-        while len(self.messages) > self.max_history and len(exchanges) > 2:
+        exchanges = group_tool_exchanges(candidate)
+        while self._over_hot_limit(candidate) and len(exchanges) > 2:
             remove_at = 1 if exchanges[0][0].get("role") == "user" else 0
             archived = exchanges.pop(remove_at)
-            archived_exchanges.extend(archived)
-            self.messages = [message for exchange in exchanges for message in exchange]
-        if archived_exchanges and self.memory_store is not None:
-            self.memory_store.archive_messages(archived_exchanges)
+            archived_messages.extend(archived)
+            candidate = [message for exchange in exchanges for message in exchange]
+
+        if not archived_messages:
+            return
+        if self.memory_store is not None and not self._archive_messages(
+            archived_messages, kind="history"
+        ):
+            return
+        self.messages = candidate
 
     def search_cold_memory(self, query: str, *, limit: int = 5) -> list[dict[str, Any]]:
         """Retrieve relevant archived turns only when explicitly requested."""
         if self.memory_store is None:
             return []
-        return self.memory_store.search_messages(query, limit=limit)
+        return self.memory_store.search_messages(
+            query,
+            limit=limit,
+            max_chars=self.search_max_chars,
+            scope=self._memory_scope(),
+            target=str(self.state.target or ""),
+        )
 
     def compact_messages(self, *, max_recent: int = 24, note: str = "") -> str:
         """Explicitly compact older conversation messages for `/compact`."""
@@ -1224,8 +1295,17 @@ class ContextManager:
         if len(self.messages) <= max_recent:
             return "No compaction needed."
 
-        recent = self.messages[-max_recent:]
-        old = self.messages[:-max_recent]
+        from vulnclaw.agent.token_counter import group_tool_exchanges
+
+        groups = group_tool_exchanges(self.messages)
+        recent_groups: list[list[dict[str, Any]]] = []
+        recent_count = 0
+        while groups and recent_count < max_recent:
+            group = groups.pop()
+            recent_groups.insert(0, group)
+            recent_count += len(group)
+        recent = [message for group in recent_groups for message in group]
+        old = [message for group in groups for message in group]
         summary = self._compress_messages(old) or "(older conversation omitted)"
         if note:
             summary = f"{note}\n{summary}"
@@ -1322,5 +1402,9 @@ class ContextManager:
 
         Used when context overflow causes repeated LLM errors.
         """
-        if len(self.messages) > max_messages:
-            self.messages = self.messages[-max_messages:]
+        original_limit = self.max_history
+        try:
+            self.max_history = max(1, max_messages)
+            self._trim()
+        finally:
+            self.max_history = original_limit

--- a/vulnclaw/agent/context.py
+++ b/vulnclaw/agent/context.py
@@ -1135,10 +1135,11 @@ class SessionState(BaseModel):
 class ContextManager:
     """Manages conversation context and session state."""
 
-    def __init__(self, max_history: int = 200) -> None:
+    def __init__(self, max_history: int = 200, memory_store: Any = None) -> None:
         self.max_history = max_history
         self.messages: list[dict[str, Any]] = []
         self.state = SessionState()
+        self.memory_store = memory_store
 
     def add_user_message(self, content: str) -> None:
         """Add a user message to context."""
@@ -1189,7 +1190,33 @@ class ContextManager:
         if len(self.messages) <= self.max_history:
             return
 
-        self.messages = self.messages[-self.max_history :]
+        from vulnclaw.agent.token_counter import group_conversation_turns, group_tool_exchanges
+
+        turns = group_conversation_turns(self.messages)
+        while len(self.messages) > self.max_history and len(turns) > 1:
+            archived = turns.pop(0)
+            self.messages = self.messages[len(archived) :]
+            if self.memory_store is not None:
+                self.memory_store.archive_messages(archived)
+
+        # A single automated subtask can itself contain hundreds of tool
+        # exchanges. Keep its user instruction as a hot anchor, then spill the
+        # oldest complete exchanges until the window is bounded.
+        exchanges = group_tool_exchanges(self.messages)
+        archived_exchanges: list[dict[str, Any]] = []
+        while len(self.messages) > self.max_history and len(exchanges) > 2:
+            remove_at = 1 if exchanges[0][0].get("role") == "user" else 0
+            archived = exchanges.pop(remove_at)
+            archived_exchanges.extend(archived)
+            self.messages = [message for exchange in exchanges for message in exchange]
+        if archived_exchanges and self.memory_store is not None:
+            self.memory_store.archive_messages(archived_exchanges)
+
+    def search_cold_memory(self, query: str, *, limit: int = 5) -> list[dict[str, Any]]:
+        """Retrieve relevant archived turns only when explicitly requested."""
+        if self.memory_store is None:
+            return []
+        return self.memory_store.search_messages(query, limit=limit)
 
     def compact_messages(self, *, max_recent: int = 24, note: str = "") -> str:
         """Explicitly compact older conversation messages for `/compact`."""

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -64,7 +64,7 @@ class AgentCore:
         self.mcp_manager = mcp_manager
         memory_dir = config.session.output_dir / "memory"
         self.context = ContextManager(
-            max_history=24,
+            max_history=48,
             memory_store=MemoryStore(store_dir=memory_dir),
         )
         self.active_role: str | None = None

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -36,6 +36,7 @@ from vulnclaw.agent.kb_context import build_kb_context
 from vulnclaw.agent.llm_client import StreamSink, call_llm
 from vulnclaw.agent.loop_controller import auto_pentest as run_auto_pentest
 from vulnclaw.agent.loop_controller import persistent_pentest as run_persistent_pentest
+from vulnclaw.agent.memory import MemoryStore
 from vulnclaw.agent.prompt_context import build_round_context, generate_attack_summary
 from vulnclaw.agent.recon_tracker import update_recon_dimension_completion
 from vulnclaw.agent.roles import role_prompt_block
@@ -61,7 +62,11 @@ class AgentCore:
     def __init__(self, config: VulnClawConfig, mcp_manager: Any = None) -> None:
         self.config = config
         self.mcp_manager = mcp_manager
-        self.context = ContextManager()
+        memory_dir = config.session.output_dir / "memory"
+        self.context = ContextManager(
+            max_history=24,
+            memory_store=MemoryStore(store_dir=memory_dir),
+        )
         self.active_role: str | None = None
         self._client = None
         # Failover key pool: prefer llm.api_keys, else the single llm.api_key.

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -64,8 +64,14 @@ class AgentCore:
         self.mcp_manager = mcp_manager
         memory_dir = config.session.output_dir / "memory"
         self.context = ContextManager(
-            max_history=48,
-            memory_store=MemoryStore(store_dir=memory_dir),
+            max_history=config.session.context_hot_max_messages,
+            max_tokens=config.session.context_hot_max_tokens,
+            search_max_chars=config.session.memory_search_max_chars,
+            memory_store=MemoryStore(
+                store_dir=memory_dir,
+                archive_max_bytes=config.session.memory_archive_max_bytes,
+                archive_max_files=config.session.memory_archive_max_files,
+            ),
         )
         self.active_role: str | None = None
         self._client = None
@@ -150,6 +156,16 @@ class AgentCore:
         self._client = None
         self._key_pool = config.llm.key_pool()
         self._key_index = 0
+        context = getattr(self, "context", None)
+        if context is not None:
+            context.max_history = config.session.context_hot_max_messages
+            context.max_tokens = config.session.context_hot_max_tokens
+            context.search_max_chars = config.session.memory_search_max_chars
+            memory_store = getattr(context, "memory_store", None)
+            if memory_store is not None:
+                memory_store.archive_max_bytes = config.session.memory_archive_max_bytes
+                memory_store.archive_max_files = config.session.memory_archive_max_files
+            context._trim()
 
     def _reset_runtime_state(
         self,

--- a/vulnclaw/agent/memory.py
+++ b/vulnclaw/agent/memory.py
@@ -77,3 +77,42 @@ class MemoryStore:
                 score = value_str.count(query_lower)
                 results.append((key, entry.get("value"), float(score)))
         return sorted(results, key=lambda x: x[2], reverse=True)
+
+    def archive_messages(self, messages: list[dict[str, Any]]) -> None:
+        """Append a complete conversation turn to durable cold storage."""
+        if not messages:
+            return
+        entry = self._cache.setdefault(
+            "conversation_archive",
+            {"value": [], "updated_at": datetime.now().isoformat()},
+        )
+        archive = entry.get("value")
+        if not isinstance(archive, list):
+            archive = []
+            entry["value"] = archive
+        archive.append(
+            {
+                "archived_at": datetime.now().isoformat(),
+                "messages": messages,
+            }
+        )
+        entry["updated_at"] = datetime.now().isoformat()
+        self._save()
+
+    def search_messages(self, query: str, *, limit: int = 5) -> list[dict[str, Any]]:
+        """Search archived conversation turns without loading them into prompts."""
+        query = str(query or "").strip().lower()
+        if not query:
+            return []
+        entry = self._cache.get("conversation_archive", {})
+        archive = entry.get("value", []) if isinstance(entry, dict) else []
+        if not isinstance(archive, list):
+            return []
+        matches: list[dict[str, Any]] = []
+        for record in reversed(archive):
+            rendered = json.dumps(record.get("messages", []), ensure_ascii=False).lower()
+            if query in rendered:
+                matches.append(record)
+                if len(matches) >= max(1, min(int(limit), 20)):
+                    break
+        return matches

--- a/vulnclaw/agent/memory.py
+++ b/vulnclaw/agent/memory.py
@@ -3,116 +3,243 @@
 from __future__ import annotations
 
 import json
+import os
+import threading
+from collections import deque
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
+from uuid import uuid4
 
 from vulnclaw.config.settings import KB_DIR
 
+_PROCESS_LOCK = threading.RLock()
+
+
+@contextmanager
+def _file_lock(path: Path) -> Iterator[None]:
+    """Serialize writers across threads and processes on Windows and POSIX."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _PROCESS_LOCK, open(path, "a+b") as handle:
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            handle.seek(0)
+            if os.name == "nt":
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
 
 class MemoryStore:
-    """Manages agent memory across sessions.
+    """Durable key/value memory plus append-only cold conversation storage."""
 
-    Three tiers:
-    - Short-term: conversation history (handled by ContextManager)
-    - Mid-term: current session findings and state (handled by SessionState)
-    - Long-term: cross-session knowledge (this class)
-    """
-
-    def __init__(self, store_dir: Optional[Path] = None) -> None:
+    def __init__(
+        self,
+        store_dir: Optional[Path] = None,
+        *,
+        archive_max_bytes: int = 64 * 1024 * 1024,
+        archive_max_files: int = 8,
+    ) -> None:
         self.store_dir = store_dir or KB_DIR / "memory"
         self.store_dir.mkdir(parents=True, exist_ok=True)
+        self.archive_max_bytes = max(1024, int(archive_max_bytes))
+        self.archive_max_files = max(2, int(archive_max_files))
+        self.session_id = uuid4().hex
         self._cache: dict[str, Any] = {}
         self._load()
 
+    @property
+    def _memory_file(self) -> Path:
+        return self.store_dir / "long_term.json"
+
+    @property
+    def _archive_file(self) -> Path:
+        return self.store_dir / "conversation_archive.jsonl"
+
+    def new_scope(self) -> str:
+        """Start an isolated task scope while retaining the same durable store."""
+        self.session_id = uuid4().hex
+        return self.session_id
+
     def _load(self) -> None:
-        """Load memory from disk."""
-        memory_file = self.store_dir / "long_term.json"
-        if memory_file.exists():
+        """Load the small key/value store; archives stay on disk as JSONL."""
+        if self._memory_file.exists():
             try:
-                with open(memory_file, "r", encoding="utf-8") as f:
-                    self._cache = json.load(f)
-            except (json.JSONDecodeError, IOError):
+                with open(self._memory_file, "r", encoding="utf-8") as handle:
+                    self._cache = json.load(handle)
+            except (json.JSONDecodeError, OSError):
                 self._cache = {}
 
     def _save(self) -> None:
-        """Persist memory to disk."""
-        memory_file = self.store_dir / "long_term.json"
-        with open(memory_file, "w", encoding="utf-8") as f:
-            json.dump(self._cache, f, ensure_ascii=False, indent=2)
+        """Atomically persist key/value memory without exposing partial JSON."""
+        lock_path = self.store_dir / ".long_term.lock"
+        with _file_lock(lock_path):
+            temporary = self.store_dir / f".long_term.{os.getpid()}.{uuid4().hex}.tmp"
+            try:
+                with open(temporary, "w", encoding="utf-8") as handle:
+                    json.dump(self._cache, handle, ensure_ascii=False, indent=2)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temporary, self._memory_file)
+                try:
+                    os.chmod(self._memory_file, 0o600)
+                except OSError:
+                    pass
+            finally:
+                temporary.unlink(missing_ok=True)
 
     def save(self, key: str, value: Any) -> None:
-        """Save a memory entry."""
-        self._cache[key] = {
-            "value": value,
-            "updated_at": datetime.now().isoformat(),
-        }
+        self._cache[key] = {"value": value, "updated_at": datetime.now().isoformat()}
         self._save()
 
     def retrieve(self, key: str) -> Optional[Any]:
-        """Retrieve a memory entry."""
         entry = self._cache.get(key)
         return entry.get("value") if entry else None
 
     def list_keys(self) -> list[str]:
-        """List all memory keys."""
         return list(self._cache.keys())
 
     def delete(self, key: str) -> None:
-        """Delete a memory entry."""
         self._cache.pop(key, None)
         self._save()
 
     def search(self, query: str) -> list[tuple[str, Any, float]]:
-        """Simple keyword search across memory values.
-
-        Returns list of (key, value, relevance_score) tuples.
-        """
         results = []
         query_lower = query.lower()
         for key, entry in self._cache.items():
             value_str = json.dumps(entry.get("value", ""), ensure_ascii=False).lower()
             if query_lower in value_str or query_lower in key.lower():
-                # Simple relevance: count occurrences
-                score = value_str.count(query_lower)
-                results.append((key, entry.get("value"), float(score)))
-        return sorted(results, key=lambda x: x[2], reverse=True)
+                results.append((key, entry.get("value"), float(value_str.count(query_lower))))
+        return sorted(results, key=lambda item: item[2], reverse=True)
 
-    def archive_messages(self, messages: list[dict[str, Any]]) -> None:
-        """Append a complete conversation turn to durable cold storage."""
+    def archive_messages(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        scope: str = "",
+        target: str = "",
+        kind: str = "history",
+    ) -> str:
+        """Append one cold-memory record and return its stable identifier."""
         if not messages:
-            return
-        entry = self._cache.setdefault(
-            "conversation_archive",
-            {"value": [], "updated_at": datetime.now().isoformat()},
-        )
-        archive = entry.get("value")
-        if not isinstance(archive, list):
-            archive = []
-            entry["value"] = archive
-        archive.append(
-            {
-                "archived_at": datetime.now().isoformat(),
-                "messages": messages,
-            }
-        )
-        entry["updated_at"] = datetime.now().isoformat()
-        self._save()
+            return ""
+        record_id = f"mem-{uuid4().hex[:12]}"
+        record = {
+            "version": 1,
+            "record_id": record_id,
+            "archived_at": datetime.now().isoformat(),
+            "scope": scope or self.session_id,
+            "target": target,
+            "kind": kind,
+            "messages": messages,
+        }
+        encoded = json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+        with _file_lock(self.store_dir / ".conversation_archive.lock"):
+            encoded_size = len((encoded + "\n").encode("utf-8"))
+            if (
+                self._archive_file.exists()
+                and self._archive_file.stat().st_size + encoded_size > self.archive_max_bytes
+            ):
+                rotated = self.store_dir / (
+                    f"conversation_archive.{datetime.now().strftime('%Y%m%d%H%M%S%f')}."
+                    f"{uuid4().hex[:8]}.jsonl"
+                )
+                os.replace(self._archive_file, rotated)
+                self._prune_archive_shards()
+            with open(self._archive_file, "a", encoding="utf-8", newline="\n") as handle:
+                handle.write(encoded + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.chmod(self._archive_file, 0o600)
+            except OSError:
+                pass
+        return record_id
 
-    def search_messages(self, query: str, *, limit: int = 5) -> list[dict[str, Any]]:
-        """Search archived conversation turns without loading them into prompts."""
-        query = str(query or "").strip().lower()
-        if not query:
+    def _archive_shards(self) -> list[Path]:
+        return sorted(
+            self.store_dir.glob("conversation_archive*.jsonl"),
+            key=lambda path: (path.stat().st_mtime_ns, path.name),
+        )
+
+    def _prune_archive_shards(self) -> None:
+        shards = self._archive_shards()
+        while len(shards) >= self.archive_max_files:
+            shards.pop(0).unlink(missing_ok=True)
+
+    def search_messages(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        max_chars: int = 6000,
+        scope: str = "",
+        target: str = "",
+    ) -> list[dict[str, Any]]:
+        """Return bounded snippets from matching JSONL records in one task scope."""
+        query = str(query or "").strip()
+        if not query or not self._archive_file.exists():
             return []
-        entry = self._cache.get("conversation_archive", {})
-        archive = entry.get("value", []) if isinstance(entry, dict) else []
-        if not isinstance(archive, list):
-            return []
-        matches: list[dict[str, Any]] = []
-        for record in reversed(archive):
-            rendered = json.dumps(record.get("messages", []), ensure_ascii=False).lower()
-            if query in rendered:
-                matches.append(record)
-                if len(matches) >= max(1, min(int(limit), 20)):
-                    break
-        return matches
+        limit = max(1, min(int(limit), 20))
+        max_chars = max(256, int(max_chars))
+        matches: deque[tuple[dict[str, Any], str]] = deque(maxlen=limit)
+        query_lower = query.lower()
+        for archive_file in self._archive_shards():
+            with open(archive_file, "r", encoding="utf-8") as handle:
+                for line in handle:
+                    try:
+                        record = json.loads(line)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    if scope and record.get("scope") != scope:
+                        continue
+                    if target and record.get("target") not in {"", target}:
+                        continue
+                    rendered = json.dumps(record.get("messages", []), ensure_ascii=False)
+                    if query_lower not in rendered.lower() and query_lower not in str(
+                        record.get("record_id", "")
+                    ).lower():
+                        continue
+                    matches.append((record, rendered))
+
+        remaining = max_chars
+        results: list[dict[str, Any]] = []
+        for record, rendered in reversed(matches):
+            if remaining <= 0:
+                break
+            allowance = min(remaining, max(256, max_chars // max(1, len(matches))))
+            lowered = rendered.lower()
+            match_at = lowered.find(query_lower)
+            if match_at < 0:
+                match_at = 0
+            start = max(0, match_at - allowance // 3)
+            prefix = "..." if start else ""
+            suffix = "..." if start + allowance < len(rendered) else ""
+            body_allowance = max(0, allowance - len(prefix) - len(suffix))
+            snippet = prefix + rendered[start : start + body_allowance] + suffix
+            results.append(
+                {
+                    "record_id": record.get("record_id", ""),
+                    "archived_at": record.get("archived_at", ""),
+                    "target": record.get("target", ""),
+                    "kind": record.get("kind", "history"),
+                    "snippet": snippet,
+                }
+            )
+            remaining -= len(snippet)
+        return results

--- a/vulnclaw/agent/roles.py
+++ b/vulnclaw/agent/roles.py
@@ -27,6 +27,7 @@ ROLE_REGISTRY: dict[str, AgentRole] = {
         ),
         allowed_tool_globs=(
             "load_skill_reference",
+            "memory_search",
             "evidence_*",
             "source_extract",
             "space_search",
@@ -56,6 +57,7 @@ ROLE_REGISTRY: dict[str, AgentRole] = {
         ),
         allowed_tool_globs=(
             "load_skill_reference",
+            "memory_search",
             "evidence_*",
             "source_extract",
             "runtime_diff_probe",
@@ -82,6 +84,7 @@ ROLE_REGISTRY: dict[str, AgentRole] = {
         ),
         allowed_tool_globs=(
             "load_skill_reference",
+            "memory_search",
             "evidence_*",
             "source_extract",
             "runtime_diff_probe",
@@ -119,7 +122,7 @@ ROLE_REGISTRY: dict[str, AgentRole] = {
             "You are the Adviser specialist. Plan, critique, and decide whether to "
             "continue, re-plan, or stop. You have no execution tools."
         ),
-        allowed_tool_globs=(),
+        allowed_tool_globs=("memory_search",),
         goal_template=(
             "Advisory objective: {objective}\n"
             "Done when: {done_when}\n"

--- a/vulnclaw/agent/token_counter.py
+++ b/vulnclaw/agent/token_counter.py
@@ -96,6 +96,55 @@ def estimate_tokens(messages: list[dict]) -> int:
     return sum(estimate_message_tokens(m) for m in messages)
 
 
+def group_tool_exchanges(messages: list[dict]) -> list[list[dict]]:
+    """Group assistant tool calls with their consecutive tool responses.
+
+    OpenAI-compatible providers reject a ``tool`` message when the assistant
+    message that declared its ``tool_call_id`` is absent.  Context trimming
+    therefore has to treat that exchange as one indivisible unit.
+    """
+    groups: list[list[dict]] = []
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+        group = [message]
+        tool_calls = message.get("tool_calls") if isinstance(message, dict) else None
+        if message.get("role") == "assistant" and isinstance(tool_calls, list) and tool_calls:
+            expected_ids = {
+                str(call.get("id") or "")
+                for call in tool_calls
+                if isinstance(call, dict) and call.get("id")
+            }
+            cursor = index + 1
+            while cursor < len(messages):
+                candidate = messages[cursor]
+                if candidate.get("role") != "tool":
+                    break
+                if str(candidate.get("tool_call_id") or "") not in expected_ids:
+                    break
+                group.append(candidate)
+                cursor += 1
+            index = cursor
+        else:
+            index += 1
+        groups.append(group)
+    return groups
+
+
+def group_conversation_turns(messages: list[dict]) -> list[list[dict]]:
+    """Group hot/cold history into user-led turns without splitting tools."""
+    turns: list[list[dict]] = []
+    current: list[dict] = []
+    for exchange in group_tool_exchanges(messages):
+        if exchange[0].get("role") == "user" and current:
+            turns.append(current)
+            current = []
+        current.extend(exchange)
+    if current:
+        turns.append(current)
+    return turns
+
+
 def truncate_messages(
     messages: list[dict],
     max_tokens: int,
@@ -120,27 +169,34 @@ def truncate_messages(
         body = body[1:]
 
     min_recent = max(min_recent, 1)
+    groups = group_tool_exchanges(body)
     if len(body) <= min_recent:
         return system_msgs + body
 
-    recent = body[-min_recent:]
-    middle = body[:-min_recent]
+    recent_groups: list[list[dict]] = []
+    recent_count = 0
+    while groups and recent_count < min_recent:
+        group = groups.pop()
+        recent_groups.insert(0, group)
+        recent_count += len(group)
+    recent = [message for group in recent_groups for message in group]
 
     notice = {"role": "system", "content": _TRUNCATION_NOTICE}
     base_tokens = estimate_tokens(system_msgs) + estimate_tokens(recent)
     base_tokens += estimate_message_tokens(notice)
 
-    kept_middle: list[dict] = []
+    kept_groups: list[list[dict]] = []
     running = base_tokens
-    # Add middle messages from newest to oldest until the budget is exhausted.
-    for msg in reversed(middle):
-        cost = estimate_message_tokens(msg)
+    # Add older atomic exchanges from newest to oldest until the budget is exhausted.
+    for group in reversed(groups):
+        cost = estimate_tokens(group)
         if running + cost > max_tokens:
             break
         running += cost
-        kept_middle.insert(0, msg)
+        kept_groups.insert(0, group)
 
-    truncated_any = len(kept_middle) < len(middle)
+    truncated_any = len(kept_groups) < len(groups)
+    kept_middle = [message for group in kept_groups for message in group]
     result = list(system_msgs)
     if truncated_any:
         result.append(notice)

--- a/vulnclaw/config/cli_constants.py
+++ b/vulnclaw/config/cli_constants.py
@@ -355,6 +355,8 @@ COMMANDS: tuple[ManualTopic, ...] = (
             "llm.max_context_tokens, llm.temperature, llm.reasoning_effort. Use `vulnclaw login` "
             "instead of llm.api_key for OAuth-based ChatGPT-subscription auth.",
             "Useful session keys: session.output_dir, session.report_format, session.max_rounds, "
+            "session.context_hot_max_messages, session.context_hot_max_tokens, "
+            "session.memory_search_max_chars, session.memory_archive_max_bytes/files, "
             "session.engine (solve|rounds), session.solve_max_steps, session.solve_auto_compact, "
             "session.solve_compact_trigger_ratio, session.solve_max_tool_rounds (compat), "
             "session.solve_max_parallel (team/legacy), session.show_thinking, "

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -282,6 +282,31 @@ class SessionConfig(BaseModel):
     )
     poc_language: str = Field(default="python", description="Default PoC language: python, bash")
     max_rounds: int = Field(default=15, description="Max autonomous pentest rounds (1-100)")
+    context_hot_max_messages: int = Field(
+        default=48,
+        ge=4,
+        description="Maximum messages retained in hot conversation memory",
+    )
+    context_hot_max_tokens: int = Field(
+        default=32000,
+        ge=1024,
+        description="Approximate token cap for hot conversation memory",
+    )
+    memory_search_max_chars: int = Field(
+        default=6000,
+        ge=512,
+        description="Maximum cold-memory characters returned by one search",
+    )
+    memory_archive_max_bytes: int = Field(
+        default=64 * 1024 * 1024,
+        ge=1024 * 1024,
+        description="Rotate a cold-memory JSONL shard after this many bytes",
+    )
+    memory_archive_max_files: int = Field(
+        default=8,
+        ge=2,
+        description="Maximum cold-memory JSONL shards retained per output directory",
+    )
     # Autonomous engine: "solve" = model-led agent loop with evidence memory (default),
     # "team" = role-specialized supervisor, "rounds" = legacy fixed-round loop.
     engine: str = Field(


### PR DESCRIPTION
## 变更概述
- 按完整 assistant/tool exchange 原子截断，避免产生孤立 tool 消息触发 DeepSeek 400
- 热上下文采用可配置双上限：默认 48 条消息、约 32000 tokens
- 超大工具结果自动写入冷存储，热区仅保留有界预览和记录 ID
- 冷历史改用追加式 JSONL，跨线程/进程写锁、原子写入、损坏行隔离及文件轮转
- 每个 Agent 任务使用独立 scope，并记录 target/kind/时间等检索元数据
- memory_search 仅返回有界相关片段，默认最多 6000 字符
- 冷存储失败时保留热历史，避免磁盘异常造成上下文丢失
- 配置热更新会同步应用到现有 ContextManager

## 默认容量
- session.context_hot_max_messages = 48
- session.context_hot_max_tokens = 32000
- session.memory_search_max_chars = 6000
- session.memory_archive_max_bytes = 67108864
- session.memory_archive_max_files = 8

## 验证
- 冷热记忆、token 截断、流式 LLM、团队 Agent 与配置相关回归：206 passed
- 配置热更新兼容测试：1 passed
- Ruff 与 git diff --check 通过
Fixes #144